### PR TITLE
[SignUp] Policy(약관)ViewModel 재사용 버그 이슈 해결 및 리팩토링

### DIFF
--- a/PLUB/Sources/Views/Login/Policy/PolicyHeaderTableViewCell.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyHeaderTableViewCell.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import RxSwift
 import SnapKit
 import Then
 
@@ -16,6 +17,8 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
   
   /// Disclosure Indicator의 애니메이션 flag
   private var indicatorFlag = false
+  
+  var disposeBag = DisposeBag()
   
   private let disclosureIndicator: UIImageView = UIImageView().then {
     $0.image = UIImage(systemName: "chevron.down")
@@ -87,6 +90,12 @@ final class PolicyHeaderTableViewCell: UITableViewCell {
       let upsideDown = CGAffineTransform(rotationAngle: .pi * 0.9999)
       self.disclosureIndicator.transform = self.indicatorFlag ? upsideDown : .identity
     }
+  }
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    // 재사용 시 기존의 disposeBag에 있는 Disposables를 Dispose 시킴
+    disposeBag = DisposeBag()
   }
   
   func configure(with policy: String) {

--- a/PLUB/Sources/Views/Login/Policy/PolicyViewController.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyViewController.swift
@@ -88,10 +88,11 @@ final class PolicyViewController: BaseViewController {
   
   override func bind() {
     super.bind()
+    agreementCheckboxButton.rx.tap
+      .bind(to: viewModel.allAgreementButtonTapped)
+      .disposed(by: disposeBag)
     
-    let output = viewModel.transform(input: .init(allAgreementButtonTapped: agreementCheckboxButton.rx.tap.asObservable()))
-    
-    output.checkedButtonListState
+    viewModel.checkedButtonListState
       .do { print($0) }
       .map { $0.reduce(true, { $0 && $1 }) }
       .drive(onNext: { [weak self] in
@@ -99,7 +100,7 @@ final class PolicyViewController: BaseViewController {
       })
       .disposed(by: disposeBag)
     
-    output.checkedButtonListState
+    viewModel.checkedButtonListState
       .map { $0.dropLast(1).reduce(true, { $0 && $1 }) }
       .drive(with: self, onNext: { owner, flag in
         // delegate 처리

--- a/PLUB/Sources/Views/Login/Policy/PolicyViewModel.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyViewModel.swift
@@ -27,7 +27,7 @@ final class PolicyViewModel: PolicyViewModelType {
   let checkedButtonListState: Driver<[Bool]> // 현재 버튼 체크되어있는 상태
   
   private let allAgreementSubject = PublishSubject<Void>()
-  private let buttonCheckedRelay = BehaviorRelay<[Bool]>(value: [])
+  private let buttonCheckedRelay = BehaviorRelay<[Bool]>(value: [Bool](repeating: false, count: 5))
   
   private let disposeBag = DisposeBag()
   
@@ -38,16 +38,6 @@ final class PolicyViewModel: PolicyViewModelType {
     "개인정보 수집 이용 동의 (필수)",
     "마케팅 활용 동의 (선택)"
   ]
-  
-  private var checkedList = [CheckBoxButton]() {
-    didSet {
-      // tableView cell의 버튼들이 전부 들어가져있다면
-      if checkedList.count == policies.count {
-        // 바인딩 처리
-        bindCheckbox()
-      }
-    }
-  }
   
   private var dataSource: DataSource? = nil {
     didSet {
@@ -75,23 +65,9 @@ extension PolicyViewModel {
       .disposed(by: disposeBag)
   }
   
-  func bindCheckbox() {
-    let drivers = checkedList.map { $0.rx.isChecked.asDriver() }
-    Driver<Bool>.combineLatest(drivers)
-      .drive(with: self, onNext: { owner, _ in
-        // 전체 동의 버튼 클릭 시의 isChecked 값이 combineLatest의 값과 연동되어있지 않아서
-        // self.checkedList의 isChecked를 accept하도록 구현
-        owner.buttonCheckedRelay.accept(owner.checkedList.map { $0.isChecked })
-      })
-      .disposed(by: disposeBag)
-  }
-  
-  func applyAllAgreement() {
-    let alreadyCheckedAll = checkedList.map(\.isChecked).filter({$0}).count == checkedList.count
-    checkedList.forEach {
-      $0.isChecked = alreadyCheckedAll ? false : true
-    }
-    buttonCheckedRelay.accept(checkedList.map { $0.isChecked })
+  private func applyAllAgreement() {
+    let alreadyCheckedAll = buttonCheckedRelay.value.firstIndex(of: false) == nil
+    buttonCheckedRelay.accept([Bool](repeating: !alreadyCheckedAll, count: 5))
   }
 }
 
@@ -120,7 +96,22 @@ extension PolicyViewModel {
       }
       
       if let headerCell = cell as? PolicyHeaderTableViewCell {
-        self.checkedList.append(headerCell.checkbox)
+        
+        // 셀의 체크박스가 탭되면, viewModel의 check list 업데이트
+        headerCell.checkbox.rx.tap
+          .withUnretained(self)
+          .subscribe(onNext: { owner, _ in
+            var transformedValue = owner.buttonCheckedRelay.value
+            transformedValue[indexPath.section] = headerCell.checkbox.isChecked
+            owner.buttonCheckedRelay.accept(transformedValue)
+          })
+          .disposed(by: headerCell.disposeBag) // disposeBag을 cell에게 위임 -> cell 재사용될 시 dispose
+        
+        // check list가 바뀌면 버튼 ui도 바뀌도록 바인딩 처리 진행
+        self.buttonCheckedRelay
+          .map { $0[indexPath.section] }
+          .bind(to: headerCell.checkbox.rx.isChecked)
+          .disposed(by: headerCell.disposeBag) // disposeBag을 cell에게 위임 -> cell 재사용 시 dispose
       }
       
       return cell


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- ~~작업한 내용은 곧 커밋의 body 내용입니다. (작곧커?)~~
- ViewModel binding 컨벤션을 수정했습니다. (Input-Output 제거, protocol로 통일)
- 기존에는 tableview cell의 CheckBoxButton을 ViewModel이 갖고있는 식으로 구현해두었으나, 이를 제거하는 방식으로 리팩토링했습니다.

## 📸 스크린샷

|셀 재사용시 데이터 보존|
|:--:|
|![Screen Recording 2023-01-23 at 10 46 09 PM](https://user-images.githubusercontent.com/57972338/214060406-c7df1880-ec36-4565-8844-8ab20503f7e5.gif)|

## 📮 관련 이슈
- #59

