### PR TITLE
[Network] Base Model 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,8 @@ iOSInjectionProject/
 **/xcshareddata/WorkspaceSettings.xcsettings
 
 # End of https://www.toptal.com/developers/gitignore/api/xcode,macos,cocoapods,swift
+
+
+### Custom gitignore ###
+
+PLUB/Sources/Network/Environment/Config.swift

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		BA780E0D297133F80032C178 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E0C297133F80032C178 /* Router.swift */; };
 		BA780E0F297138F10032C178 /* HeaderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E0E297138F10032C178 /* HeaderType.swift */; };
 		BA780E1129713BF30032C178 /* ParameterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E1029713BF30032C178 /* ParameterType.swift */; };
+		BA780E1329713F370032C178 /* BaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E1229713F370032C178 /* BaseService.swift */; };
 		BA876BA1296514DA0029CF34 /* PaddingTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA0296514DA0029CF34 /* PaddingTextField.swift */; };
 		BA876BA4296529100029CF34 /* IntroductionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA3296529100029CF34 /* IntroductionViewController.swift */; };
 		BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88124D28E48A2F00BD832A /* AppDelegate.swift */; };
@@ -137,6 +138,7 @@
 		BA780E0C297133F80032C178 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		BA780E0E297138F10032C178 /* HeaderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderType.swift; sourceTree = "<group>"; };
 		BA780E1029713BF30032C178 /* ParameterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterType.swift; sourceTree = "<group>"; };
+		BA780E1229713F370032C178 /* BaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseService.swift; sourceTree = "<group>"; };
 		BA876BA0296514DA0029CF34 /* PaddingTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingTextField.swift; sourceTree = "<group>"; };
 		BA876BA3296529100029CF34 /* IntroductionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionViewController.swift; sourceTree = "<group>"; };
 		BA88124A28E48A2F00BD832A /* PLUB.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PLUB.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -437,9 +439,10 @@
 		BA780E0429712DE70032C178 /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
-				BA780E0C297133F80032C178 /* Router.swift */,
 				BA780E0E297138F10032C178 /* HeaderType.swift */,
 				BA780E1029713BF30032C178 /* ParameterType.swift */,
+				BA780E0C297133F80032C178 /* Router.swift */,
+				BA780E1229713F370032C178 /* BaseService.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -683,6 +686,7 @@
 				BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */,
 				7095A58C292FB0B6002A52E6 /* InterestTypeCollectionViewCell.swift in Sources */,
 				BA780E1129713BF30032C178 /* ParameterType.swift in Sources */,
+				BA780E1329713F370032C178 /* BaseService.swift in Sources */,
 				70BD5F272959F718002CBA89 /* UIView + extension.swift in Sources */,
 				7085678C28EFBDC1008047DC /* RegisterInterestViewController.swift in Sources */,
 			);

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		BA780E0F297138F10032C178 /* HeaderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E0E297138F10032C178 /* HeaderType.swift */; };
 		BA780E1129713BF30032C178 /* ParameterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E1029713BF30032C178 /* ParameterType.swift */; };
 		BA780E1329713F370032C178 /* BaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E1229713F370032C178 /* BaseService.swift */; };
+		BA780E1529714AAB0032C178 /* GeneralResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E1429714AAB0032C178 /* GeneralResponse.swift */; };
 		BA876BA1296514DA0029CF34 /* PaddingTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA0296514DA0029CF34 /* PaddingTextField.swift */; };
 		BA876BA4296529100029CF34 /* IntroductionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA3296529100029CF34 /* IntroductionViewController.swift */; };
 		BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88124D28E48A2F00BD832A /* AppDelegate.swift */; };
@@ -139,6 +140,7 @@
 		BA780E0E297138F10032C178 /* HeaderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderType.swift; sourceTree = "<group>"; };
 		BA780E1029713BF30032C178 /* ParameterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterType.swift; sourceTree = "<group>"; };
 		BA780E1229713F370032C178 /* BaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseService.swift; sourceTree = "<group>"; };
+		BA780E1429714AAB0032C178 /* GeneralResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralResponse.swift; sourceTree = "<group>"; };
 		BA876BA0296514DA0029CF34 /* PaddingTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingTextField.swift; sourceTree = "<group>"; };
 		BA876BA3296529100029CF34 /* IntroductionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionViewController.swift; sourceTree = "<group>"; };
 		BA88124A28E48A2F00BD832A /* PLUB.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PLUB.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -353,6 +355,7 @@
 		BA36EED5295463AA00D30169 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				BA780E1429714AAB0032C178 /* GeneralResponse.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -679,6 +682,7 @@
 				BA42D1F528EDE11900C20061 /* MeetingViewController.swift in Sources */,
 				BA88125028E48A2F00BD832A /* SceneDelegate.swift in Sources */,
 				BA0322BA294F3F9D002466C5 /* PolicyConfigurable.swift in Sources */,
