### PR TITLE
[로그인] 약관 페이지 리스트 UI

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		BA88127028E48AC800BD832A /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = BA88126F28E48AC800BD832A /* Alamofire */; };
 		BAE16029292221ED00D595FF /* CheckBoxButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE16028292221ED00D595FF /* CheckBoxButton.swift */; };
 		BAE1AD952944775C00CE36B9 /* PolicyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */; };
+		BAE1AD972944C16600CE36B9 /* PolicyHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -68,6 +69,7 @@
 		BAE058E528EC7CEC00F09BD8 /* PLUB.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PLUB.entitlements; sourceTree = "<group>"; };
 		BAE16028292221ED00D595FF /* CheckBoxButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckBoxButton.swift; sourceTree = "<group>"; };
 		BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyViewController.swift; sourceTree = "<group>"; };
+		BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyHeaderTableViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -219,6 +221,7 @@
 		BAE1AD932944770000CE36B9 /* Policy */ = {
 			isa = PBXGroup;
 			children = (
+				BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */,
 				BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */,
 			);
 			path = Policy;
@@ -329,6 +332,7 @@
 				BA42D1F528EDE11900C20061 /* MeetingViewController.swift in Sources */,
 				BA88125028E48A2F00BD832A /* SceneDelegate.swift in Sources */,
 				0A81767F28F3105200C1E074 /* Preview.swift in Sources */,
+				BAE1AD972944C16600CE36B9 /* PolicyHeaderTableViewCell.swift in Sources */,
 				BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0A3E42D928E7343F00F62BF0 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3E42D828E7343F00F62BF0 /* Constants.swift */; };
 		0A3E42DC28E734E800F62BF0 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3E42DB28E734E800F62BF0 /* Device.swift */; };
 		0A81767F28F3105200C1E074 /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A81767E28F3105200C1E074 /* Preview.swift */; };
+		BA0322BA294F3F9D002466C5 /* PolicyConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0322B9294F3F9D002466C5 /* PolicyConfigurable.swift */; };
 		BA42D1F328EDE10F00C20061 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA42D1F228EDE10F00C20061 /* LoginViewController.swift */; };
 		BA42D1F528EDE11900C20061 /* MeetingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA42D1F428EDE11900C20061 /* MeetingViewController.swift */; };
 		BA46CC9F28EC9B05004953B1 /* Ex+UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA46CC9D28EC9B05004953B1 /* Ex+UIColor.swift */; };
@@ -46,6 +47,7 @@
 		0A3E42D828E7343F00F62BF0 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		0A3E42DB28E734E800F62BF0 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		0A81767E28F3105200C1E074 /* Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preview.swift; sourceTree = "<group>"; };
+		BA0322B9294F3F9D002466C5 /* PolicyConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyConfigurable.swift; sourceTree = "<group>"; };
 		BA42D1F228EDE10F00C20061 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		BA42D1F428EDE11900C20061 /* MeetingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingViewController.swift; sourceTree = "<group>"; };
 		BA46CC9D28EC9B05004953B1 /* Ex+UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Ex+UIColor.swift"; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 			isa = PBXGroup;
 			children = (
 				BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */,
+				BA0322B9294F3F9D002466C5 /* PolicyConfigurable.swift */,
 				BAE1AD982944C75F00CE36B9 /* PolicyTableViewCell.swift */,
 				BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */,
 				BAF54B7A29487CE900C59FBA /* PolicyViewModel.swift */,
@@ -339,6 +342,7 @@
 				BA46CCA028EC9B05004953B1 /* Ex+UIButton.swift in Sources */,
 				BA42D1F528EDE11900C20061 /* MeetingViewController.swift in Sources */,
 				BA88125028E48A2F00BD832A /* SceneDelegate.swift in Sources */,
+				BA0322BA294F3F9D002466C5 /* PolicyConfigurable.swift in Sources */,
 				0A81767F28F3105200C1E074 /* Preview.swift in Sources */,
 				BAE1AD972944C16600CE36B9 /* PolicyHeaderTableViewCell.swift in Sources */,
 				BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		BAE1AD952944775C00CE36B9 /* PolicyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */; };
 		BAE1AD972944C16600CE36B9 /* PolicyHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */; };
 		BAE1AD992944C75F00CE36B9 /* PolicyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD982944C75F00CE36B9 /* PolicyTableViewCell.swift */; };
+		BAF54B7B29487CE900C59FBA /* PolicyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF54B7A29487CE900C59FBA /* PolicyViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -72,6 +73,7 @@
 		BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyViewController.swift; sourceTree = "<group>"; };
 		BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyHeaderTableViewCell.swift; sourceTree = "<group>"; };
 		BAE1AD982944C75F00CE36B9 /* PolicyTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyTableViewCell.swift; sourceTree = "<group>"; };
+		BAF54B7A29487CE900C59FBA /* PolicyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -226,6 +228,7 @@
 				BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */,
 				BAE1AD982944C75F00CE36B9 /* PolicyTableViewCell.swift */,
 				BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */,
+				BAF54B7A29487CE900C59FBA /* PolicyViewModel.swift */,
 			);
 			path = Policy;
 			sourceTree = "<group>";
