### PR TITLE
[CONFIG] Plub Color 

### DIFF
--- a/PLUB/Configuration/Extensions/Ex+UIColor.swift
+++ b/PLUB/Configuration/Extensions/Ex+UIColor.swift
@@ -25,8 +25,16 @@ extension UIColor {
       alpha: CGFloat(alpha)
     )
   }
+}
+
+// MARK: - Plub Color Palette
+
+extension UIColor {
   
-  // MARK: 메인 테마 색 또는 자주 쓰는 색을 정의
-  // ex. label.textColor = .mainOrange
-  static var mainOrange: UIColor { UIColor(hex: 0xF5663F) }
+  static let main: UIColor        = .init(hex: 0x5F5FF9)
+  static let subMain: UIColor     = .init(hex: 0xB5B5FB)
+  static let background: UIColor  = .init(hex: 0xF5F3F6)
+  static let deepGray: UIColor    = .init(hex: 0x8C8C8C)
+  static let mediumGray: UIColor  = .init(hex: 0xC4C4C4)
+  static let lightGray: UIColor   = .init(hex: 0xE4E4E4)
 }

--- a/PLUB/Configuration/Extensions/Ex+UIColor.swift
+++ b/PLUB/Configuration/Extensions/Ex+UIColor.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+// MARK: - Init
+
 extension UIColor {
   
   /// 16진수(hex code)를 이용하여 색상을 지정합니다.

--- a/PLUB/Configuration/Extensions/Ex+UIColor.swift
+++ b/PLUB/Configuration/Extensions/Ex+UIColor.swift
@@ -30,7 +30,6 @@ extension UIColor {
 // MARK: - Plub Color Palette
 
 extension UIColor {
-  
   static let main: UIColor        = .init(hex: 0x5F5FF9)
   static let subMain: UIColor     = .init(hex: 0xB5B5FB)
   static let background: UIColor  = .init(hex: 0xF5F3F6)


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- Plub 디자인에 사용될 Color 색상을 추가했습니다.
   - UIColor 내부에 main, subMain, background, deepGray, mediumGray, lightGray를 선언해두었습니다.
   - black, white는 이미 UIColor에 존재하고 색상도 같기에 추가로 설정하진 않았습니다.
   - lightGray는 UIColor과 다르지만, 사용하지 않을 거라 판단하여 재정의하여 구현했습니다.


## 📸 스크린샷

|Color Code|
|:--:|
|<img width="470" alt="image" src="https://user-images.githubusercontent.com/57972338/198597952-87deb9ab-3a0d-4cfc-b828-d1655ce9a6a4.png">|

|적용 방법|
|:-:|
|<img width="901" alt="image" src="https://user-images.githubusercontent.com/57972338/198600798-1635c360-2c1e-451e-9145-db0987a56809.png">|

## 📮 관련 이슈
- Resolved: #9