+				BA780E1529714AAB0032C178 /* GeneralResponse.swift in Sources */,
 				C3AD265D296ACC0600C57370 /* MeetingNameViewController.swift in Sources */,
 				0A81767F28F3105200C1E074 /* Preview.swift in Sources */,
 				C3AD265F296AD3C100C57370 /* InputTextView.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		BA780E1129713BF30032C178 /* ParameterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E1029713BF30032C178 /* ParameterType.swift */; };
 		BA780E1329713F370032C178 /* BaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E1229713F370032C178 /* BaseService.swift */; };
 		BA780E1529714AAB0032C178 /* GeneralResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E1429714AAB0032C178 /* GeneralResponse.swift */; };
+		BA780E192972A0D90032C178 /* PLUBError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E182972A0D90032C178 /* PLUBError.swift */; };
 		BA876BA1296514DA0029CF34 /* PaddingTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA0296514DA0029CF34 /* PaddingTextField.swift */; };
 		BA876BA4296529100029CF34 /* IntroductionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA3296529100029CF34 /* IntroductionViewController.swift */; };
 		BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88124D28E48A2F00BD832A /* AppDelegate.swift */; };
@@ -141,6 +142,7 @@
 		BA780E1029713BF30032C178 /* ParameterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterType.swift; sourceTree = "<group>"; };
 		BA780E1229713F370032C178 /* BaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseService.swift; sourceTree = "<group>"; };
 		BA780E1429714AAB0032C178 /* GeneralResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralResponse.swift; sourceTree = "<group>"; };
+		BA780E182972A0D90032C178 /* PLUBError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLUBError.swift; sourceTree = "<group>"; };
 		BA876BA0296514DA0029CF34 /* PaddingTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingTextField.swift; sourceTree = "<group>"; };
 		BA876BA3296529100029CF34 /* IntroductionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionViewController.swift; sourceTree = "<group>"; };
 		BA88124A28E48A2F00BD832A /* PLUB.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PLUB.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -446,6 +448,7 @@
 				BA780E1029713BF30032C178 /* ParameterType.swift */,
 				BA780E0C297133F80032C178 /* Router.swift */,
 				BA780E1229713F370032C178 /* BaseService.swift */,
+				BA780E182972A0D90032C178 /* PLUBError.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -690,6 +693,7 @@
 				BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */,
 				7095A58C292FB0B6002A52E6 /* InterestTypeCollectionViewCell.swift in Sources */,
 				BA780E1129713BF30032C178 /* ParameterType.swift in Sources */,
+				BA780E192972A0D90032C178 /* PLUBError.swift in Sources */,
 				BA780E1329713F370032C178 /* BaseService.swift in Sources */,
 				70BD5F272959F718002CBA89 /* UIView + extension.swift in Sources */,
 				7085678C28EFBDC1008047DC /* RegisterInterestViewController.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		BA771652296FBF4400762362 /* KeyChainWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA771651296FBF4400762362 /* KeyChainWrapper.swift */; };
 		BA780E09297133220032C178 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E08297133220032C178 /* Config.swift */; };
 		BA780E0D297133F80032C178 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E0C297133F80032C178 /* Router.swift */; };
+		BA780E0F297138F10032C178 /* HeaderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E0E297138F10032C178 /* HeaderType.swift */; };
 		BA876BA1296514DA0029CF34 /* PaddingTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA0296514DA0029CF34 /* PaddingTextField.swift */; };
 		BA876BA4296529100029CF34 /* IntroductionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA3296529100029CF34 /* IntroductionViewController.swift */; };
 		BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88124D28E48A2F00BD832A /* AppDelegate.swift */; };
@@ -133,6 +134,7 @@
 		BA771651296FBF4400762362 /* KeyChainWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainWrapper.swift; sourceTree = "<group>"; };
 		BA780E08297133220032C178 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		BA780E0C297133F80032C178 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
+		BA780E0E297138F10032C178 /* HeaderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderType.swift; sourceTree = "<group>"; };
 		BA876BA0296514DA0029CF34 /* PaddingTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingTextField.swift; sourceTree = "<group>"; };
 		BA876BA3296529100029CF34 /* IntroductionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionViewController.swift; sourceTree = "<group>"; };
 		BA88124A28E48A2F00BD832A /* PLUB.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PLUB.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -434,6 +436,7 @@
 			isa = PBXGroup;
 			children = (
 				BA780E0C297133F80032C178 /* Router.swift */,
+				BA780E0E297138F10032C178 /* HeaderType.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -629,6 +632,7 @@
 				70197B7B29549B6A000503F6 /* SelectedCategoryChartCollectionViewCell.swift in Sources */,
 				70197B722953698F000503F6 /* SelectedCategoryViewController.swift in Sources */,
 				7085678828EEACFB008047DC /* RecommendedMeetingCollectionViewCell.swift in Sources */,