@@ -322,6 +325,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BAF54B7B29487CE900C59FBA /* PolicyViewModel.swift in Sources */,
 				BA42D1F328EDE10F00C20061 /* LoginViewController.swift in Sources */,
 				BAE16029292221ED00D595FF /* CheckBoxButton.swift in Sources */,
 				BA46CC9F28EC9B05004953B1 /* Ex+UIColor.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -39,7 +39,7 @@
 		BAE16029292221ED00D595FF /* CheckBoxButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE16028292221ED00D595FF /* CheckBoxButton.swift */; };
 		BAE1AD952944775C00CE36B9 /* PolicyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */; };
 		BAE1AD972944C16600CE36B9 /* PolicyHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */; };
-		BAE1AD992944C75F00CE36B9 /* PolicyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD982944C75F00CE36B9 /* PolicyTableViewCell.swift */; };
+		BAE1AD992944C75F00CE36B9 /* PolicyBodyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD982944C75F00CE36B9 /* PolicyBodyTableViewCell.swift */; };
 		BAF54B7B29487CE900C59FBA /* PolicyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF54B7A29487CE900C59FBA /* PolicyViewModel.swift */; };
 /* End PBXBuildFile section */
 
@@ -74,7 +74,7 @@
 		BAE16028292221ED00D595FF /* CheckBoxButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckBoxButton.swift; sourceTree = "<group>"; };
 		BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyViewController.swift; sourceTree = "<group>"; };
 		BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyHeaderTableViewCell.swift; sourceTree = "<group>"; };
-		BAE1AD982944C75F00CE36B9 /* PolicyTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyTableViewCell.swift; sourceTree = "<group>"; };
+		BAE1AD982944C75F00CE36B9 /* PolicyBodyTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyBodyTableViewCell.swift; sourceTree = "<group>"; };
 		BAF54B7A29487CE900C59FBA /* PolicyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -229,7 +229,7 @@
 			children = (
 				BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */,
 				BA0322B9294F3F9D002466C5 /* PolicyConfigurable.swift */,
-				BAE1AD982944C75F00CE36B9 /* PolicyTableViewCell.swift */,
+				BAE1AD982944C75F00CE36B9 /* PolicyBodyTableViewCell.swift */,
 				BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */,
 				BAF54B7A29487CE900C59FBA /* PolicyViewModel.swift */,
 			);
@@ -336,7 +336,7 @@
 				BA88125228E48A2F00BD832A /* HomeViewController.swift in Sources */,
 				BA88126228E48A5800BD832A /* BaseViewController.swift in Sources */,
 				BAE1AD952944775C00CE36B9 /* PolicyViewController.swift in Sources */,
-				BAE1AD992944C75F00CE36B9 /* PolicyTableViewCell.swift in Sources */,
+				BAE1AD992944C75F00CE36B9 /* PolicyBodyTableViewCell.swift in Sources */,
 				0A3E42DC28E734E800F62BF0 /* Device.swift in Sources */,
 				BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */,
 				BA46CCA028EC9B05004953B1 /* Ex+UIButton.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		BA88126D28E48AB700BD832A /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = BA88126C28E48AB700BD832A /* SnapKit */; };
 		BA88127028E48AC800BD832A /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = BA88126F28E48AC800BD832A /* Alamofire */; };
 		BAE16029292221ED00D595FF /* CheckBoxButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE16028292221ED00D595FF /* CheckBoxButton.swift */; };
+		BAE1AD952944775C00CE36B9 /* PolicyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -66,6 +67,7 @@
 		BA88126128E48A5800BD832A /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		BAE058E528EC7CEC00F09BD8 /* PLUB.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PLUB.entitlements; sourceTree = "<group>"; };
 		BAE16028292221ED00D595FF /* CheckBoxButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckBoxButton.swift; sourceTree = "<group>"; };
+		BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -143,6 +145,7 @@
 		BA42D1EF28EDE05A00C20061 /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				BAE1AD932944770000CE36B9 /* Policy */,
 				BA42D1F228EDE10F00C20061 /* LoginViewController.swift */,
 			);
 			path = Login;
@@ -211,6 +214,14 @@
 				BA88125B28E48A3000BD832A /* Info.plist */,
 			);
 			path = PLUB;
+			sourceTree = "<group>";
+		};
+		BAE1AD932944770000CE36B9 /* Policy */ = {
+			isa = PBXGroup;
+			children = (
+				BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */,
+			);
+			path = Policy;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -311,6 +322,7 @@
 				0A3E42D928E7343F00F62BF0 /* Constants.swift in Sources */,
 				BA88125228E48A2F00BD832A /* HomeViewController.swift in Sources */,
 				BA88126228E48A5800BD832A /* BaseViewController.swift in Sources */,
+				BAE1AD952944775C00CE36B9 /* PolicyViewController.swift in Sources */,
 				0A3E42DC28E734E800F62BF0 /* Device.swift in Sources */,
 				BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */,
 				BA46CCA028EC9B05004953B1 /* Ex+UIButton.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		BAE16029292221ED00D595FF /* CheckBoxButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE16028292221ED00D595FF /* CheckBoxButton.swift */; };
 		BAE1AD952944775C00CE36B9 /* PolicyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */; };
 		BAE1AD972944C16600CE36B9 /* PolicyHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */; };
