### PR TITLE
[SignUp] 약관페이지, 생년월일 페이지 ViewModel 바인딩

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		BA784FA82978EB9100E8B06F /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA784FA72978EB9100E8B06F /* SignUpViewController.swift */; };
 		BA784FAA2978EB9900E8B06F /* SignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA784FA92978EB9900E8B06F /* SignUpViewModel.swift */; };
 		BA784FAE297937DA00E8B06F /* CalendarControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA784FAD297937D600E8B06F /* CalendarControl.swift */; };
+		BA7AD73E297D6720000E7D5D /* BirthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7AD73D297D6720000E7D5D /* BirthViewModel.swift */; };
 		BA876BA1296514DA0029CF34 /* PaddingTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA0296514DA0029CF34 /* PaddingTextField.swift */; };
 		BA876BA4296529100029CF34 /* IntroductionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA876BA3296529100029CF34 /* IntroductionViewController.swift */; };
 		BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88124D28E48A2F00BD832A /* AppDelegate.swift */; };
@@ -226,6 +227,7 @@
 		BA784FA72978EB9100E8B06F /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		BA784FA92978EB9900E8B06F /* SignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewModel.swift; sourceTree = "<group>"; };
 		BA784FAD297937D600E8B06F /* CalendarControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalendarControl.swift; sourceTree = "<group>"; };
+		BA7AD73D297D6720000E7D5D /* BirthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthViewModel.swift; sourceTree = "<group>"; };
 		BA876BA0296514DA0029CF34 /* PaddingTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingTextField.swift; sourceTree = "<group>"; };
 		BA876BA3296529100029CF34 /* IntroductionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionViewController.swift; sourceTree = "<group>"; };
 		BA88124A28E48A2F00BD832A /* PLUB.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PLUB.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -718,6 +720,7 @@
 			isa = PBXGroup;
 			children = (
 				BAC923DE29546BF500385841 /* BirthViewController.swift */,
+				BA7AD73D297D6720000E7D5D /* BirthViewModel.swift */,
 				BA784FAD297937D600E8B06F /* CalendarControl.swift */,
 			);
 			path = Birth;
@@ -941,7 +944,7 @@
 				7036A3EB294E3E810041B8DD /* RegisterInterestDetailTableViewCell.swift in Sources */,
 				70197B7929549B29000503F6 /* SelectedCategoryGridCollectionViewCell.swift in Sources */,
 				70BD5F302964823C002CBA89 /* ApplyQuestionViewController.swift in Sources */,
-				7095A58A292E58F9002A52E6 /* IndicatorButton.swift in Sources */,
+				7095A58A292E58F9002A52E6 /* ToggleButton.swift in Sources */,
 				C38A5B93297ACF5B00485355 /* LocationControl.swift in Sources */,
 				C38A5BA3297B17EF00485355 /* MeetingLocationViewModel.swift in Sources */,
 				7095A58A292E58F9002A52E6 /* ToggleButton.swift in Sources */,
@@ -967,6 +970,7 @@
 				BA771652296FBF4400762362 /* KeyChainWrapper.swift in Sources */,
 				BA340E2029782301002BAF2C /* LeftAlignedCollectionViewFlowLayout.swift in Sources */,
 				BA88126228E48A5800BD832A /* BaseViewController.swift in Sources */,
+				BA7AD73E297D6720000E7D5D /* BirthViewModel.swift in Sources */,
 				BA340E1C297822CC002BAF2C /* IntroduceCategoryInfoView.swift in Sources */,
 				C36CE39F29731A0700E3A68C /* PhotoSelectView.swift in Sources */,
 				BA784FAE297937DA00E8B06F /* CalendarControl.swift in Sources */,

--- a/PLUB/Configuration/Base/BaseViewController.swift
+++ b/PLUB/Configuration/Base/BaseViewController.swift
@@ -22,6 +22,10 @@ class BaseViewController: UIViewController {
     bind()
   }
   
+  override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    view.endEditing(true)
+  }
+  
   /// UI 프로퍼티를 view에 할당합니다.
   ///
   /// ```