+				BA780E0F297138F10032C178 /* HeaderType.swift in Sources */,
 				BA42D1F328EDE10F00C20061 /* LoginViewController.swift in Sources */,
 				BAE16029292221ED00D595FF /* CheckBoxButton.swift in Sources */,
 				70BD5F2E296472CF002CBA89 /* IntroduceCategoryNavigationBar.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52778F28EECEB40036B825 /* Ex+UIFont.swift */; };
 		BA771652296FBF4400762362 /* KeyChainWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA771651296FBF4400762362 /* KeyChainWrapper.swift */; };
 		BA780E09297133220032C178 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E08297133220032C178 /* Config.swift */; };
+		BA780E0D297133F80032C178 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E0C297133F80032C178 /* Router.swift */; };
 		BA876BA1296514DA0029CF34 /* PaddingTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA0296514DA0029CF34 /* PaddingTextField.swift */; };
 		BA876BA4296529100029CF34 /* IntroductionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA3296529100029CF34 /* IntroductionViewController.swift */; };
 		BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88124D28E48A2F00BD832A /* AppDelegate.swift */; };
@@ -131,6 +132,7 @@
 		BA52778F28EECEB40036B825 /* Ex+UIFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+UIFont.swift"; sourceTree = "<group>"; };
 		BA771651296FBF4400762362 /* KeyChainWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainWrapper.swift; sourceTree = "<group>"; };
 		BA780E08297133220032C178 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
+		BA780E0C297133F80032C178 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		BA876BA0296514DA0029CF34 /* PaddingTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingTextField.swift; sourceTree = "<group>"; };
 		BA876BA3296529100029CF34 /* IntroductionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionViewController.swift; sourceTree = "<group>"; };
 		BA88124A28E48A2F00BD832A /* PLUB.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PLUB.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -431,6 +433,7 @@
 		BA780E0429712DE70032C178 /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
+				BA780E0C297133F80032C178 /* Router.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -642,6 +645,7 @@
 				70197B7929549B29000503F6 /* SelectedCategoryGridCollectionViewCell.swift in Sources */,
 				70BD5F302964823C002CBA89 /* ApplyQuestionViewController.swift in Sources */,
 				7095A58A292E58F9002A52E6 /* IndicatorButton.swift in Sources */,
+				BA780E0D297133F80032C178 /* Router.swift in Sources */,
 				BA4DADB3295747E700C7ABD7 /* PageControl.swift in Sources */,
 				704AC7952938E800008C3A88 /* RegisterInterestModel.swift in Sources */,
 				0A3E42D928E7343F00F62BF0 /* Constants.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		BA780E09297133220032C178 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E08297133220032C178 /* Config.swift */; };
 		BA780E0D297133F80032C178 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E0C297133F80032C178 /* Router.swift */; };
 		BA780E0F297138F10032C178 /* HeaderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E0E297138F10032C178 /* HeaderType.swift */; };
+		BA780E1129713BF30032C178 /* ParameterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E1029713BF30032C178 /* ParameterType.swift */; };
 		BA876BA1296514DA0029CF34 /* PaddingTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA0296514DA0029CF34 /* PaddingTextField.swift */; };
 		BA876BA4296529100029CF34 /* IntroductionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA3296529100029CF34 /* IntroductionViewController.swift */; };
 		BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88124D28E48A2F00BD832A /* AppDelegate.swift */; };
@@ -135,6 +136,7 @@
 		BA780E08297133220032C178 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		BA780E0C297133F80032C178 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		BA780E0E297138F10032C178 /* HeaderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderType.swift; sourceTree = "<group>"; };
+		BA780E1029713BF30032C178 /* ParameterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterType.swift; sourceTree = "<group>"; };
 		BA876BA0296514DA0029CF34 /* PaddingTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingTextField.swift; sourceTree = "<group>"; };
 		BA876BA3296529100029CF34 /* IntroductionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionViewController.swift; sourceTree = "<group>"; };
 		BA88124A28E48A2F00BD832A /* PLUB.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PLUB.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -437,6 +439,7 @@
 			children = (
 				BA780E0C297133F80032C178 /* Router.swift */,
 				BA780E0E297138F10032C178 /* HeaderType.swift */,
+				BA780E1029713BF30032C178 /* ParameterType.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -679,6 +682,7 @@
 				BAE1AD972944C16600CE36B9 /* PolicyHeaderTableViewCell.swift in Sources */,
 				BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */,
 				7095A58C292FB0B6002A52E6 /* InterestTypeCollectionViewCell.swift in Sources */,