+		BAE1AD992944C75F00CE36B9 /* PolicyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD982944C75F00CE36B9 /* PolicyTableViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -70,6 +71,7 @@
 		BAE16028292221ED00D595FF /* CheckBoxButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckBoxButton.swift; sourceTree = "<group>"; };
 		BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyViewController.swift; sourceTree = "<group>"; };
 		BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyHeaderTableViewCell.swift; sourceTree = "<group>"; };
+		BAE1AD982944C75F00CE36B9 /* PolicyTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyTableViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -222,6 +224,7 @@
 			isa = PBXGroup;
 			children = (
 				BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */,
+				BAE1AD982944C75F00CE36B9 /* PolicyTableViewCell.swift */,
 				BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */,
 			);
 			path = Policy;
@@ -326,6 +329,7 @@
 				BA88125228E48A2F00BD832A /* HomeViewController.swift in Sources */,
 				BA88126228E48A5800BD832A /* BaseViewController.swift in Sources */,
 				BAE1AD952944775C00CE36B9 /* PolicyViewController.swift in Sources */,
+				BAE1AD992944C75F00CE36B9 /* PolicyTableViewCell.swift in Sources */,
 				0A3E42DC28E734E800F62BF0 /* Device.swift in Sources */,
 				BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */,
 				BA46CCA028EC9B05004953B1 /* Ex+UIButton.swift in Sources */,

--- a/PLUB/Sources/Login/Policy/PolicyBodyTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyBodyTableViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  PolicyTableViewCell.swift
+//  PolicyBodyTableViewCell.swift
 //  PLUB
 //
 //  Created by 홍승현 on 2022/12/10.
@@ -10,9 +10,9 @@ import UIKit
 
 import SnapKit
 
