### PR TITLE
[Policy] 버튼 처리 로직 구현

### DIFF
--- a/PLUB/Sources/Views/Login/Policy/PolicyHeaderTableViewCell.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyHeaderTableViewCell.swift
@@ -33,13 +33,13 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
     $0.backgroundColor = .lightGray
   }
   
-  private let checkbox: CheckBoxButton = CheckBoxButton(type: .full)
+  let checkbox: CheckBoxButton = CheckBoxButton(type: .full)
   
   private let stackView: UIStackView = UIStackView().then {
     $0.spacing = 2
     $0.alignment = .center
   }
-
+  
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
     setupLayouts()

--- a/PLUB/Sources/Views/Login/Policy/PolicyViewController.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyViewController.swift
@@ -83,6 +83,27 @@ final class PolicyViewController: BaseViewController {
       $0.horizontalEdges.bottom.equalToSuperview()
     }
   }
+  
+  override func bind() {
+    super.bind()
+    
+    let output = viewModel.transform(input: .init(allAgreementButtonTapped: agreementCheckboxButton.rx.tap.asObservable()))
+    
+    output.checkedButtonListState
+      .do { print($0) }
+      .map { $0.reduce(true, { $0 && $1 }) }
+      .drive(onNext: { [weak self] in
+        self?.agreementCheckboxButton.isChecked = $0
+      })
+      .disposed(by: disposeBag)
+    
+    output.checkedButtonListState
+      .map { $0.dropLast(1).reduce(true, { $0 && $1 }) }
+      .drive(onNext: { flag in
+        // delegate 처리
+      })
+      .disposed(by: disposeBag)
+  }
 }
 
 

--- a/PLUB/Sources/Views/Login/Policy/PolicyViewController.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyViewController.swift
@@ -16,7 +16,24 @@ final class PolicyViewController: BaseViewController {
   
   private let viewModel = PolicyViewModel()
   
-  private lazy var tableView: UITableView = UITableView().then {
+  private let agreementControl = UIControl().then {
+    $0.backgroundColor = .white
+    $0.layer.cornerRadius = 8
+    $0.layer.shadowColor = UIColor(hex: 0x000000).withAlphaComponent(0.1).cgColor
+    $0.layer.shadowOpacity = 1
+    $0.layer.shadowRadius = 10
+    $0.layer.shadowOffset = CGSize(width: 0, height: 2)
+  }
+  
+  private let agreementLabel = UILabel().then {
+    $0.text = "전체 동의"
+    $0.font = .subtitle
+    $0.textColor = .black
+  }
+  
+  private let agreementCheckboxButton = CheckBoxButton(type: .full)
+  
+  private lazy var tableView = UITableView().then {
     $0.backgroundColor = .background
     $0.register(PolicyHeaderTableViewCell.self, forCellReuseIdentifier: PolicyHeaderTableViewCell.identifier)
     $0.register(PolicyBodyTableViewCell.self, forCellReuseIdentifier: PolicyBodyTableViewCell.identifier)
@@ -24,20 +41,46 @@ final class PolicyViewController: BaseViewController {
     $0.delegate = self
   }
   
+  // MARK: - Life Cycle
+  
   override func viewDidLoad() {
     super.viewDidLoad()
     viewModel.setTableView(tableView)
   }
   
+  // MARK: - Configuration
+  
   override func setupLayouts() {
     super.setupLayouts()
+    view.addSubview(agreementControl)
     view.addSubview(tableView)
+    
+    agreementControl.addSubview(agreementLabel)
+    agreementControl.addSubview(agreementCheckboxButton)
   }
   
   override func setupConstraints() {
     super.setupConstraints()
+    
+    agreementControl.snp.makeConstraints {
+      $0.top.horizontalEdges.equalToSuperview()
+      $0.height.equalTo(48)
+    }
+    
+    agreementLabel.snp.makeConstraints {
+      $0.centerY.equalToSuperview()
+      $0.leading.equalToSuperview().inset(16)
+    }
+    
+    agreementCheckboxButton.snp.makeConstraints {
+      $0.centerY.equalToSuperview()
+      $0.size.equalTo(24)
+      $0.trailing.equalToSuperview().inset(12)
+    }
+    
     tableView.snp.makeConstraints {
-      $0.edges.equalToSuperview()
+      $0.top.equalTo(agreementControl.snp.bottom).offset(16)
+      $0.horizontalEdges.bottom.equalToSuperview()
     }
   }
 }

--- a/PLUB/Sources/Views/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyViewModel.swift
@@ -80,9 +80,9 @@ extension PolicyViewModel {
   }
   
   func applyAllAgreement() {
-    // 전체 동의 버튼 클릭되었으므로 모든 체크박스 true 처리
+    let alreadyCheckedAll = checkedList.map(\.isChecked).filter({$0}).count == checkedList.count
     checkedList.forEach {
-      $0.isChecked = true
+      $0.isChecked = alreadyCheckedAll ? false : true
     }
   }
 }

--- a/PLUB/Sources/Views/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyViewModel.swift
@@ -17,6 +17,15 @@ final class PolicyViewModel {
     "마케팅 활용 동의 (선택)"
   ]
   
+  private var checkedList = [CheckBoxButton]() {
+    didSet {
+      // tableView cell의 버튼들이 전부 들어가져있다면
+      if checkedList.count == policies.count {
+        // 바인딩 처리
+      }
+    }
+  }
+  
   private var dataSource: DataSource? = nil {
     didSet {
       applyInitialSnapshots()
@@ -46,6 +55,10 @@ extension PolicyViewModel {
       
       if let cellConfigurable = cell as? PolicyConfigurable {
         cellConfigurable.configure(with: model)
+      }
+      
+      if let headerCell = cell as? PolicyHeaderTableViewCell {
+        self.checkedList.append(headerCell.checkbox)
       }
       
       return cell

--- a/PLUB/Sources/Views/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyViewModel.swift
@@ -7,7 +7,12 @@
 
 import UIKit
 
+import RxCocoa
+import RxSwift
+
 final class PolicyViewModel {
+  
+  private let disposeBag = DisposeBag()
   
   private let policies = [
     "이용약관 및 개인정보취급방침 (필수)",
@@ -31,6 +36,8 @@ final class PolicyViewModel {
       applyInitialSnapshots()
     }
   }
+  
+  private let buttonCheckedRelay = BehaviorRelay<[Bool]>(value: [])
 }
 
 // MARK: - Set Property Methods


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 전체 동의 뷰 구현
- 버튼이 눌릴 때 로직 구현
   - 전체동의 버튼 클릭시 전체 체크박스가 체크 처리
   - 전체동의 버튼 클릭시 이미 전체가 체크박스처리가 되어있다면 전부 체크 해제

🌱 PR 포인트
- 체크박스 버튼이 cell에 들어가 있어서 이를 처리하기 위해 어쩔 수 없이 viewmodel에서 체크박스 버튼을 캐싱할 수 밖에 없었습니다.. 마음에 들지 않지만 아이디어가 나오지 않았습니다. 나중에 리팩토링 시 바꿔볼게요.. :'(

## 📸 스크린샷
|스크린샷|
|:--:|
|![RPReplay_Final1674138510](https://user-images.githubusercontent.com/57972338/213468710-d000e70f-78d2-4932-9551-bf59614ad733.gif)|

## 📮 관련 이슈
- #72

