### PR TITLE
컨벤션 수정 & 공통 컴포넌트로 대체

### DIFF
--- a/PLUB/Configuration/CommonClass/InputTextView.swift
+++ b/PLUB/Configuration/CommonClass/InputTextView.swift
@@ -185,6 +185,15 @@ final class InputTextView: UIView {
   }
 }
 
+// MARK: - First Responder
+
+extension InputTextView {
+  @discardableResult
+  override func resignFirstResponder() -> Bool {
+    return textView.resignFirstResponder()
+  }
+}
+
 // MARK: - Function
 
 extension InputTextView {

--- a/PLUB/Configuration/CommonClass/PageControl.swift
+++ b/PLUB/Configuration/CommonClass/PageControl.swift
@@ -111,8 +111,8 @@ final class PageControl: UIControl {
   private func configureUI() {
     self.addSubview(stackView)
     
-    stackView.snp.makeConstraints { make in
-      make.edges.equalToSuperview()
+    stackView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
     }
   }
   
@@ -134,13 +134,13 @@ final class PageControl: UIControl {
       stackView.addArrangedSubview(dot)
       
       // == dot constraints ==
-      dot.snp.makeConstraints { make in
+      dot.snp.makeConstraints {
         if index == _currentPage {
-          make.width.equalTo(40)
+          $0.width.equalTo(40)
         } else {
-          make.width.equalTo(10)
+          $0.width.equalTo(10)
         }
-        make.height.equalTo(8)
+        $0.height.equalTo(8)
       }
       
       // == dot appearence ==
@@ -159,11 +159,11 @@ final class PageControl: UIControl {
   
   private func updateDotsConstraints() {
     for (index, dot) in dots.enumerated() {
-      dot.snp.updateConstraints { make in
+      dot.snp.updateConstraints {
         if index == _currentPage {
-          make.width.equalTo(40)
+          $0.width.equalTo(40)
         } else {
-          make.width.equalTo(10)
+          $0.width.equalTo(10)
         }
       }
     }

--- a/PLUB/Sources/Views/Login/Birth/BirthViewController.swift
+++ b/PLUB/Sources/Views/Login/Birth/BirthViewController.swift
@@ -99,13 +99,13 @@ final class BirthViewController: BaseViewController {
   
   override func setupConstraints() {
     super.setupConstraints()
-    wholeStackView.snp.makeConstraints { make in
-      make.horizontalEdges.top.equalToSuperview()
+    wholeStackView.snp.makeConstraints {
+      $0.horizontalEdges.top.equalToSuperview()
     }
     
     [maleButton, femaleButton].forEach {
-      $0.snp.makeConstraints { make in
-        make.height.equalTo(40)
+      $0.snp.makeConstraints {
+        $0.height.equalTo(40)
       }
     }
   }

--- a/PLUB/Sources/Views/Login/Introduction/IntroductionViewController.swift
+++ b/PLUB/Sources/Views/Login/Introduction/IntroductionViewController.swift
@@ -55,17 +55,17 @@ final class IntroductionViewController: BaseViewController {
   
   override func setupConstraints() {
     super.setupConstraints()
-    stackView.snp.makeConstraints { make in
-      make.top.horizontalEdges.equalToSuperview()
+    stackView.snp.makeConstraints {
+      $0.top.horizontalEdges.equalToSuperview()
     }
     
-    introductionTextView.snp.makeConstraints { make in
-      make.height.equalTo(46)
+    introductionTextView.snp.makeConstraints {
+      $0.height.equalTo(46)
     }
     
-    overlineLabel.snp.makeConstraints { make in
-      make.top.equalTo(stackView.snp.bottom).offset(4)
-      make.trailing.equalToSuperview()
+    overlineLabel.snp.makeConstraints {
+      $0.top.equalTo(stackView.snp.bottom).offset(4)
+      $0.trailing.equalToSuperview()
     }
   }
   
@@ -88,8 +88,8 @@ final class IntroductionViewController: BaseViewController {
     let estimatedSize = textView.sizeThatFits(size)
     
     // update height constraints
-    textView.snp.updateConstraints { make in
-      make.height.equalTo(estimatedSize.height)
+    textView.snp.updateConstraints {
+      $0.height.equalTo(estimatedSize.height)
     }
   }
   

--- a/PLUB/Sources/Views/Login/Introduction/IntroductionViewController.swift
+++ b/PLUB/Sources/Views/Login/Introduction/IntroductionViewController.swift
@@ -14,144 +14,33 @@ final class IntroductionViewController: BaseViewController {
   
   // MARK: - Property
   
-  private let stackView: UIStackView = UIStackView().then {
-    $0.axis = .vertical
-    $0.spacing = 8
-  }
-  
-  private let introductionLabel: UILabel = UILabel().then {
-    $0.text = "소개"
-    $0.font = .subtitle
-  }
-  
-  private lazy var introductionTextView: UITextView = UITextView().then {
-    $0.text = placeHolder
-    $0.textColor = .deepGray
-    $0.textContainerInset = UIEdgeInsets(top: 14, left: 8, bottom: 14, right: 8)
-    $0.font = .body2
-    
-    $0.backgroundColor = .white
-    $0.layer.cornerRadius = 8
-    
-    $0.isScrollEnabled = false
-    $0.delegate = self
-  }
-  
-  private let overlineLabel: UILabel = UILabel().then {
-    $0.font = .overLine
-  }
+  let inputTextView = InputTextView(
+    title: "소개",
+    placeHolder: "소개하는 내용을 입력해주세요",
+    options: .textCount,
+    totalCharacterLimit: 150
+  )
   
   // MARK: - Configuration
   
   override func setupLayouts() {
     super.setupLayouts()
-    view.addSubview(stackView)
-    view.addSubview(overlineLabel)
-    
-    [introductionLabel, introductionTextView].forEach {
-      stackView.addArrangedSubview($0)
-    }
+    view.addSubview(inputTextView)
   }
   
   override func setupConstraints() {
     super.setupConstraints()
-    stackView.snp.makeConstraints {
+    inputTextView.snp.makeConstraints {
       $0.top.horizontalEdges.equalToSuperview()
-    }
-    
-    introductionTextView.snp.makeConstraints {
-      $0.height.equalTo(46)
-    }
-    
-    overlineLabel.snp.makeConstraints {
-      $0.top.equalTo(stackView.snp.bottom).offset(4)
-      $0.trailing.equalToSuperview()
-    }
-  }
-  
-  override func setupStyles() {
-    super.setupStyles()
-    updateWrittenCharactersLabel(count: 0, pointColor: .mediumGray)
-  }
-  
-  private func updateWrittenCharactersLabel(count: Int, pointColor: UIColor) {
-    let writtenCharacters = NSAttributedString(string: "\(count)", attributes: [.foregroundColor: pointColor])
-    let totalCharacters = NSAttributedString(string: "/\(totalCharacterLimit)", attributes: [.foregroundColor: UIColor.deepGray])
-    overlineLabel.attributedText = NSMutableAttributedString(attributedString: writtenCharacters).then {
-      $0.append(totalCharacters)
-    }
-  }
-  
-  private func updateTextViewHeightAutomatically(_ textView: UITextView) {
-    // == textView dynamic height settings ==
-    let size = CGSize(width: view.frame.width, height: .infinity)
-    let estimatedSize = textView.sizeThatFits(size)
-    
-    // update height constraints
-    textView.snp.updateConstraints {
-      $0.height.equalTo(estimatedSize.height)
     }
   }
   
   // MARK: - First Responder
   
   override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-    introductionTextView.resignFirstResponder()
+    inputTextView.resignFirstResponder()
   }
 }
-
-// MARK: - Constants
-
-extension IntroductionViewController {
-  private var placeHolder: String {
-    return "소개하는 내용을 입력해주세요"
-  }
-  
-  private var totalCharacterLimit: Int {
-    return 150
-  }
-}
-
-// MARK: - UITextViewDelegate
-
-extension IntroductionViewController: UITextViewDelegate {
-  func textViewDidEndEditing(_ textView: UITextView) {
-    // text가 비어있으면서 글자색이 검정인 경우 -> 사용자가 입력 후 다 지운 경우
-    if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && textView.textColor == .black {
-      updateWrittenCharactersLabel(count: 0, pointColor: .mediumGray)
-      textView.text = placeHolder
-      textView.textColor = .deepGray
-    }
-    
-    // == textView dynamic height settings ==
-    updateTextViewHeightAutomatically(textView)
-  }
-  
-  func textViewDidBeginEditing(_ textView: UITextView) {
-    // text가 지정된 placeholder면서 글자색이 짙은회색인 경우
-    // 즉 placeholder을 띄운 상태인데 사용자가 수정하려고 textview를 누른 경우
-    if textView.text == placeHolder && textView.textColor == .deepGray {
-      textView.text = ""
-      textView.textColor = .black
-    }
-  }
-  
-  func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-    // if the user presses the delete key, the length of the range is 1.
-    if range.length == 1 { return true }
-    return textView.text.count < totalCharacterLimit ? true : false
-  }
-  
-  func textViewDidChange(_ textView: UITextView) {
-    // == textView dynamic height settings ==
-    updateTextViewHeightAutomatically(textView)
-    
-    // == overline label settings ==
-    let color: UIColor =  introductionTextView.text.count == 0 ? .mediumGray : .black
-    updateWrittenCharactersLabel(count: introductionTextView.text.count, pointColor: color)
-  }
-}
-
 
 #if canImport(SwiftUI) && DEBUG
 import SwiftUI

--- a/PLUB/Sources/Views/Login/LoginViewController.swift
+++ b/PLUB/Sources/Views/Login/LoginViewController.swift
@@ -97,25 +97,25 @@ final class LoginViewController: BaseViewController {
   override func setupConstraints() {
     super.setupConstraints()
     
-    self.logoImageView.snp.makeConstraints { make in
-      make.horizontalEdges.equalToSuperview().inset(106)
-      make.centerY.equalToSuperview().offset(-150)
+    self.logoImageView.snp.makeConstraints {
+      $0.horizontalEdges.equalToSuperview().inset(106)
+      $0.centerY.equalToSuperview().offset(-150)
     }
     
-    self.loginStackView.snp.makeConstraints { make in
-      make.leading.trailing.equalToSuperview().inset(40)
-      make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(164)
+    self.loginStackView.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview().inset(40)
+      $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(164)
     }
     
-    self.termsLabel.snp.makeConstraints { make in
-      make.centerX.equalToSuperview()
-      make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(60)
+    self.termsLabel.snp.makeConstraints {
+      $0.centerX.equalToSuperview()
+      $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(60)
     }
     
     // == Button's constraints ==
     [kakaoLoginButton, googleLoginButton, appleLoginButton].forEach {
-      $0.snp.makeConstraints { make in
-        make.height.equalTo(44)
+      $0.snp.makeConstraints {
+        $0.height.equalTo(44)
       }
     }
   }

--- a/PLUB/Sources/Views/Login/LoginViewController.swift
+++ b/PLUB/Sources/Views/Login/LoginViewController.swift
@@ -86,30 +86,30 @@ final class LoginViewController: BaseViewController {
   override func setupLayouts() {
     super.setupLayouts()
     [logoImageView, loginStackView, termsLabel].forEach {
-      self.view.addSubview($0)
+      view.addSubview($0)
     }
     
     [kakaoLoginButton, googleLoginButton, appleLoginButton].forEach {
-      self.loginStackView.addArrangedSubview($0)
+      loginStackView.addArrangedSubview($0)
     }
   }
   
   override func setupConstraints() {
     super.setupConstraints()
     
-    self.logoImageView.snp.makeConstraints {
+    logoImageView.snp.makeConstraints {
       $0.horizontalEdges.equalToSuperview().inset(106)
       $0.centerY.equalToSuperview().offset(-150)
     }
     
-    self.loginStackView.snp.makeConstraints {
+    loginStackView.snp.makeConstraints {
       $0.leading.trailing.equalToSuperview().inset(40)
-      $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(164)
+      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(164)
     }
     
-    self.termsLabel.snp.makeConstraints {
+    termsLabel.snp.makeConstraints {
       $0.centerX.equalToSuperview()
-      $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(60)
+      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(60)
     }
     
     // == Button's constraints ==

--- a/PLUB/Sources/Views/Login/Policy/PolicyBodyTableViewCell.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyBodyTableViewCell.swift
@@ -39,16 +39,16 @@ final class PolicyBodyTableViewCell: UITableViewCell {
   }
   
   private func setupConstraints() {
-    webView.snp.makeConstraints { make in
-      make.leading.equalToSuperview().inset(26) // 24(size) + 2(spacing)
-      make.trailing.equalToSuperview().inset(39) // 13(trailing) + 24(size) + 2(spacing)
-      make.verticalEdges.equalToSuperview().inset(4)
-      make.height.equalTo(208)
+    webView.snp.makeConstraints {
+      $0.leading.equalToSuperview().inset(26) // 24(size) + 2(spacing)
+      $0.trailing.equalToSuperview().inset(39) // 13(trailing) + 24(size) + 2(spacing)
+      $0.verticalEdges.equalToSuperview().inset(4)
+      $0.height.equalTo(208)
     }
     
-    seperatorLineView.snp.makeConstraints { make in
-      make.bottom.horizontalEdges.equalToSuperview()
-      make.height.equalTo(1) // 높이를 1로 설정하여 테이블 구분선을 만듦
+    seperatorLineView.snp.makeConstraints {
+      $0.bottom.horizontalEdges.equalToSuperview()
+      $0.height.equalTo(1) // 높이를 1로 설정하여 테이블 구분선을 만듦
     }
   }
   

--- a/PLUB/Sources/Views/Login/Policy/PolicyHeaderTableViewCell.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyHeaderTableViewCell.swift
@@ -61,22 +61,22 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
   
   private func setupConstraints() {
     
-    seperatorLineView.snp.makeConstraints { make in
-      make.bottom.horizontalEdges.equalToSuperview()
-      make.height.equalTo(1) // 높이를 1로 설정하여 테이블 구분선을 만듦
+    seperatorLineView.snp.makeConstraints {
+      $0.bottom.horizontalEdges.equalToSuperview()
+      $0.height.equalTo(1) // 높이를 1로 설정하여 테이블 구분선을 만듦
     }
     
-    stackView.snp.makeConstraints { make in
-      make.top.leading.equalToSuperview().inset(10)
-      make.bottom.trailing.equalToSuperview().inset(13)
+    stackView.snp.makeConstraints {
+      $0.top.leading.equalToSuperview().inset(10)
+      $0.bottom.trailing.equalToSuperview().inset(13)
     }
     
-    disclosureIndicator.snp.makeConstraints { make in
-      make.size.equalTo(24)
+    disclosureIndicator.snp.makeConstraints {
+      $0.size.equalTo(24)
     }
     
-    checkbox.snp.makeConstraints { make in
-      make.size.equalTo(24)
+    checkbox.snp.makeConstraints {
+      $0.size.equalTo(24)
     }
   }
   

--- a/PLUB/Sources/Views/Login/Policy/PolicyViewController.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyViewController.swift
@@ -36,8 +36,8 @@ final class PolicyViewController: BaseViewController {
   
   override func setupConstraints() {
     super.setupConstraints()
-    tableView.snp.makeConstraints { make in
-      make.edges.equalToSuperview()
+    tableView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
     }
   }
 }

--- a/PLUB/Sources/Views/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyViewModel.swift
@@ -33,7 +33,7 @@ extension PolicyViewModel {
   /// tableView를 세팅하며, `DiffableDataSource`를 초기화하여 해당 tableView에 데이터를 지닌 셀을 처리합니다.
   /// - Parameter tableView: 보여질 tableView
   func setTableView(_ tableView: UITableView) {
-    self.dataSource = DataSource(tableView: tableView) { tableView, indexPath, model in
+    dataSource = DataSource(tableView: tableView) { tableView, indexPath, model in
       let identifier: String
       switch model.type {
       case .header:

--- a/PLUB/Sources/Views/Login/Profile/ProfileViewController.swift
+++ b/PLUB/Sources/Views/Login/Profile/ProfileViewController.swift
@@ -116,24 +116,24 @@ final class ProfileViewController: BaseViewController {
   override func setupConstraints() {
     super.setupConstraints()
     
-    wholeStackView.snp.makeConstraints { make in
-      make.top.horizontalEdges.equalToSuperview()
+    wholeStackView.snp.makeConstraints {
+      $0.top.horizontalEdges.equalToSuperview()
     }
     
-    uploadImageButton.snp.makeConstraints { make in
-      make.size.equalTo(120)
+    uploadImageButton.snp.makeConstraints {
+      $0.size.equalTo(120)
     }
     
-    profileLabel.snp.makeConstraints { make in
-      make.leading.equalToSuperview()
+    profileLabel.snp.makeConstraints {
+      $0.leading.equalToSuperview()
     }
     
-    nicknameTextField.snp.makeConstraints { make in
-      make.height.equalTo(46)
+    nicknameTextField.snp.makeConstraints {
+      $0.height.equalTo(46)
     }
     
-    alertImageView.snp.makeConstraints { make in
-      make.size.equalTo(18)
+    alertImageView.snp.makeConstraints {
+      $0.size.equalTo(18)
     }
   }
   


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 컨벤션 정리와 기존 코드를 공통 컴포넌트로 바꾸었습니다. ( make -> $0, self 제거, inputTextView로 변경)
- InputText 사용 시 resignFirstResponder메서드를 호출하기 위해 InputTextView의 textView를 resign하도록 세팅해두었습니다.

## 📮 관련 이슈
- Resolved: #56 