-final class PolicyTableViewCell: UITableViewCell {
+final class PolicyBodyTableViewCell: UITableViewCell {
   
-  static let identifier = "\(PolicyTableViewCell.self)"
+  static let identifier = "\(PolicyBodyTableViewCell.self)"
   
   private let webView: WKWebView = WKWebView()
   

--- a/PLUB/Sources/Login/Policy/PolicyBodyTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyBodyTableViewCell.swift
@@ -25,6 +25,7 @@ final class PolicyBodyTableViewCell: UITableViewCell {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
     setupLayouts()
     setupConstraints()
+    backgroundColor = .background
   }
   
   required init?(coder: NSCoder) {

--- a/PLUB/Sources/Login/Policy/PolicyConfigurable.swift
+++ b/PLUB/Sources/Login/Policy/PolicyConfigurable.swift
@@ -20,7 +20,7 @@ extension PolicyHeaderTableViewCell: PolicyConfigurable {
   }
 }
 
-extension PolicyTableViewCell: PolicyConfigurable {
+extension PolicyBodyTableViewCell: PolicyConfigurable {
   func configure(with model: PolicyViewModel.Item) {
     guard let url = model.url else { return }
     if model.type != .body { return }

--- a/PLUB/Sources/Login/Policy/PolicyConfigurable.swift
+++ b/PLUB/Sources/Login/Policy/PolicyConfigurable.swift
@@ -1,0 +1,29 @@
+//
+//  PolicyConfigurable.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2022/12/18.
+//
+
+import Foundation
+
+protocol PolicyConfigurable {
+  func configure(with model: PolicyViewModel.Item)
+}
+
+
+extension PolicyHeaderTableViewCell: PolicyConfigurable {
+  func configure(with model: PolicyViewModel.Item) {
+    guard let policy = model.policy else { return }
+    if model.type != .header { return }
+    configure(with: policy)
+  }
+}
+
+extension PolicyTableViewCell: PolicyConfigurable {
+  func configure(with model: PolicyViewModel.Item) {
+    guard let url = model.url else { return }
+    if model.type != .body { return }
+    configure(with: url)
+  }
+}

--- a/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 
+import SnapKit
+import Then
+
 final class PolicyHeaderTableViewCell: UITableViewCell {
   
   static let identifier = "\(PolicyHeaderTableViewCell.self)"
@@ -32,9 +35,37 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
+    setupLayouts()
+    setupConstraints()
   }
   
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupLayouts() {
+    contentView.addSubview(stackView)
+    [disclosureIndicator, policyLabel, checkbox].forEach {
+      stackView.addArrangedSubview($0)
+    }
+  }
+  
+  private func setupConstraints() {
+    stackView.snp.makeConstraints { make in
+      make.edges.equalToSuperview()
+      make.height.equalTo(48)
+    }
+    
+    disclosureIndicator.snp.makeConstraints { make in
+      make.size.equalTo(24)
+    }
+    
+    checkbox.snp.makeConstraints { make in
+      make.size.equalTo(24)
+    }
+  }
+  
+  func configure(with policy: String) {
+    policyLabel.text = policy
   }
 }

--- a/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
@@ -10,6 +10,25 @@ import UIKit
 final class PolicyHeaderTableViewCell: UITableViewCell {
   
   static let identifier = "\(PolicyHeaderTableViewCell.self)"
+  
+  private let disclosureIndicator: UIImageView = UIImageView().then {
+    $0.image = UIImage(systemName: "chevron.down")
+    $0.contentMode = .scaleAspectFit
+    $0.tintColor = .deepGray
+  }
+  
+  private let policyLabel: UILabel = UILabel().then {
+    $0.numberOfLines = 0
+    $0.font = .body2
+    $0.textColor = .deepGray
+  }
+  
+  private let checkbox: CheckBoxButton = CheckBoxButton(type: .full)
+  
+  private let stackView: UIStackView = UIStackView().then {
+    $0.spacing = 2
+    $0.alignment = .center
+  }
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)

--- a/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
@@ -14,7 +14,7 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
   
   static let identifier = "\(PolicyHeaderTableViewCell.self)"
   
-  var isTapped: Bool = false { didSet { updateIndicators() } }
+  private var indicatorFlag = false
   
   private let disclosureIndicator: UIImageView = UIImageView().then {
     $0.image = UIImage(systemName: "chevron.down")
@@ -69,13 +69,23 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
   
   /// 화살표 인디케이터에 아래쪽, 위쪽 방향 애니메이션을 적용합니다.
   private func updateIndicators() {
+    defer {
+      indicatorFlag.toggle() // 함수 종료시 flag 토글
+    }
     UIView.animate(withDuration: 0.3) {
       let upsideDown = CGAffineTransform(rotationAngle: .pi * 0.9999)
-      self.disclosureIndicator.transform = self.isTapped ? upsideDown : .identity 
+      self.disclosureIndicator.transform = self.indicatorFlag ? upsideDown : .identity
     }
   }
   
   func configure(with policy: String) {
     policyLabel.text = policy
+  }
+  
+  override func setSelected(_ selected: Bool, animated: Bool) {
+    super.setSelected(false, animated: animated)
+    if selected {
+      updateIndicators()
+    }
   }
 }

--- a/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
@@ -14,7 +14,7 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
   
   static let identifier = "\(PolicyHeaderTableViewCell.self)"
   
-  /// IndicatorDisclosure의 애니메이션 flag
+  /// Disclosure Indicator의 애니메이션 flag
   private var indicatorFlag = false
   
   private let disclosureIndicator: UIImageView = UIImageView().then {
@@ -70,9 +70,7 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
   
   /// 화살표 인디케이터에 아래쪽, 위쪽 방향 애니메이션을 적용합니다.
   private func updateIndicators() {
-    defer {
-      indicatorFlag.toggle() // 함수 종료시 flag 토글
-    }
+    indicatorFlag.toggle() // toggle flag
     UIView.animate(withDuration: 0.3) {
       let upsideDown = CGAffineTransform(rotationAngle: .pi * 0.9999)
       self.disclosureIndicator.transform = self.indicatorFlag ? upsideDown : .identity

--- a/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
@@ -44,6 +44,7 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
     setupLayouts()
     setupConstraints()
+    backgroundColor = .background
   }
   
   required init?(coder: NSCoder) {

--- a/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
@@ -14,6 +14,7 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
   
   static let identifier = "\(PolicyHeaderTableViewCell.self)"
   
+  /// IndicatorDisclosure의 애니메이션 flag
   private var indicatorFlag = false
   
   private let disclosureIndicator: UIImageView = UIImageView().then {

--- a/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
@@ -1,0 +1,21 @@
+//
+//  PolicyHeaderTableViewCell.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2022/12/10.
+//
+
+import UIKit
+
+final class PolicyHeaderTableViewCell: UITableViewCell {
+  
+  static let identifier = "\(PolicyHeaderTableViewCell.self)"
+
+  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
@@ -14,6 +14,8 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
   
   static let identifier = "\(PolicyHeaderTableViewCell.self)"
   
+  var isTapped: Bool = false
+  
   private let disclosureIndicator: UIImageView = UIImageView().then {
     $0.image = UIImage(systemName: "chevron.down")
     $0.contentMode = .scaleAspectFit

--- a/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
@@ -29,6 +29,10 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
     $0.textColor = .deepGray
   }
   
+  private let seperatorLineView: UIView = UIView().then {
+    $0.backgroundColor = .lightGray
+  }
+  
   private let checkbox: CheckBoxButton = CheckBoxButton(type: .full)
   
   private let stackView: UIStackView = UIStackView().then {
@@ -48,12 +52,19 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
   
   private func setupLayouts() {
     contentView.addSubview(stackView)
+    contentView.addSubview(seperatorLineView)
     [disclosureIndicator, policyLabel, checkbox].forEach {
       stackView.addArrangedSubview($0)
     }
   }
   
   private func setupConstraints() {
+    
+    seperatorLineView.snp.makeConstraints { make in
+      make.bottom.horizontalEdges.equalToSuperview()
+      make.height.equalTo(1) // 높이를 1로 설정하여 테이블 구분선을 만듦
+    }
+    
     stackView.snp.makeConstraints { make in
       make.top.leading.equalToSuperview().inset(10)
       make.bottom.trailing.equalToSuperview().inset(13)
@@ -85,6 +96,7 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
     super.setSelected(false, animated: animated)
     if selected {
       updateIndicators()
+      seperatorLineView.isHidden.toggle()
     }
   }
 }

--- a/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
@@ -54,8 +54,8 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
   
   private func setupConstraints() {
     stackView.snp.makeConstraints { make in
-      make.edges.equalToSuperview()
-      make.height.equalTo(48)
+      make.top.leading.equalToSuperview().inset(10)
+      make.bottom.trailing.equalToSuperview().inset(13)
     }
     
     disclosureIndicator.snp.makeConstraints { make in

--- a/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyHeaderTableViewCell.swift
@@ -14,7 +14,7 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
   
   static let identifier = "\(PolicyHeaderTableViewCell.self)"
   
-  var isTapped: Bool = false
+  var isTapped: Bool = false { didSet { updateIndicators() } }
   
   private let disclosureIndicator: UIImageView = UIImageView().then {
     $0.image = UIImage(systemName: "chevron.down")
@@ -64,6 +64,14 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
     
     checkbox.snp.makeConstraints { make in
       make.size.equalTo(24)
+    }
+  }
+  
+  /// 화살표 인디케이터에 아래쪽, 위쪽 방향 애니메이션을 적용합니다.
+  private func updateIndicators() {
+    UIView.animate(withDuration: 0.3) {
+      let upsideDown = CGAffineTransform(rotationAngle: .pi * 0.9999)
+      self.disclosureIndicator.transform = self.isTapped ? upsideDown : .identity 
     }
   }
   

--- a/PLUB/Sources/Login/Policy/PolicyTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyTableViewCell.swift
@@ -12,6 +12,8 @@ import SnapKit
 
 final class PolicyTableViewCell: UITableViewCell {
   
+  static let identifier = "\(PolicyTableViewCell.self)"
+  
   private let webView: WKWebView = WKWebView()
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {

--- a/PLUB/Sources/Login/Policy/PolicyTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyTableViewCell.swift
@@ -42,4 +42,11 @@ final class PolicyTableViewCell: UITableViewCell {
     let request = URLRequest(url: url)
     webView.load(request)
   }
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    
+    webView.stopLoading()
+    webView.loadHTMLString("", baseURL: nil)
+  }
 }

--- a/PLUB/Sources/Login/Policy/PolicyTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyTableViewCell.swift
@@ -33,7 +33,9 @@ final class PolicyTableViewCell: UITableViewCell {
   
   private func setupConstraints() {
     webView.snp.makeConstraints { make in
-      make.edges.equalToSuperview()
+      make.leading.equalToSuperview().inset(26) // 24(size) + 2(spacing)
+      make.trailing.equalToSuperview().inset(39) // 13(trailing) + 24(size) + 2(spacing)
+      make.verticalEdges.equalToSuperview().inset(4)
       make.height.equalTo(208)
     }
   }

--- a/PLUB/Sources/Login/Policy/PolicyTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyTableViewCell.swift
@@ -1,0 +1,43 @@
+//
+//  PolicyTableViewCell.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2022/12/10.
+//
+
+import WebKit
+import UIKit
+
+import SnapKit
+
+final class PolicyTableViewCell: UITableViewCell {
+  
+  private let webView: WKWebView = WKWebView()
+
+  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+    setupLayouts()
+    setupConstraints()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  
+  private func setupLayouts() {
+    contentView.addSubview(webView)
+  }
+  
+  private func setupConstraints() {
+    webView.snp.makeConstraints { make in
+      make.edges.equalToSuperview()
+      make.height.equalTo(208)
+    }
+  }
+  
+  func configure(with url: URL) {
+    let request = URLRequest(url: url)
+    webView.load(request)
+  }
+}

--- a/PLUB/Sources/Login/Policy/PolicyTableViewCell.swift
+++ b/PLUB/Sources/Login/Policy/PolicyTableViewCell.swift
@@ -15,6 +15,11 @@ final class PolicyTableViewCell: UITableViewCell {
   static let identifier = "\(PolicyTableViewCell.self)"
   
   private let webView: WKWebView = WKWebView()
+  
+  private let seperatorLineView: UIView = UIView().then {
+    $0.backgroundColor = .lightGray
+    $0.isHidden = true
+  }
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -29,6 +34,7 @@ final class PolicyTableViewCell: UITableViewCell {
   
   private func setupLayouts() {
     contentView.addSubview(webView)
+    contentView.addSubview(seperatorLineView)
   }
   
   private func setupConstraints() {
@@ -38,11 +44,17 @@ final class PolicyTableViewCell: UITableViewCell {
       make.verticalEdges.equalToSuperview().inset(4)
       make.height.equalTo(208)
     }
+    
+    seperatorLineView.snp.makeConstraints { make in
+      make.bottom.horizontalEdges.equalToSuperview()
+      make.height.equalTo(1) // 높이를 1로 설정하여 테이블 구분선을 만듦
+    }
   }
   
   func configure(with url: URL) {
     let request = URLRequest(url: url)
     webView.load(request)
+    seperatorLineView.isHidden = false
   }
   
   override func prepareForReuse() {

--- a/PLUB/Sources/Login/Policy/PolicyViewController.swift
+++ b/PLUB/Sources/Login/Policy/PolicyViewController.swift
@@ -1,0 +1,40 @@
+//
+//  PolicyViewController.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2022/12/10.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
+
+final class PolicyViewController: BaseViewController {
+  
+  override func setupLayouts() {
+    super.setupLayouts()
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+  }
+  
+  override func setupStyles() {
+    super.setupStyles()
+    view.backgroundColor = .background
+  }
+}
+
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+struct PolicyViewControllerPreview: PreviewProvider {
+  static var previews: some View {
+    PolicyViewController().toPreview()
+  }
+}
+#endif
+

--- a/PLUB/Sources/Login/Policy/PolicyViewController.swift
+++ b/PLUB/Sources/Login/Policy/PolicyViewController.swift
@@ -14,17 +14,24 @@ import Then
 
 final class PolicyViewController: BaseViewController {
   
+  
+  private lazy var tableView: UITableView = UITableView().then {
+    $0.backgroundColor = .background
+    $0.register(PolicyHeaderTableViewCell.self, forCellReuseIdentifier: PolicyHeaderTableViewCell.identifier)
+    $0.register(PolicyTableViewCell.self, forCellReuseIdentifier: PolicyTableViewCell.identifier)
+    $0.separatorStyle = .none
+  }
+  
   override func setupLayouts() {
     super.setupLayouts()
+    view.addSubview(tableView)
   }
   
   override func setupConstraints() {
     super.setupConstraints()
-  }
-  
-  override func setupStyles() {
-    super.setupStyles()
-    view.backgroundColor = .background
+    tableView.snp.makeConstraints { make in
+      make.edges.equalToSuperview()
+    }
   }
 }
 

--- a/PLUB/Sources/Login/Policy/PolicyViewController.swift
+++ b/PLUB/Sources/Login/Policy/PolicyViewController.swift
@@ -44,7 +44,9 @@ final class PolicyViewController: BaseViewController {
 
 
 extension PolicyViewController: UITableViewDelegate {
-
+  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    viewModel.loadNextSnapshots(for: .init(rawValue: indexPath.section)!)
+  }
 }
 
 #if canImport(SwiftUI) && DEBUG
@@ -55,4 +57,3 @@ struct PolicyViewControllerPreview: PreviewProvider {
   }
 }
 #endif
-

--- a/PLUB/Sources/Login/Policy/PolicyViewController.swift
+++ b/PLUB/Sources/Login/Policy/PolicyViewController.swift
@@ -14,12 +14,19 @@ import Then
 
 final class PolicyViewController: BaseViewController {
   
+  private let viewModel = PolicyViewModel()
   
   private lazy var tableView: UITableView = UITableView().then {
     $0.backgroundColor = .background
     $0.register(PolicyHeaderTableViewCell.self, forCellReuseIdentifier: PolicyHeaderTableViewCell.identifier)
     $0.register(PolicyTableViewCell.self, forCellReuseIdentifier: PolicyTableViewCell.identifier)
     $0.separatorStyle = .none
+    $0.delegate = self
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    viewModel.setTableView(tableView)
   }
   
   override func setupLayouts() {
@@ -35,6 +42,10 @@ final class PolicyViewController: BaseViewController {
   }
 }
 
+
+extension PolicyViewController: UITableViewDelegate {
+
+}
 
 #if canImport(SwiftUI) && DEBUG
 import SwiftUI

--- a/PLUB/Sources/Login/Policy/PolicyViewController.swift
+++ b/PLUB/Sources/Login/Policy/PolicyViewController.swift
@@ -19,7 +19,7 @@ final class PolicyViewController: BaseViewController {
   private lazy var tableView: UITableView = UITableView().then {
     $0.backgroundColor = .background
     $0.register(PolicyHeaderTableViewCell.self, forCellReuseIdentifier: PolicyHeaderTableViewCell.identifier)
-    $0.register(PolicyTableViewCell.self, forCellReuseIdentifier: PolicyTableViewCell.identifier)
+    $0.register(PolicyBodyTableViewCell.self, forCellReuseIdentifier: PolicyBodyTableViewCell.identifier)
     $0.separatorStyle = .none
     $0.delegate = self
   }

--- a/PLUB/Sources/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Login/Policy/PolicyViewModel.swift
@@ -5,10 +5,52 @@
 //  Created by 홍승현 on 2022/12/13.
 //
 
-import Foundation
+import UIKit
 
 final class PolicyViewModel {
   
+}
+
+// MARK: - Diffable Models & Types
+
+extension PolicyViewModel {
   
+  typealias DataSource = UITableViewDiffableDataSource<Section, Item>
+  typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
   
+  enum Section: Int, CaseIterable {
+    /// 이용약관 및 개인정보 취급 방침
+    case termsOfService
+    /// 위치 기반 서비스 이용 약관
+    case locationBasedService
+    /// 만 14세 이상 확인
+    case termsAndConditionsForAges
+    /// 개인정보 수집 이용 동의
+    case privacyPolicy
+    /// 마케팅 활용 동의
+    case marketing
+  }
+  
+  enum CellType {
+    case header
+    case body
+  }
+  
+  struct Item: Hashable {
+    let type: CellType
+    let url: URL?
+    let policy: String?
+    
+    init(type: CellType, url: URL? = nil, policy: String? = nil) {
+      self.type = type
+      self.url = url
+      self.policy = policy
+    }
+    
+    func hash(into hasher: inout Hasher) {
+      hasher.combine(identifier)
+    }
+    
+    private let identifier = UUID()
+  }
 }

--- a/PLUB/Sources/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Login/Policy/PolicyViewModel.swift
@@ -17,7 +17,13 @@ final class PolicyViewModel {
     "마케팅 활용 동의 (선택)"
   ]
   
-  private var dataSource: DataSource? = nil
+  private var dataSource: DataSource? = nil {
+    didSet {
+      applyInitialSnapshots()
+    }
+  }
+  
+  private var snapshot = Snapshot()
 }
 
 // MARK: - Set Property Methods
@@ -46,6 +52,17 @@ extension PolicyViewModel {
       
       return cell
     }
+  }
+  
+  /// 초기 Snapshot을 설정합니다. DataSource가 초기화될 시 해당 메서드가 실행됩니다.
+  /// 직접 이 메서드를 실행할 필요는 없습니다.
+  private func applyInitialSnapshots() {
+    var snapshot = Snapshot()
+    snapshot.appendSections(Section.allCases)
+    for (section, policy) in zip(Section.allCases, policies) {
+      snapshot.appendItems([Item(type: .header, policy: policy)], toSection: section)
+    }
+    dataSource?.apply(snapshot)
   }
 }
 

--- a/PLUB/Sources/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Login/Policy/PolicyViewModel.swift
@@ -16,6 +16,37 @@ final class PolicyViewModel {
     "개인정보 수집 이용 동의 (필수)",
     "마케팅 활용 동의 (선택)"
   ]
+  
+  private var dataSource: DataSource? = nil
+}
+
+// MARK: - Set Property Methods
+
+extension PolicyViewModel {
+  
+  /// tableView를 세팅하며, `DiffableDataSource`를 초기화하여 해당 tableView에 데이터를 지닌 셀을 처리합니다.
+  /// - Parameter tableView: 보여질 tableView
+  func setTableView(_ tableView: UITableView) {
+    self.dataSource = DataSource(tableView: tableView) { tableView, indexPath, model in
+      
+      // == header cell ==
+      let identifier: String
+      switch model.type {
+      case .header:
+        identifier = PolicyHeaderTableViewCell.identifier
+      case .body:
+        identifier = PolicyTableViewCell.identifier
+      }
+      
+      let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath)
+      
+      if let cellConfigurable = cell as? PolicyConfigurable {
+        cellConfigurable.configure(with: model)
+      }
+      
+      return cell
+    }
+  }
 }
 
 // MARK: - Diffable Models & Types

--- a/PLUB/Sources/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Login/Policy/PolicyViewModel.swift
@@ -1,0 +1,14 @@
+//
+//  PolicyViewModel.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2022/12/13.
+//
+
+import Foundation
+
+final class PolicyViewModel {
+  
+  
+  
+}

--- a/PLUB/Sources/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Login/Policy/PolicyViewModel.swift
@@ -9,6 +9,13 @@ import UIKit
 
 final class PolicyViewModel {
   
+  private let policies = [
+    "이용약관 및 개인정보취급방침 (필수)",
+    "위치 기반 서비스 이용 약관 (필수)",
+    "만 14세 이상 확인 (필수)",
+    "개인정보 수집 이용 동의 (필수)",
+    "마케팅 활용 동의 (선택)"
+  ]
 }
 
 // MARK: - Diffable Models & Types

--- a/PLUB/Sources/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Login/Policy/PolicyViewModel.swift
@@ -30,6 +30,8 @@ final class PolicyViewModel {
 
 extension PolicyViewModel {
   
+  // MARK: DataSource
+  
   /// tableView를 세팅하며, `DiffableDataSource`를 초기화하여 해당 tableView에 데이터를 지닌 셀을 처리합니다.
   /// - Parameter tableView: 보여질 tableView
   func setTableView(_ tableView: UITableView) {
@@ -52,6 +54,26 @@ extension PolicyViewModel {
       
       return cell
     }
+  }
+  
+  // MARK: Snapshot
+  
+  func loadNextSnapshots(for section: Section) {
+    guard let dataSource = dataSource else { return }
+    var snapshot = dataSource.snapshot()
+    // selected 된 section의 셀 정보(identifier)를 가져옴
+    guard let identifier = snapshot.itemIdentifiers(inSection: section).last else { return }
+    
+    // body가 없어 expand 해야하는 경우
+    if identifier.type == .header {
+      snapshot.appendItems([Item(type: .body, url: URL(string: "https://velog.io/@whitehyun"))], toSection: section)
+    }
+    // body가 이미 존재하지만, 한번 더 탭되어 collapse 해야하는 경우
+    else {
+      snapshot.deleteItems([identifier])
+    }
+    
+    dataSource.apply(snapshot)
   }
   
   /// 초기 Snapshot을 설정합니다. DataSource가 초기화될 시 해당 메서드가 실행됩니다.

--- a/PLUB/Sources/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Login/Policy/PolicyViewModel.swift
@@ -22,8 +22,6 @@ final class PolicyViewModel {
       applyInitialSnapshots()
     }
   }
-  
-  private var snapshot = Snapshot()
 }
 
 // MARK: - Set Property Methods

--- a/PLUB/Sources/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Login/Policy/PolicyViewModel.swift
@@ -34,8 +34,6 @@ extension PolicyViewModel {
   /// - Parameter tableView: 보여질 tableView
   func setTableView(_ tableView: UITableView) {
     self.dataSource = DataSource(tableView: tableView) { tableView, indexPath, model in
-      
-      // == header cell ==
       let identifier: String
       switch model.type {
       case .header:

--- a/PLUB/Sources/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Login/Policy/PolicyViewModel.swift
@@ -41,7 +41,7 @@ extension PolicyViewModel {
       case .header:
         identifier = PolicyHeaderTableViewCell.identifier
       case .body:
-        identifier = PolicyTableViewCell.identifier
+        identifier = PolicyBodyTableViewCell.identifier
       }
       
       let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath)


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용

- 약관 페이지를 구현하였으며, 이전에 `merge`했던 `checkbox`도 추가하여 구현해두었습니다.
- 약관 설명은 textView형식으로 보여주는 것이 아니라, 백엔드에서 url을 받아 보여줄 것이기 때문에 webView로 진행하였습니다. 아직 백엔드와의 통신 구현은 미비된 상태여서 ~~제 블로그 링크를 넣어두었습니다~~.
- 아직 전체 동의 버튼은 구현하지 않은 상태입니다. 다음 PR 때 적용해두겠습니다.

🌱 PR 포인트

- NSDiffableDataSource를 적용하였습니다.
- 약관 제목란은 `Header Cell(PolicyHeaderTableViewCell)`, 약관 설명란은 `Body Cell(PolicyBodyTableViewCell)`로 구조화하였습니다.
- `Configurable`라는 protocol을 구현하여 `Header Cell`과 `Body Cell`에 적용하였습니다.

  - <details><summary>설명</summary>
     <p>

    #### `Configurable`을 적용한 이유

    cell의 configure을 쉽게 호출하기 위해서 구현하였습니다.
    비록 cell의 configure(with:)이 이미 클래스 내부에 구현되어있고, `Configurable`가 이를 또 다시 호출해주는 것일 뿐이지만
    viewModel에서 dataSource를 구성할 때 코드를 더 적게 작성하여 configure을 적용시킬 수 있었습니다.

    만약 configurable가 없는다면 다음과 같은 코드로 작성될 겁니다.

    ```swift
    self.dataSource = DataSource(tableView: tableView) { tableView, indexPath, model in

      switch model.type {
      case .header:
        guard let cell = tableView.dequeueReusableCell(
          withIdentifier: PolicyHeaderTableViewCell.identifier,
          for: indexPath
        ) as? PolicyHeaderTableViewCell else { return UITableViewCell() }
        guard let policy = model.policy else { return UITableViewCell() }
        cell.configure(with: policy)
        return cell

      case .body:
        guard let cell = tableView.dequeueReusableCell(
          withIdentifier: PolicyBodyTableViewCell.identifier,
          for: indexPath
        ) as? PolicyBodyTableViewCell else { return UITableViewCell() }
        guard let url = model.url else { return UITableViewCell() }
        cell.configure(with: url)
        return cell
      }
    ```

    이는 보일러 플레이트 코드가 발생한 것이기 때문에 좋지 않은 코드라고 판단하였고, Configurable을 적용하여 유연하게 configure을 적용시킬 수 있도록 구현하였습니다.

    ```swift
    self.dataSource = DataSource(tableView: tableView) { tableView, indexPath, model in
      let identifier: String
      switch model.type {
      case .header:
        identifier = PolicyHeaderTableViewCell.identifier
      case .body:
        identifier = PolicyBodyTableViewCell.identifier
      }

      let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath)

      if let cellConfigurable = cell as? PolicyConfigurable {
        cellConfigurable.configure(with: model)
      }

      return cell
    }
    ```

     </p>
     </details>

## 📸 스크린샷

|                                               Diffable model 설명                                               |                                                  적용된 model                                                   |
| :-------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------: |
| ![image](https://user-images.githubusercontent.com/57972338/208359367-def9f313-29fb-4804-9df6-8b36c4bd6ba6.png) | ![image](https://user-images.githubusercontent.com/57972338/208360178-1a1634cc-3e3b-43ec-8bef-598c998aa388.png) |

|                                                                      최종결과                                                                       |
| :-------------------------------------------------------------------------------------------------------------------------------------------------: |
| ![Screen Recording 2022-12-19 at 3 31 41 PM](https://user-images.githubusercontent.com/57972338/208362562-9056e954-06aa-4735-b367-a5f1064ee886.gif) |

<!--![Screen Recording 2022-12-19 at 2 25 20 PM](https://user-images.githubusercontent.com/57972338/208353934-707cd85f-cd9d-4bcb-b787-7fa8642eb525.gif)-->

## 📮 관련 이슈

- #16