+				BA780E1129713BF30032C178 /* ParameterType.swift in Sources */,
 				70BD5F272959F718002CBA89 /* UIView + extension.swift in Sources */,
 				7085678C28EFBDC1008047DC /* RegisterInterestViewController.swift in Sources */,
 			);

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		BA52778C28EECDC50036B825 /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA52778328EECDC50036B825 /* Pretendard-Light.otf */; };
 		BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52778F28EECEB40036B825 /* Ex+UIFont.swift */; };
 		BA771652296FBF4400762362 /* KeyChainWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA771651296FBF4400762362 /* KeyChainWrapper.swift */; };
+		BA780E09297133220032C178 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA780E08297133220032C178 /* Config.swift */; };
 		BA876BA1296514DA0029CF34 /* PaddingTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA0296514DA0029CF34 /* PaddingTextField.swift */; };
 		BA876BA4296529100029CF34 /* IntroductionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA3296529100029CF34 /* IntroductionViewController.swift */; };
 		BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88124D28E48A2F00BD832A /* AppDelegate.swift */; };
@@ -129,6 +130,7 @@
 		BA52778328EECDC50036B825 /* Pretendard-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.otf"; sourceTree = "<group>"; };
 		BA52778F28EECEB40036B825 /* Ex+UIFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+UIFont.swift"; sourceTree = "<group>"; };
 		BA771651296FBF4400762362 /* KeyChainWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainWrapper.swift; sourceTree = "<group>"; };
+		BA780E08297133220032C178 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		BA876BA0296514DA0029CF34 /* PaddingTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingTextField.swift; sourceTree = "<group>"; };
 		BA876BA3296529100029CF34 /* IntroductionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionViewController.swift; sourceTree = "<group>"; };
 		BA88124A28E48A2F00BD832A /* PLUB.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PLUB.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -332,6 +334,10 @@
 		BA36EED4295463A600D30169 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				BA780E07297133190032C178 /* Environment */,
+				BA780E0429712DE70032C178 /* Foundation */,
+				BA780E0A297133870032C178 /* Routers */,
+				BA780E0B2971338D0032C178 /* Services */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -420,6 +426,35 @@
 				BA771651296FBF4400762362 /* KeyChainWrapper.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		BA780E0429712DE70032C178 /* Foundation */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Foundation;
+			sourceTree = "<group>";
+		};
+		BA780E07297133190032C178 /* Environment */ = {
+			isa = PBXGroup;
+			children = (
+				BA780E08297133220032C178 /* Config.swift */,
+			);
+			path = Environment;
+			sourceTree = "<group>";
+		};
+		BA780E0A297133870032C178 /* Routers */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Routers;
+			sourceTree = "<group>";
+		};
+		BA780E0B2971338D0032C178 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 		BA876BA2296528E60029CF34 /* Introduction */ = {
@@ -620,6 +655,7 @@
 				BAE1AD992944C75F00CE36B9 /* PolicyBodyTableViewCell.swift in Sources */,
 				0A3E42DC28E734E800F62BF0 /* Device.swift in Sources */,
 				7085678628EE9A92008047DC /* HomeCollectionViewCell.swift in Sources */,
+				BA780E09297133220032C178 /* Config.swift in Sources */,
 				BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */,
 				70197B7029535BDA000503F6 /* RegisterInterestViewModel.swift in Sources */,
 				70BD5F3329648DD9002CBA89 /* ApplyQuestionTableViewCell.swift in Sources */,

--- a/PLUB/Sources/Models/GeneralResponse.swift
+++ b/PLUB/Sources/Models/GeneralResponse.swift
@@ -1,0 +1,14 @@
+//
+//  GeneralResponse.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/01/13.
+//
+
+import Foundation
+
+struct GeneralResponse<T>: Decodable where T: Decodable {
+  let statusCode: Int?
+  let message: String?
+  let data: T?
+}

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -17,6 +17,33 @@ class BaseService {
     $0.timeoutIntervalForRequest = NetworkEnvironment.requestTimeout
     $0.timeoutIntervalForResource = NetworkEnvironment.resourceTimeout
   })
+  
+  
+  /// Network Response에 대해 값을 검증하고 그 결과값을 리턴합니다.
+  /// - Parameters:
+  ///   - statusCode: http 상태 코드
+  ///   - data: 응답값으로 받아온 `Data`
+  ///   - type: Data 내부를 구성하는 타입
+  /// - Returns: GeneralResponse 또는 Plub Error
+  func evaluateStatus<T: Codable>(
+    by statusCode: Int,
+    _ data: Data,
+    type: T.Type
+  ) -> Result<GeneralResponse<T>, PLUBError> {
+    guard let decodedData = try? JSONDecoder().decode(GeneralResponse<T>.self, from: data) else {
+      return .failure(.pathError)
+    }
+    switch statusCode {
+    case 200..<300:
+      return .success(decodedData)
+    case 400..<500:
+      return .failure(.requestError)
+    case 500:
+      return .failure(.serverError)
+    default:
+      return .failure(.networkError)
+    }
+  }
 }
 
 // MARK: - Network Enum Cases

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -131,23 +131,4 @@ extension BaseService {
     /// 응답에서 `message`가 key인 값을 추출하여 전달합니다.
     case message
   }