--- a/PLUB/Sources/Views/Login/Birth/BirthViewController.swift
+++ b/PLUB/Sources/Views/Login/Birth/BirthViewController.swift
@@ -16,6 +16,8 @@ final class BirthViewController: BaseViewController {
   
   // MARK: - Property
   
+  weak var delegate: SignUpChildViewControllerDelegate?
+  
   /// 성별과 생년월일 전체를 감싸는 `StackView`
   private let wholeStackView: UIStackView = UIStackView().then {
     $0.axis = .vertical

--- a/PLUB/Sources/Views/Login/Birth/BirthViewController.swift
+++ b/PLUB/Sources/Views/Login/Birth/BirthViewController.swift
@@ -116,7 +116,7 @@ final class BirthViewController: BaseViewController {
     
     maleButton.rx.tap
       .withUnretained(self)
-      .do { $0.0.viewModel.sexButtonTapped.onNext(()) }
+      .do { $0.0.viewModel.sexButtonTapped.onNext(()) } // 성별 선택이 완료되었다고 알리기
       .subscribe(onNext: { owner, _ in
         owner.maleButton.isSelected = true
         owner.femaleButton.isSelected = false
@@ -125,7 +125,7 @@ final class BirthViewController: BaseViewController {
     
     femaleButton.rx.tap
       .withUnretained(self)
-      .do { $0.0.viewModel.sexButtonTapped.onNext(()) }
+      .do { $0.0.viewModel.sexButtonTapped.onNext(()) } // 성별 선택이 완료되었다고 알리기
       .subscribe(onNext: { owner, _ in
         owner.femaleButton.isSelected = true
         owner.maleButton.isSelected = false
@@ -142,6 +142,7 @@ final class BirthViewController: BaseViewController {
       })
       .disposed(by: disposeBag)
     
+    // 버튼 활성화가 가능하다면 delegate에게 알려줌
     viewModel.isButtonEnabled
       .drive(with: self, onNext: { owner, flag in
         owner.delegate?.checkValidation(index: 1, state: flag)
@@ -154,7 +155,7 @@ extension BirthViewController: DateBottomSheetDelegate {
   func selectDate(date: Date) {
     birthSettingControl.date = date
     birthSettingControl.isSelected = true
-    viewModel.calendarDidSet.onNext(())
+    viewModel.calendarDidSet.onNext(()) // 생년월일이 세팅되었다고 알리기
   }
 }
 

--- a/PLUB/Sources/Views/Login/Birth/BirthViewController.swift
+++ b/PLUB/Sources/Views/Login/Birth/BirthViewController.swift
@@ -18,6 +18,8 @@ final class BirthViewController: BaseViewController {
   
   weak var delegate: SignUpChildViewControllerDelegate?
   
+  private let viewModel = BirthViewModel()
+  
   /// 성별과 생년월일 전체를 감싸는 `StackView`
   private let wholeStackView: UIStackView = UIStackView().then {
     $0.axis = .vertical
@@ -114,15 +116,19 @@ final class BirthViewController: BaseViewController {
     
     maleButton.rx.tap
       .withUnretained(self)
+      .do { $0.0.viewModel.sexButtonTapped.onNext(()) }
       .subscribe(onNext: { owner, _ in
-        owner.maleButton.isSelected.toggle()
+        owner.maleButton.isSelected = true
+        owner.femaleButton.isSelected = false
       })
       .disposed(by: disposeBag)
     
     femaleButton.rx.tap
       .withUnretained(self)
+      .do { $0.0.viewModel.sexButtonTapped.onNext(()) }
       .subscribe(onNext: { owner, _ in
-        owner.femaleButton.isSelected.toggle()
+        owner.femaleButton.isSelected = true
+        owner.maleButton.isSelected = false
       })
       .disposed(by: disposeBag)
     
@@ -135,6 +141,12 @@ final class BirthViewController: BaseViewController {
         owner.parent?.present(vc, animated: false)
       })
       .disposed(by: disposeBag)
+    
+    viewModel.isButtonEnabled
+      .drive(with: self, onNext: { owner, flag in
+        owner.delegate?.checkValidation(index: 1, state: flag)
+      })
+      .disposed(by: disposeBag)
   }
 }
 
@@ -142,6 +154,7 @@ extension BirthViewController: DateBottomSheetDelegate {
   func selectDate(date: Date) {
     birthSettingControl.date = date
     birthSettingControl.isSelected = true
+    viewModel.calendarDidSet.onNext(())
   }
 }
 

--- a/PLUB/Sources/Views/Login/Birth/BirthViewModel.swift
+++ b/PLUB/Sources/Views/Login/Birth/BirthViewModel.swift
@@ -22,11 +22,11 @@ protocol BirthViewModelType: BirthViewModel {
 final class BirthViewModel: BirthViewModelType {
   
   // input
-  let sexButtonTapped: AnyObserver<Void>
-  let calendarDidSet: AnyObserver<Void>
+  let sexButtonTapped: AnyObserver<Void>  // 성별 세팅완료 탭
+  let calendarDidSet: AnyObserver<Void>   // 캘린더 세팅완료 탭
   
   // output
-  let isButtonEnabled: Driver<Bool>
+  let isButtonEnabled: Driver<Bool>       // 버튼 활성화 여부
   
   private let calendarSelected = PublishSubject<Void>()
   private let sexSelected = PublishSubject<Void>()
@@ -36,6 +36,9 @@ final class BirthViewModel: BirthViewModelType {
   init() {
     sexButtonTapped = sexSelected.asObserver()
     calendarDidSet = calendarSelected.asObserver()
+    
+    // 두 input이 전부 활성화되었다면 바로 활성화 처리
+    // input은 전부 비활성화될 수가 없기 떄문
     isButtonEnabled = Driver.combineLatest(
       sexSelected.asDriver(onErrorDriveWith: .empty()),
       calendarSelected.asDriver(onErrorDriveWith: .empty())

--- a/PLUB/Sources/Views/Login/Birth/BirthViewModel.swift
+++ b/PLUB/Sources/Views/Login/Birth/BirthViewModel.swift
@@ -1,0 +1,44 @@
+//
+//  BirthViewModel.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/01/22.
+//
+
+import Foundation
+
+import RxCocoa
+import RxSwift
+
+protocol BirthViewModelType: BirthViewModel {
+  // input
+  var sexButtonTapped: AnyObserver<Void> { get }
+  var calendarDidSet: AnyObserver<Void> { get }
+  
+  // output
+  var isButtonEnabled: Driver<Bool> { get }
+}
+
+final class BirthViewModel: BirthViewModelType {
+  
+  // input
+  let sexButtonTapped: AnyObserver<Void>
+  let calendarDidSet: AnyObserver<Void>
+  
+  // output
+  let isButtonEnabled: Driver<Bool>
+  
+  private let calendarSelected = PublishSubject<Void>()
+  private let sexSelected = PublishSubject<Void>()
+  
+  private let disposeBag = DisposeBag()
+  
+  init() {
+    sexButtonTapped = sexSelected.asObserver()
+    calendarDidSet = calendarSelected.asObserver()
+    isButtonEnabled = Driver.combineLatest(
+      sexSelected.asDriver(onErrorDriveWith: .empty()),
+      calendarSelected.asDriver(onErrorDriveWith: .empty())
+    ) { _, _  in true }
+  }
+}

--- a/PLUB/Sources/Views/Login/Introduction/IntroductionViewController.swift
+++ b/PLUB/Sources/Views/Login/Introduction/IntroductionViewController.swift
@@ -14,6 +14,8 @@ final class IntroductionViewController: BaseViewController {
   
   // MARK: - Property
   
+  weak var delegate: SignUpChildViewControllerDelegate?
+  
   let inputTextView = InputTextView(
     title: "소개",
     placeHolder: "소개하는 내용을 입력해주세요",

--- a/PLUB/Sources/Views/Login/Policy/PolicyViewController.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyViewController.swift
@@ -16,6 +16,8 @@ final class PolicyViewController: BaseViewController {
   
   private let viewModel = PolicyViewModel()
   
+  weak var delegate: SignUpChildViewControllerDelegate?
+  
   private let agreementControl = UIControl().then {
     $0.backgroundColor = .white
     $0.layer.cornerRadius = 8
@@ -99,8 +101,9 @@ final class PolicyViewController: BaseViewController {
     
     output.checkedButtonListState
       .map { $0.dropLast(1).reduce(true, { $0 && $1 }) }
-      .drive(onNext: { flag in
+      .drive(with: self, onNext: { owner, flag in
         // delegate 처리
+        owner.delegate?.checkValidation(index: 0, state: flag)
       })
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyViewModel.swift
@@ -70,11 +70,10 @@ extension PolicyViewModel {
   func bind() {
     let drivers = checkedList.map { $0.rx.isChecked.asDriver() }
     Driver<Bool>.combineLatest(drivers)
-      .drive(onNext: { [weak self] _ in
-        guard let self = self else { return }
+      .drive(with: self, onNext: { owner, _ in
         // 전체 동의 버튼 클릭 시의 isChecked 값이 combineLatest의 값과 연동되어있지 않아서
         // self.checkedList의 isChecked를 accept하도록 구현
-        self.buttonCheckedRelay.accept(self.checkedList.map { $0.isChecked })
+        owner.buttonCheckedRelay.accept(owner.checkedList.map { $0.isChecked })
       })
       .disposed(by: disposeBag)
   }
@@ -84,6 +83,7 @@ extension PolicyViewModel {
     checkedList.forEach {
       $0.isChecked = alreadyCheckedAll ? false : true
     }
+    buttonCheckedRelay.accept(checkedList.map { $0.isChecked })
   }
 }
 

--- a/PLUB/Sources/Views/Login/Profile/ProfileViewController.swift
+++ b/PLUB/Sources/Views/Login/Profile/ProfileViewController.swift
@@ -16,6 +16,8 @@ final class ProfileViewController: BaseViewController {
   
   // MARK: - Property
   
+  weak var delegate: SignUpChildViewControllerDelegate?
+  
   private let viewModel = ProfileViewModel()
   
   private let wholeStackView: UIStackView = UIStackView().then {

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -10,6 +10,10 @@ import UIKit
 import SnapKit
 import Then
 
+protocol SignUpChildViewControllerDelegate: BaseViewController {
+  func checkValidation(index: Int, state: Bool)
+}
+
 final class SignUpViewController: BaseViewController {
   
   // MARK: - Properties
@@ -36,11 +40,11 @@ final class SignUpViewController: BaseViewController {
     }
   }
   
-  private var viewControllers = [
-    PolicyViewController(),
-    BirthViewController(),
-    ProfileViewController(),
-    IntroductionViewController()
+  private lazy var viewControllers = [
+    PolicyViewController().then { $0.delegate = self },
+    BirthViewController().then { $0.delegate = self },
+    ProfileViewController().then { $0.delegate = self },
+    IntroductionViewController().then { $0.delegate = self }
   ]
   
   // MARK: UI Properties
@@ -248,5 +252,13 @@ extension SignUpViewController: UIScrollViewDelegate {
     } else if velocity.x < 0 { // move left
       currentPage = currentPage == 0 ? 0 : currentPage - 1
     }
+  }
+}
+
+// MARK: - SignUpChildViewControllerDelegate
+
+extension SignUpViewController: SignUpChildViewControllerDelegate {
+  func checkValidation(index: Int, state: Bool) {
+    
   }
 }

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -173,6 +173,10 @@ final class SignUpViewController: BaseViewController {
         owner.scrollToPage(index: owner.currentPage)
       })
       .disposed(by: disposeBag)
+    
+    viewModel.isButtonEnabled
+      .drive(nextButton.rx.isEnabled)
+      .disposed(by: disposeBag)
   }
   
   // MARK: - Custom Methods
@@ -259,6 +263,6 @@ extension SignUpViewController: UIScrollViewDelegate {
 
 extension SignUpViewController: SignUpChildViewControllerDelegate {
   func checkValidation(index: Int, state: Bool) {
-    
+    viewModel.validationState.onNext(ValidationState(index: index, state: state))
   }
 }

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -37,6 +37,7 @@ final class SignUpViewController: BaseViewController {
       viewControllers[lastPageIndex].view.snp.makeConstraints {
         $0.width.equalTo(view.snp.width)
       }
+      viewModel.validationState.onNext(ValidationState(index: lastPageIndex, state: false))
     }
   }
   

--- a/PLUB/Sources/Views/Login/SignUpViewModel.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewModel.swift
@@ -7,7 +7,34 @@
 
 import Foundation
 
-final class SignUpViewModel {
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
+
+struct ValidationState {
+  let index: Int  // 인덱스
+  let state: Bool // 활성화 상태
+}
+
+protocol SignUpViewModelType: SignUpViewModel {
+  // Input
+  var validationState: AnyObserver<ValidationState> { get }
+  
+  // Output
+  var isButtonEnabled: Driver<Bool> { get } // 버튼 활성화 제어
+}
+
+final class SignUpViewModel: SignUpViewModelType {
+  
+  // Input
+  let validationState: AnyObserver<ValidationState>
+  
+  // Output
+  let isButtonEnabled: Driver<Bool> // 버튼 활성화 제어
+  
+  private let disposeBag = DisposeBag()
+  
   var titles = [
     "가입을 위한 약관 동의가 필요해요.",
     "먼저, 성별과 태어난 날을 알려주세요.",
@@ -23,4 +50,43 @@ final class SignUpViewModel {
     "취미, 관심사, 가치관, 종사하는 분야, 뭐든 좋아요.",
     "(닉네임)님이 흥미로워 할 만한 모임을 추천해 드릴게요."
   ]
+  
+  private var stateList = [Bool]()
+  
+  private let stateSubject = PublishSubject<ValidationState>()
+  private let resultSubject = BehaviorSubject<Bool>(value: false)
+  
+  // MARK: - Initialization
+  
+  init() {
+    validationState = stateSubject.asObserver()
+    isButtonEnabled = resultSubject.asDriver(onErrorDriveWith: .empty())
+    bind()
+  }
+  
+  // MARK: - Custom Functions
+  
+  func bind() {
+    // 어떤 VC의 delegate로 인한 state 변경
+    // ==> viewModel의 state 값 변경
+    // ==> 값 변동 이후 버튼 활성화 유무 판단
+    // ==> `버튼 활성화 Driver`에 부울값 emit
+    stateSubject
+      .withUnretained(self)
+      .do { $0.changeState(index: $1.index, state: $1.state) }
+      .map { owner, _ in
+        owner.stateList.firstIndex(of: false) == nil
+      }
+      .bind(to: resultSubject)
+      .disposed(by: disposeBag)
+  }
+  
+  private func changeState(index: Int, state: Bool) {
+    // 순서대로 오는 이상 index가 stateList의 개수보다 클 수 없음
+    assert(stateList.count >= index)
+    if stateList.count == index {
+      stateList.append(state)
+    }
+    stateList[index] = state
+  }
 }

--- a/PLUB/Sources/Views/Login/SignUpViewModel.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewModel.swift
@@ -22,13 +22,13 @@ protocol SignUpViewModelType: SignUpViewModel {
   var validationState: AnyObserver<ValidationState> { get }
   
   // Output
-  var isButtonEnabled: Driver<Bool> { get } // 버튼 활성화 제어
+  var isButtonEnabled: Driver<Bool> { get }
 }
 
 final class SignUpViewModel: SignUpViewModelType {
   
   // Input
-  let validationState: AnyObserver<ValidationState>
+  let validationState: AnyObserver<ValidationState> // 자식들에게서 상태값을 받음
   
   // Output
   let isButtonEnabled: Driver<Bool> // 버튼 활성화 제어


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 회원가입 시 필요한 정보를 입력해야 버튼이 활성화되도록 구현
- 약관 ViewModel과 생년월일 ViewModel만 구현된 상태
- SignUpViewController의 자식ViewControllerDelegate를 설정 ( CreateMeetingViewController와 유사합니다. ) 다만, 각 뷰 컨트롤러마다 서로 다른 정보를 내려줘야한다는 점에서 나중에 각각의 delegate를 구현해야할 것 같습니다. 지금은 정보를 전달하지 않고 버튼 상태값만 전달하기 때문에 동일한 delegate를 설정해두었습니다.

🌱 PR 포인트
- 각 ViewModel마다 바인딩이 구현된 로직이 다릅니다. 아직 뷰모델 로직 춘추 전국 시대라 ㅎㅎ... 확실하게 개념이 잡히면 통일해서 구현할게요!

## 📸 스크린샷
|예시 영상(다크모드라 텍스트가 하얗습니다)|
|:--:|
|<img src="https://user-images.githubusercontent.com/57972338/213918247-d515ff2a-6d3a-46d3-878d-e4c5fba3a61e.gif" width="50%"/>|


## 📮 관련 이슈
- #59 

