### PR TITLE
[FEAT] 네트워크 모델 리팩토링

### DIFF
--- a/PLUB/Sources/Models/GeneralResponse.swift
+++ b/PLUB/Sources/Models/GeneralResponse.swift
@@ -11,4 +11,17 @@ struct GeneralResponse<T>: Decodable where T: Decodable {
   let statusCode: Int?
   let message: String?
   let data: T?
+  
+  enum CodingKeys: CodingKey {
+    case statusCode
+    case message
+    case data
+  }
+  
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.statusCode = try? container.decodeIfPresent(Int.self, forKey: .statusCode)
+    self.message = try? container.decodeIfPresent(String.self, forKey: .message)
+    self.data = try? container.decodeIfPresent(T.self, forKey: .data)
+  }
 }

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -65,7 +65,7 @@ class BaseService {
   ///   - completion: 요청에 따른 응답값을 처리하는 콜백 함수
   func sendRequest<T: Codable>(
     _ router: Router,
-    type: T.Type,
+    type: T.Type = EmptyModel.self,
     completion: @escaping (Result<Any, PLUBError>) -> Void
   ) {
     session.request(router).responseData { response in
@@ -86,5 +86,7 @@ class BaseService {
 // MARK: - Network Enum Cases
 
 extension BaseService {
-  
+  struct EmptyModel: Codable {
+    
+  }
 }

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -58,23 +58,6 @@ class BaseService {
     }
   }
   
-  /// 응답값만을 검증할 때 사용됩니다.
-  /// - Parameter statusCode: HTTP 상태코드
-  /// - Returns: success or failure
-  func evaluateStatusWithoutPayload(by statusCode: Int?) -> Result<Any, PLUBError> {
-    guard let statusCode = statusCode else { return .failure(.pathError) }
-    switch statusCode {
-    case 200..<300:
-      return .success(())
-    case 400..<500:
-      return .failure(.requestError((0)))
-    case 500:
-      return .failure(.serverError)
-    default:
-      return .failure(.networkError)
-    }
-  }
-  
   /// PLUB 서버에 필요한 값을 동봉하여 요청합니다.
   /// - Parameters:
   ///   - target: Router를 채택한 인스턴스(instance)
@@ -98,20 +81,6 @@ class BaseService {
       case .failure(let error):
         print(error)
       }
-    }
-  }
-  
-  /// PLUB 서버에 요청을 전달할 때 사용되며 응답값이 필요없을 때 사용합니다.
-  /// - Parameters:
-  ///   - router: Router를 채택한 인스턴스(instance)
-  ///   - completion: 요청에 따른 응답값을 처리하는 콜백 함수
-  ///
-  /// 요청을 보내되 제대로 요청이 처리되었는지만을 확인하고 싶은 경우가 있습니다.
-  /// 그럴 때 해당 메서드를 사용하시면 됩니다.
-  /// 예를 들어, `회원탈퇴`나 `로그아웃`과 같은 경우가 이에 속합니다.
-  func sendRequestWithoutPayload(_ router: Router, completion: @escaping (Result<Any, PLUBError>) -> Void) {
-    session.request(router).responseData { response in
-      completion(self.evaluateStatusWithoutPayload(by: response.response?.statusCode))
     }
   }
 }

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -35,7 +35,7 @@ class BaseService {
     _ data: Data,
     type: T.Type,
     decodingMode: DecodingMode
-  ) -> Result<Any, PLUBError<GeneralResponse<T>>> {
+  ) -> Result<Any, PLUBError> {
     guard let decodedData = try? JSONDecoder().decode(GeneralResponse<T>.self, from: data) else {
       return .failure(.pathError)
     }
@@ -50,7 +50,7 @@ class BaseService {
         return .success(decodedData)
       }
     case 400..<500:
-      return .failure(.requestError(decodedData))
+      return .failure(.requestError(decodedData.statusCode!))
     case 500:
       return .failure(.serverError)
     default:
@@ -61,13 +61,13 @@ class BaseService {
   /// 응답값만을 검증할 때 사용됩니다.
   /// - Parameter statusCode: HTTP 상태코드
   /// - Returns: success or failure
-  func evaluateStatusWithoutPayload(by statusCode: Int?) -> Result<Any, PLUBError<Void>> {
+  func evaluateStatusWithoutPayload(by statusCode: Int?) -> Result<Any, PLUBError> {
     guard let statusCode = statusCode else { return .failure(.pathError) }
     switch statusCode {
     case 200..<300:
       return .success(())
     case 400..<500:
-      return .failure(.requestError(()))
+      return .failure(.requestError((0)))
     case 500:
       return .failure(.serverError)
     default:
@@ -85,7 +85,7 @@ class BaseService {
     _ target: Router,
     type: T.Type,
     decodingMode: DecodingMode,
-    completion: @escaping (Result<Any, PLUBError<GeneralResponse<T>>>) -> Void
+    completion: @escaping (Result<Any, PLUBError>) -> Void
   ) {
     session.request(target).responseData { response in
       switch response.result {
@@ -109,7 +109,7 @@ class BaseService {
   /// 요청을 보내되 제대로 요청이 처리되었는지만을 확인하고 싶은 경우가 있습니다.
   /// 그럴 때 해당 메서드를 사용하시면 됩니다.
   /// 예를 들어, `회원탈퇴`나 `로그아웃`과 같은 경우가 이에 속합니다.
-  func sendRequestWithoutPayload(_ router: Router, completion: @escaping (Result<Any, PLUBError<Void>>) -> Void) {
+  func sendRequestWithoutPayload(_ router: Router, completion: @escaping (Result<Any, PLUBError>) -> Void) {
     session.request(router).responseData { response in
       completion(self.evaluateStatusWithoutPayload(by: response.response?.statusCode))
     }

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -40,14 +40,7 @@ class BaseService {
     }
     switch statusCode {
     case 200..<300:
-      switch decodingMode {
-      case .data:
-        return .success(decodedData.data ?? "None-Data")
-      case .message:
-        return .success(decodedData.message ?? "None-Data")
-      case .general:
         return .success(decodedData)
-      }
     case 400..<500:
       return .failure(.requestError(decodedData.statusCode!))
     case 500:
@@ -74,7 +67,7 @@ class BaseService {
         guard let statusCode = response.response?.statusCode else {
           fatalError("statusCode가 없는 응답값????")
         }
-        let result = self.evaluateStatus(by: statusCode, data, type: type, decodingMode: decodingMode)
+        let result = self.evaluateStatus(by: statusCode, data, type: type)
         completion(result)
       case .failure(let error):
         print(error)

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -82,12 +82,12 @@ class BaseService {
   ///   - decodingMode: 원하고자 하는 응답값의 데이터
   ///   - completion: 요청에 따른 응답값을 처리하는 콜백 함수
   func sendRequest<T: Codable>(
-    _ target: Router,
+    _ router: Router,
     type: T.Type,
     decodingMode: DecodingMode,
     completion: @escaping (Result<Any, PLUBError>) -> Void
   ) {
-    session.request(target).responseData { response in
+    session.request(router).responseData { response in
       switch response.result {
       case .success(let data):
         guard let statusCode = response.response?.statusCode else {

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -28,7 +28,7 @@ class BaseService {
     by statusCode: Int,
     _ data: Data,
     type: T.Type
-  ) -> Result<Any, PLUBError> {
+  ) -> Result<GeneralResponse<T>, PLUBError> {
     guard let decodedData = try? JSONDecoder().decode(GeneralResponse<T>.self, from: data) else {
       return .failure(.pathError)
     }
@@ -53,7 +53,7 @@ class BaseService {
   func sendRequest<T: Codable>(
     _ router: Router,
     type: T.Type = EmptyModel.self,
-    completion: @escaping (Result<Any, PLUBError>) -> Void
+    completion: @escaping (Result<GeneralResponse<T>, PLUBError>) -> Void
   ) {
     AF.request(router).responseData { response in
       switch response.result {

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -14,12 +14,6 @@ extension Session: Then { }
 
 class BaseService {
   
-  /// Alamofire의 Session instance입니다. 요청할 때 사용됩니다.
-  let session = Session(configuration: .af.default.then {
-    $0.timeoutIntervalForRequest = NetworkEnvironment.requestTimeout
-    $0.timeoutIntervalForResource = NetworkEnvironment.resourceTimeout
-  })
-  
   /// Network Response에 대해 값을 검증하고 그 결과값을 리턴합니다.
   /// - Parameters:
   ///   - statusCode: http 상태 코드
@@ -61,7 +55,7 @@ class BaseService {
     type: T.Type = EmptyModel.self,
     completion: @escaping (Result<Any, PLUBError>) -> Void
   ) {
-    session.request(router).responseData { response in
+    AF.request(router).responseData { response in
       switch response.result {
       case .success(let data):
         guard let statusCode = response.response?.statusCode else {

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -33,8 +33,7 @@ class BaseService {
   func evaluateStatus<T: Codable>(
     by statusCode: Int,
     _ data: Data,
-    type: T.Type,
-    decodingMode: DecodingMode
+    type: T.Type
   ) -> Result<Any, PLUBError> {
     guard let decodedData = try? JSONDecoder().decode(GeneralResponse<T>.self, from: data) else {
       return .failure(.pathError)
@@ -67,7 +66,6 @@ class BaseService {
   func sendRequest<T: Codable>(
     _ router: Router,
     type: T.Type,
-    decodingMode: DecodingMode,
     completion: @escaping (Result<Any, PLUBError>) -> Void
   ) {
     session.request(router).responseData { response in
@@ -89,15 +87,4 @@ class BaseService {
 
 extension BaseService {
   
-  enum DecodingMode {
-    
-    /// 응답으로 받은 값을 전부 전달합니다.
-    case general
-    
-    /// 응답에서 `data`가 key인 값을 추출하여 전달합니다.
-    case data
-    
-    /// 응답에서 `message`가 key인 값을 추출하여 전달합니다.
-    case message
-  }
 }

--- a/PLUB/Sources/Network/Foundation/PLUBError.swift
+++ b/PLUB/Sources/Network/Foundation/PLUBError.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum PLUBError<T>: Error {
+enum PLUBError: Error {
   
   /// 경로 에러, path가 잘못된 경우
   case pathError
@@ -15,7 +15,7 @@ enum PLUBError<T>: Error {
   /// 요청 값에 문제가 발생한 경우 발생되는 에러입니다.
   ///
   /// 400~499 대의 응답코드가 이 에러에 속합니다.
-  case requestError(T)
+  case requestError(Int)
   
   /// 서버에 문제가 생겼을 때 발생됩니다.
   ///


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 오늘 오프라인 회의에서 작업했던 코드입니다 :)

🌱 PR 포인트
- completion에서 Observable로 변경
- `DecodingMode` 제거
- `sendRequestWithoutPayload(_:)` 제거 -> 대신 sendRequest에 type의 파라미터 기본값을 `EmptyModel`로 설정
   - `EmptyModel`은 비어있는 모델 값
- session 제거 -> AF로 변경
- GeneralResponse<T>의 decoding initialization 추가

## 📮 관련 이슈
- Resolved: 38