-  
-  enum PLUBError: Error {
-    
-    /// 경로 에러, path가 잘못된 경우
-    case pathError
-    
-    /// 요청 값에 문제가 발생한 경우 발생되는 에러입니다.
-    ///
-    /// 400~499 대의 응답코드가 이 에러에 속합니다.
-    case requestError
-    
-    /// 서버에 문제가 생겼을 때 발생됩니다.
-    ///
-    /// 500번대 응답코드가 이 에러에 속합니다.
-    case serverError
-    
-    /// 사용자의 네트워크에 문제가 있어 값을 가져오지 못하는 경우
-    case networkError
-  }
 }

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -18,3 +18,27 @@ class BaseService {
     $0.timeoutIntervalForResource = NetworkEnvironment.resourceTimeout
   })
 }
+
+// MARK: - Network Enum Cases
+
+extension BaseService {
+  
+  enum PLUBError: Error {
+    
+    /// 경로 에러, path가 잘못된 경우
+    case pathError
+    
+    /// 요청 값에 문제가 발생한 경우 발생되는 에러입니다.
+    ///
+    /// 400~499 대의 응답코드가 이 에러에 속합니다.
+    case requestError
+    
+    /// 서버에 문제가 생겼을 때 발생됩니다.
+    ///
+    /// 500번대 응답코드가 이 에러에 속합니다.
+    case serverError
+    
+    /// 사용자의 네트워크에 문제가 있어 값을 가져오지 못하는 경우
+    case networkError
+  }
+}

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -1,0 +1,14 @@
+//
+//  BaseService.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/01/13.
+//
+
+import Foundation
+
+import Alamofire
+
+class BaseService {
+  
+}

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -13,11 +13,12 @@ import Then
 extension Session: Then { }
 
 class BaseService {
-  let manager = Session(configuration: .af.default.then {
+  
+  /// Alamofire의 Session instance입니다. 요청할 때 사용됩니다.
+  let session = Session(configuration: .af.default.then {
     $0.timeoutIntervalForRequest = NetworkEnvironment.requestTimeout
     $0.timeoutIntervalForResource = NetworkEnvironment.resourceTimeout
   })
-  
   
   /// Network Response에 대해 값을 검증하고 그 결과값을 리턴합니다.
   /// - Parameters:
@@ -69,7 +70,7 @@ class BaseService {
     decodingMode: DecodingMode,
     completion: @escaping (Result<Any, PLUBError>) -> Void
   ) {
-    manager.request(target).responseData { response in
+    session.request(target).responseData { response in
       switch response.result {
       case .success(let data):
         guard let statusCode = response.response?.statusCode else {

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -108,7 +108,7 @@ class BaseService {
   ///
   /// 요청을 보내되 제대로 요청이 처리되었는지만을 확인하고 싶은 경우가 있습니다.
   /// 그럴 때 해당 메서드를 사용하시면 됩니다.
-  /// 예를 들어, `회원 탈퇴`나 `로그 아웃`과 같은 경우가 이에 속합니다.
+  /// 예를 들어, `회원탈퇴`나 `로그아웃`과 같은 경우가 이에 속합니다.
   func sendRequestWithoutPayload(_ router: Router, completion: @escaping (Result<Any, PLUBError<Void>>) -> Void) {
     session.request(router).responseData { response in
       completion(self.evaluateStatusWithoutPayload(by: response.response?.statusCode))

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -8,7 +8,13 @@
 import Foundation
 
 import Alamofire
+import Then
+
+extension Session: Then { }
 
 class BaseService {
-  
+  let manager = Session(configuration: .af.default.then {
+    $0.timeoutIntervalForRequest = NetworkEnvironment.requestTimeout
+    $0.timeoutIntervalForResource = NetworkEnvironment.resourceTimeout
+  })
 }

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -58,6 +58,23 @@ class BaseService {
     }
   }
   
+  /// 응답값만을 검증할 때 사용됩니다.
+  /// - Parameter statusCode: HTTP 상태코드
+  /// - Returns: success or failure
+  func evaluateStatusWithoutPayload(by statusCode: Int?) -> Result<Any, PLUBError> {
+    guard let statusCode = statusCode else { return .failure(.pathError) }
+    switch statusCode {
+    case 200..<300:
+      return .success(())
+    case 400..<500:
+      return .failure(.requestError)
+    case 500:
+      return .failure(.serverError)
+    default:
+      return .failure(.networkError)
+    }
+  }
+  
   /// PLUB 서버에 필요한 값을 동봉하여 요청합니다.
   /// - Parameters:
   ///   - target: Router를 채택한 인스턴스(instance)
@@ -81,6 +98,20 @@ class BaseService {
       case .failure(let error):
         print(error)
       }
+    }
+  }
+  
+  /// PLUB 서버에 요청을 전달할 때 사용되며 응답값이 필요없을 때 사용합니다.
+  /// - Parameters:
+  ///   - router: Router를 채택한 인스턴스(instance)
+  ///   - completion: 요청에 따른 응답값을 처리하는 콜백 함수
+  ///
+  /// 요청을 보내되 제대로 요청이 처리되었는지만을 확인하고 싶은 경우가 있습니다.
+  /// 그럴 때 해당 메서드를 사용하시면 됩니다.
+  /// 예를 들어, `회원 탈퇴`나 `로그 아웃`과 같은 경우가 이에 속합니다.
+  func sendRequestWithoutPayload(_ router: Router, completion: @escaping (Result<Any, PLUBError>) -> Void) {
+    session.request(router).responseData { response in
+      completion(self.evaluateStatusWithoutPayload(by: response.response?.statusCode))
     }
   }
 }

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -64,7 +64,7 @@ class BaseService {
   ///   - type: 응답 값에 들어오는 `data`를 파싱할 모델
   ///   - decodingMode: 원하고자 하는 응답값의 데이터
   ///   - completion: 요청에 따른 응답값을 처리하는 콜백 함수
-  func requestObject<T: Codable>(
+  func sendRequest<T: Codable>(
     _ target: Router,
     type: T.Type,
     decodingMode: DecodingMode,

--- a/PLUB/Sources/Network/Foundation/HeaderType.swift
+++ b/PLUB/Sources/Network/Foundation/HeaderType.swift
@@ -9,8 +9,29 @@ import Foundation
 
 import Alamofire
 
-
 enum HeaderType {
   case `default`
   case withToken
+}
+
+extension HeaderType {
+  var toHTTPHeader: HTTPHeaders {
+    switch self {
+    case .default:
+      return .default
+    //TODO: 승현 - 아직 테스트 코드입니다. UserManager 구현 후 코드가 대체될 예정입니다.
+    case .withToken:
+      @KeyChainWrapper(key: "accessToken")
+      var token: String?
+      
+      // 토큰이 존재하지 않는 경우
+      guard let token = token else { return .default }
+      
+      // default 헤더 값에 `Authorization token` 및 `Content-Type` 추가
+      var defaultHeaders = HTTPHeaders.default
+      defaultHeaders.add(.authorization(bearerToken: token))
+      defaultHeaders.add(.contentType("application/json"))
+      return defaultHeaders
+    }
+  }
 }

--- a/PLUB/Sources/Network/Foundation/HeaderType.swift
+++ b/PLUB/Sources/Network/Foundation/HeaderType.swift
@@ -1,0 +1,16 @@
+//
+//  HeaderType.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/01/13.
+//
+
+import Foundation
+
+import Alamofire
+
+
+enum HeaderType {
+  case `default`
+  case withToken
+}

--- a/PLUB/Sources/Network/Foundation/PLUBError.swift
+++ b/PLUB/Sources/Network/Foundation/PLUBError.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum PLUBError: Error {
+enum PLUBError<T>: Error {
   
   /// 경로 에러, path가 잘못된 경우
   case pathError
@@ -15,7 +15,7 @@ enum PLUBError: Error {
   /// 요청 값에 문제가 발생한 경우 발생되는 에러입니다.
   ///
   /// 400~499 대의 응답코드가 이 에러에 속합니다.
-  case requestError
+  case requestError(T)
   
   /// 서버에 문제가 생겼을 때 발생됩니다.
   ///

--- a/PLUB/Sources/Network/Foundation/PLUBError.swift
+++ b/PLUB/Sources/Network/Foundation/PLUBError.swift
@@ -1,0 +1,27 @@
+//
+//  PLUBError.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/01/14.
+//
+
+import Foundation
+
+enum PLUBError: Error {
+  
+  /// 경로 에러, path가 잘못된 경우
+  case pathError
+  
+  /// 요청 값에 문제가 발생한 경우 발생되는 에러입니다.
+  ///
+  /// 400~499 대의 응답코드가 이 에러에 속합니다.
+  case requestError
+  
+  /// 서버에 문제가 생겼을 때 발생됩니다.
+  ///
+  /// 500번대 응답코드가 이 에러에 속합니다.
+  case serverError
+  
+  /// 사용자의 네트워크에 문제가 있어 값을 가져오지 못하는 경우
+  case networkError
+}

--- a/PLUB/Sources/Network/Foundation/ParameterType.swift
+++ b/PLUB/Sources/Network/Foundation/ParameterType.swift
@@ -1,0 +1,26 @@
+//
+//  ParameterType.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/01/13.
+//
+
+import Foundation
+
+enum ParameterType {
+  
+  /// 빈 평문입니다.
+  ///
+  /// 아무런 정보 값 없이 요청할 때 사용됩니다.
+  case plain
+  
+  /// query를 설정합니다.
+  ///
+  /// query문으로 요청값을 전달하고 싶을 때 사용됩니다.
+  case query(Encodable)
+  
+  /// body값을 설정합니다.
+  ///
+  /// `post`요청과 같이 body-field에 무언가를 담아 보내야하는 경우 사용됩니다.
+  case body(Encodable)
+}

--- a/PLUB/Sources/Network/Foundation/ParameterType.swift
+++ b/PLUB/Sources/Network/Foundation/ParameterType.swift
@@ -17,10 +17,10 @@ enum ParameterType {
   /// query를 설정합니다.
   ///
   /// query문으로 요청값을 전달하고 싶을 때 사용됩니다.
-  case query(Encodable)
+  case query([String: Any])
   
   /// body값을 설정합니다.
   ///
   /// `post`요청과 같이 body-field에 무언가를 담아 보내야하는 경우 사용됩니다.
-  case body(Encodable)
+  case body([String: Any])
 }

--- a/PLUB/Sources/Network/Foundation/Router.swift
+++ b/PLUB/Sources/Network/Foundation/Router.swift
@@ -62,22 +62,12 @@ extension Router {
     case .plain:
       break
       
-    case .body(let data):
-      guard let data = try? JSONEncoder().encode(data),
-            let jsonData = try? JSONSerialization.jsonObject(with: data),
-            let dictionaryData = jsonData as? [String: Any] else {
-        break
-      }
-      request.httpBody = try? JSONSerialization.data(withJSONObject: dictionaryData)
+    case .body(let body):
+      request.httpBody = try JSONSerialization.data(withJSONObject: body)
       
-    case .query(let data):
-      guard let data = try? JSONEncoder().encode(data),
-            let jsonData = try? JSONSerialization.jsonObject(with: data),
-            let dictionaryData = jsonData as? [String: Any] else {
-        break
-      }
+    case .query(let query):
       var components = URLComponents(string: url.appendingPathComponent(path).absoluteString)
-      components?.queryItems = dictionaryData.map { URLQueryItem(name: $0, value: "\($1)") }
+      components?.queryItems = query.map { URLQueryItem(name: $0, value: "\($1)") }
       request.url = components?.url
     }
     

--- a/PLUB/Sources/Network/Foundation/Router.swift
+++ b/PLUB/Sources/Network/Foundation/Router.swift
@@ -47,4 +47,29 @@ extension Router {
   var headers: HTTPHeaders {
     return .default
   }
+  
+  func asURLRequest() throws -> URLRequest {
+    let url = try baseURL.asURL()
+    
+    var request = try URLRequest(url: url.appendingPathComponent(path), method: method)
+    
+    // check headers
+    request.headers = headers
+    
+    // check parameters
+    guard let parameters = parameters else { return request }
+    
+    //FIXME: 승현 - parameter 작업 수정 필요
+    // method 값에 의존적임, 원하지 않는 작업이 될 수도 있다.
+    switch method {
+    case .post: // body
+      request.httpBody = try? JSONSerialization.data(withJSONObject: parameters)
+    default: // query
+      var components = URLComponents(string: url.appendingPathComponent(path).absoluteString)
+      components?.queryItems = parameters.map { URLQueryItem(name: $0, value: "\($1)") }
+      request.url = components?.url
+    }
+    
+    return request
+  }
 }

--- a/PLUB/Sources/Network/Foundation/Router.swift
+++ b/PLUB/Sources/Network/Foundation/Router.swift
@@ -31,3 +31,20 @@ protocol Router: URLRequestConvertible {
   /// 헤더 값을 설정할 때 사용됩니다.
   var headers: HTTPHeaders { get }
 }
+
+// MARK: - Default Value Settings
+
+extension Router {
+  
+  var baseURL: String {
+    return URLConstants.baseURL
+  }
+  
+  var parameters: Parameters? {
+    return nil
+  }
+  
+  var headers: HTTPHeaders {
+    return .default
+  }
+}

--- a/PLUB/Sources/Network/Foundation/Router.swift
+++ b/PLUB/Sources/Network/Foundation/Router.swift
@@ -1,0 +1,33 @@
+//
+//  Router.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/01/13.
+//
+
+import Foundation
+
+import Alamofire
+
+/// Base Router Protocol입니다.
+///
+/// 추가 네트워킹 작업이 필요한 경우 `Router`을 채택하는 다른 Router를 구현하시면 됩니다.
+protocol Router: URLRequestConvertible {
+  /// 공통 base URL
+  var baseURL: String { get }
+  
+  /// HTTP Request method
+  var method: HTTPMethod { get }
+  
+  /// HTTP Path
+  var path: String { get }
+  
+  /// 요청시 넣을 파라미터입니다.
+  ///
+  /// body값이거나 query값을 설정할 때 이용합니다.
+  var parameters: Parameters? { get }
+  
+  
+  /// 헤더 값을 설정할 때 사용됩니다.
+  var headers: HTTPHeaders { get }
+}


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 기초적인 네트워크 구조를 구현했습니다.
- `form-data`에 대한 작업, 토큰 자동 요청 처리 등 미숙한 부분은 다음 PR에 올릴 예정입니다. (이것 까지 개발하면 PR이 너무 커져버릴 것 같아서요 ㅎ)
- 파일 구조는 다음과 같습니다.
<img width="195" alt="image" src="https://user-images.githubusercontent.com/57972338/212464451-8b87976a-9b74-4407-9b61-902f9a6d82f5.png">

🌱 PR 포인트

- 각  파일들에 대해서 설명드리도록 하겠습니다.

### 1. Environment

- Network 작업에 필요한 환경값들을 해당 폴더에 정리합니다. 현재 `Config.swift`파일이 있으나 이는 `gitignore`로 처리했기 때문에 저희 iOS slack방에 파일을 올리도록 하겠습니다 :)

#### 1-1. Config.swift

- PLUB 서버에 요청할 baseURL과 네트워킹할 때 필요한 timeout 설정 값이 들어가있습니다.

---

### 2. Foundation

- Network 작업에 필요한 뼈대들을 두는 폴더입니다. `Router`, `BaseService`, 각종 네트워킹 타입과 에러가 해당 폴더에 들어가 있습니다.

#### 2-1. HeaderType

|HeaderType.swift|
|:-:|
|<img width="597" alt="image" src="https://user-images.githubusercontent.com/57972338/212464734-ead24610-bea4-4620-ba6e-7f8e5f4838ad.png">|

Router의 파라미터로 존재하며, 네트워크요청을 보낼 때 어떠한 헤더값을 전달할지 선택할 수 있습니다.
default의 경우 Alamofire에서 제공하는 `HTTPHeader.default`로 세팅됩니다.
withToken의 경우 지난 번에 구현했던 KeyChainWrapper를 이용하여 accessToken을 가져와 header에 추가합니다. `withToken` case는 아직 구현이 미비된 상태라 다음에 UserManager와 함께 완벽하게 구현하도록 하겠습니다. 지금은 단순히 구조로만 봐주시면 감사하겠습니다.

> 지금 보니까 여기에는 주석을 안써놨네요 ㅎㅎ..죄송합니다

#### 2-2. ParameterType

|ParameterType.swift|
|:-:|
|<img width="475" alt="image" src="https://user-images.githubusercontent.com/57972338/212465282-a1bac5af-3e21-4d9a-b1ca-d8deb699e807.png">|

위 주석 설명과 같습니다.

#### 2-3. Router

|Router.swift|
|:-:|
|<img width="545" alt="image" src="https://user-images.githubusercontent.com/57972338/212465360-0d773083-9c6e-4678-8e48-899bac306844.png">|

- URLRequestConvertible를 채택하고있는 프로토콜입니다. Alamofire의 [공식문서](https://github.com/Alamofire/Alamofire/blob/master/Documentation/AdvancedUsage.md#routing-requests)와 유사하게 구현했습니다.
- 위에서 설명한 `HeaderType`과 `ParameterType`을 프로퍼티로 갖고있습니다.
- baseURL, parameters, headers 프로퍼티는 전부 기본값을 갖고 있습니다.

#### 2-4. BaseService(중요)

- 구현되어있는 코드량이 길어 따로 올리지는 않겠습니다.
- BaseService는 전반적인 백엔드 요청 작업 코드가 들어가있습니다. 그 밖에 응답 값을 검증하는 코드도 들어가 있습니다.
- 서버와 통신하는 작업은 `sendRequest(_:type:decodingMode:completion:)`를 사용하면 됩니다. 
- 그 밖에 응답모델이 필요없이 처리유무만을 판단하고 싶은 경우 `sendRequestWithoutPayload(_:completion:)`를 사용하여 처리하면 됩니다.
- DecodingMode라는 enum case를 두어 다양하게 모델을 받을 수 있도록 처리했습니다. 해당 열거형은 sendRequest에서 파라미터로 입력받습니다.
   - general: 응답값을 전부 받습니다.
   - data: 응답으로 받아오는 모델값만 받습니다.
   - message: 응답값의 message만 받습니다.


앞으로 서버와 통신하는 객체를 구현할 때 해당 클래스를 상속받는 자식 클래스를 구현하시면 됩니다.



---

### 3. Routers

- Foundation에 있는 `Router`를 채택할 Class Instance를 두는 곳입니다.

---

### 4. Services

- Foundation에 있는 `BaseService`를 상속할 Class instance를 두는 곳입니다.


## 📮 관련 이슈
- #38

