### PR TITLE
[Network] Logout 구현

### DIFF
--- a/PLUB/Sources/Network/Foundation/HeaderType.swift
+++ b/PLUB/Sources/Network/Foundation/HeaderType.swift
@@ -11,7 +11,8 @@ import Alamofire
 
 enum HeaderType {
   case `default`
-  case withToken
+  case withAccessToken
+  case withRefreshToken
 }
 
 extension HeaderType {
@@ -21,9 +22,21 @@ extension HeaderType {
       var defaultHeaders = HTTPHeaders.default
       defaultHeaders.add(.contentType("application/json"))
       return defaultHeaders
-    case .withToken:
+    case .withAccessToken:
       // 토큰이 존재하지 않는 경우 default 리턴
       guard let token = UserManager.shared.accessToken else {
+        return HeaderType.default.toHTTPHeader
+      }
+      
+      // default 헤더 값에 `Authorization token` 및 `Content-Type` 추가
+      var defaultHeaders = HTTPHeaders.default
+      defaultHeaders.add(.authorization(bearerToken: token))
+      defaultHeaders.add(.contentType("application/json"))
+      return defaultHeaders
+      
+    case .withRefreshToken:
+      // 토큰이 존재하지 않는 경우 default 리턴
+      guard let token = UserManager.shared.refreshToken else {
         return HeaderType.default.toHTTPHeader
       }
       

--- a/PLUB/Sources/Network/Routers/AuthRouter.swift
+++ b/PLUB/Sources/Network/Routers/AuthRouter.swift
@@ -11,6 +11,7 @@ enum AuthRouter {
   case socialLogin(SignInRequest)
   case signUpPLUB(SignUpRequest)
   case reissuanceAccessToken
+  case logout
 }
 
 extension AuthRouter: Router {
@@ -19,6 +20,8 @@ extension AuthRouter: Router {
     switch self {
     case .socialLogin, .signUpPLUB, .reissuanceAccessToken:
       return .post
+    case .logout:
+      return .get
     }
   }
   
@@ -30,6 +33,8 @@ extension AuthRouter: Router {
       return "/auth/signup"
     case .reissuanceAccessToken:
       return "/auth/reissue"
+    case .logout:
+      return "/auth/logout"
     }
   }
   
@@ -41,6 +46,8 @@ extension AuthRouter: Router {
       return .body(model)
     case .reissuanceAccessToken:
       return .body(ReissuanceRequest(refreshToken: UserManager.shared.refreshToken ?? ""))
+    case .logout:
+      return .plain
     }
   }
   
@@ -48,6 +55,8 @@ extension AuthRouter: Router {
     switch self {
     case .socialLogin, .signUpPLUB, .reissuanceAccessToken:
       return .default
+    case .logout:
+      return .withRefreshToken
     }
   }
 }

--- a/PLUB/Sources/Network/Services/AuthService.swift
+++ b/PLUB/Sources/Network/Services/AuthService.swift
@@ -63,4 +63,8 @@ extension AuthService {
   func reissuanceAccessToken() -> Observable<NetworkResult<GeneralResponse<TokenResponse>>> {
     return sendRequest(AuthRouter.reissuanceAccessToken, type: TokenResponse.self)
   }
+  
+  func logout() -> Observable<NetworkResult<GeneralResponse<EmptyModel>>> {
+    return sendRequest(AuthRouter.logout)
+  }
 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 로그인 네트워크 로직의 `logout`을 구현하였습니다.

🌱 PR 포인트
- withToken의 이름이 `withAccessToken`으로 변경되었습니다. 그 이유는 로그아웃 시 header에 `refreshToken`을 전달해주어야하는데 withToken은 accessToken을 전달해주는 케이스라 서로 의미를 구분짓기 위해섭니다.


## 📮 관련 이슈
- Resolved: #54

