### PR TITLE
[SignUp] Profile ViewModel 구현

### DIFF
--- a/PLUB/Sources/Views/Login/Profile/ProfileViewController.swift
+++ b/PLUB/Sources/Views/Login/Profile/ProfileViewController.swift
@@ -209,6 +209,7 @@ final class ProfileViewController: BaseViewController {
     viewModel.isAvailableNickname
       .drive(with: self, onNext: { owner, flag in
         owner.updateNicknameValidationUI(isValid: flag)
+        owner.delegate?.checkValidation(index: 2, state: flag)
       })
       .disposed(by: disposeBag)
     
@@ -264,6 +265,7 @@ extension ProfileViewController: PhotoBottomSheetDelegate {
 extension ProfileViewController: UITextFieldDelegate {
   
   func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+    delegate?.checkValidation(index: 2, state: false)
     textField.textColor = .black
     return range.location < 15
   }

--- a/PLUB/Sources/Views/Login/Profile/ProfileViewController.swift
+++ b/PLUB/Sources/Views/Login/Profile/ProfileViewController.swift
@@ -196,30 +196,26 @@ final class ProfileViewController: BaseViewController {
     // ===  ViewModel Binding  ===
     
     // 빨리 입력하면 api가 여러번 호출되므로, 0.5초동안 입력 없을 시 데이터 emit
-    let output = viewModel.transform(
-      input: .init(
-        text: nicknameTextField.rx.text
-          .orEmpty
-          .distinctUntilChanged()
-          .skip(1)
-          .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
-          .filter { $0 != "" }
-          .asObservable()
-      )
-    )
+    nicknameTextField.rx.text
+      .orEmpty
+      .distinctUntilChanged()
+      .skip(1)
+      .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
+      .filter { $0 != "" }
+      .bind(to: viewModel.nicknameText)
+      .disposed(by: disposeBag)
     
-    // 닉네임 사용가능여부
-    output.isAvailable
-      .drive(onNext: { [weak self] flag in
-        self?.updateNicknameValidationUI(isValid: flag)
+    // 닉네임 사용가능여부를 판단하고 UI 업데이트
+    viewModel.isAvailableNickname
+      .drive(with: self, onNext: { owner, flag in
+        owner.updateNicknameValidationUI(isValid: flag)
       })
       .disposed(by: disposeBag)
     
     // 메시지 처리
-    output.alertMessage
+    viewModel.alertMessage
       .drive(alertLabel.rx.text)
       .disposed(by: disposeBag)
-    
   }
   
   /// 최초 상태의 UI를 설정합니다. (textField, label, bubble image 등)

--- a/PLUB/Sources/Views/Login/Profile/ProfileViewModel.swift
+++ b/PLUB/Sources/Views/Login/Profile/ProfileViewModel.swift
@@ -51,6 +51,13 @@ final class ProfileViewModel: ProfileViewModelType {
   
   private func validate(text: String) {
     let characterRegex = "[^a-zA-Z가-힣0-9]" // 한글, 영어, 숫자를 제외한 문자를 찾는 정규표현식 (특수문자 찾기용)
+    print(text)
+    // 2~8자가 아닌 경우
+    if text.count < 2 || text.count > 8 {
+      isAvailableRelay.accept(false)
+      alertMessageRelay.accept("2자에서 8자 사이로 입력해주세요.")
+      return
+    }
     
     // text에 공백이 존재하는 경우
     if text.range(of: " ") != nil {


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- ViewModel의 Binding 로직을 수정했습니다.
- 버튼이 활성화될 수 있도록 delegate 세팅을 해두었습니다.
- 2자에서 8자 미만의 닉네임이 아닌 경우 에러가 뜨도록 구현했습니다.
   - 이거는 디자인 파트에 존재하지 않아 제가 커스텀으로 만들어 구현해두었습니다.

## 📸 스크린샷
|스크린샷|
|:--:|
|<img src="https://user-images.githubusercontent.com/57972338/213986447-ce7e82bf-6f00-49cd-9017-ac65ec7f5086.gif" width="50%"/>|

## 📮 관련 이슈
- #59


## P.S.

닉네임 입력할 때 뷰 자체를 키보드 높이만큼 띄워야할 것 같습니다. 하하 다음에 작업해볼게요!
