### PR TITLE
[SignUp] 관심사 선택 구현

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		BA8E2B46297467A2009DDF32 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8E2B45297467A2009DDF32 /* AuthService.swift */; };
 		BA8E2B4829746881009DDF32 /* SignInResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8E2B4729746881009DDF32 /* SignInResponse.swift */; };
 		BA94E81C297E706A00DF23CE /* IntroductionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA94E81B297E706A00DF23CE /* IntroductionViewModel.swift */; };
+		BABB011A297ED415004178EC /* InterestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB0119297ED415004178EC /* InterestViewController.swift */; };
 		BAC8930929755B87000D44E2 /* SignUpRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC8930829755B87000D44E2 /* SignUpRequest.swift */; };
 		BAC923DF29546BF500385841 /* BirthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC923DE29546BF500385841 /* BirthViewController.swift */; };
 		BAE16029292221ED00D595FF /* CheckBoxButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE16028292221ED00D595FF /* CheckBoxButton.swift */; };
@@ -244,6 +245,7 @@
 		BA8E2B45297467A2009DDF32 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		BA8E2B4729746881009DDF32 /* SignInResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInResponse.swift; sourceTree = "<group>"; };
 		BA94E81B297E706A00DF23CE /* IntroductionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionViewModel.swift; sourceTree = "<group>"; };
+		BABB0119297ED415004178EC /* InterestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewController.swift; sourceTree = "<group>"; };
 		BAC8930829755B87000D44E2 /* SignUpRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequest.swift; sourceTree = "<group>"; };
 		BAC923DE29546BF500385841 /* BirthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthViewController.swift; sourceTree = "<group>"; };
 		BAE058E528EC7CEC00F09BD8 /* PLUB.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PLUB.entitlements; sourceTree = "<group>"; };
@@ -553,6 +555,7 @@
 				BAE1AD932944770000CE36B9 /* Policy */,
 				BA1BEDC12964548300C6BD41 /* Profile */,
 				BA876BA2296528E60029CF34 /* Introduction */,
+				BABB0118297ED405004178EC /* Interest */,
 				BA42D1F228EDE10F00C20061 /* LoginViewController.swift */,
 				BA784FA72978EB9100E8B06F /* SignUpViewController.swift */,
 				BA784FA92978EB9900E8B06F /* SignUpViewModel.swift */,
@@ -717,6 +720,14 @@
 				C38A5B98297ADE8500485355 /* KakaoLocationResponse.swift */,
 			);
 			path = Response;
+			sourceTree = "<group>";
+		};
+		BABB0118297ED405004178EC /* Interest */ = {
+			isa = PBXGroup;
+			children = (
+				BABB0119297ED415004178EC /* InterestViewController.swift */,
+			);
+			path = Interest;
 			sourceTree = "<group>";
 		};
 		BAC923DD29546BF000385841 /* Birth */ = {
@@ -1019,6 +1030,7 @@
 				C36CE39A297305E100E3A68C /* CreateMeetingTitleView.swift in Sources */,
 				BA4C46CA297ADB5900C914F3 /* ProfileViewModel.swift in Sources */,
 				BA340E1A297822A8002BAF2C /* ParticipantListHeaderView.swift in Sources */,
+				BABB011A297ED415004178EC /* InterestViewController.swift in Sources */,
 				BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */,
 				7095A58C292FB0B6002A52E6 /* InterestTypeCollectionViewCell.swift in Sources */,
 				BA780E1129713BF30032C178 /* ParameterType.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		BA8E2B4829746881009DDF32 /* SignInResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8E2B4729746881009DDF32 /* SignInResponse.swift */; };
 		BA94E81C297E706A00DF23CE /* IntroductionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA94E81B297E706A00DF23CE /* IntroductionViewModel.swift */; };
 		BABB011A297ED415004178EC /* InterestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB0119297ED415004178EC /* InterestViewController.swift */; };
+		BABB011C297ED74C004178EC /* InterestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB011B297ED74C004178EC /* InterestViewModel.swift */; };
 		BAC8930929755B87000D44E2 /* SignUpRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC8930829755B87000D44E2 /* SignUpRequest.swift */; };
 		BAC923DF29546BF500385841 /* BirthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC923DE29546BF500385841 /* BirthViewController.swift */; };
 		BAE16029292221ED00D595FF /* CheckBoxButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE16028292221ED00D595FF /* CheckBoxButton.swift */; };
@@ -246,6 +247,7 @@
 		BA8E2B4729746881009DDF32 /* SignInResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInResponse.swift; sourceTree = "<group>"; };
 		BA94E81B297E706A00DF23CE /* IntroductionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionViewModel.swift; sourceTree = "<group>"; };
 		BABB0119297ED415004178EC /* InterestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewController.swift; sourceTree = "<group>"; };
+		BABB011B297ED74C004178EC /* InterestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewModel.swift; sourceTree = "<group>"; };
 		BAC8930829755B87000D44E2 /* SignUpRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequest.swift; sourceTree = "<group>"; };
 		BAC923DE29546BF500385841 /* BirthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthViewController.swift; sourceTree = "<group>"; };
 		BAE058E528EC7CEC00F09BD8 /* PLUB.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PLUB.entitlements; sourceTree = "<group>"; };
@@ -726,6 +728,7 @@
 			isa = PBXGroup;
 			children = (
 				BABB0119297ED415004178EC /* InterestViewController.swift */,
+				BABB011B297ED74C004178EC /* InterestViewModel.swift */,
 			);
 			path = Interest;
 			sourceTree = "<group>";
@@ -1034,6 +1037,7 @@
 				BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */,
 				7095A58C292FB0B6002A52E6 /* InterestTypeCollectionViewCell.swift in Sources */,
 				BA780E1129713BF30032C178 /* ParameterType.swift in Sources */,
+				BABB011C297ED74C004178EC /* InterestViewModel.swift in Sources */,
 				BA780E1329713F370032C178 /* BaseService.swift in Sources */,
 				70F1DFDC29795C9000F9BC83 /* SubCategoryListResponse.swift in Sources */,
 				70BD5F272959F718002CBA89 /* UIView + extension.swift in Sources */,

--- a/PLUB/Sources/Views/Login/Interest/InterestViewController.swift
+++ b/PLUB/Sources/Views/Login/Interest/InterestViewController.swift
@@ -16,6 +16,8 @@ final class InterestViewController: BaseViewController {
   
   private let viewModel = InterestViewModel()
   
+  weak var delegate: SignUpChildViewControllerDelegate?
+  
   private var registerInterestModels: [RegisterInterestModel] = [] {
     didSet {
       tableView.reloadData()
@@ -51,6 +53,16 @@ final class InterestViewController: BaseViewController {
     
     viewModel.fetchData
       .drive(rx.registerInterestModels)
+      .disposed(by: disposeBag)
+    
+    Driver.combineLatest(viewModel.isButtonEnabled, viewModel.selectedSubCategories)
+      .drive(with: self, onNext: { owner, tuple in
+        let flag = tuple.0
+        let categories = tuple.1
+        
+        // TODO: 승현 - delegate에게 카테고리 정보 전달
+        owner.delegate?.checkValidation(index: 4, state: flag)
+      })
       .disposed(by: disposeBag)
   }
 }

--- a/PLUB/Sources/Views/Login/Interest/InterestViewController.swift
+++ b/PLUB/Sources/Views/Login/Interest/InterestViewController.swift
@@ -14,4 +14,113 @@ import Then
 
 final class InterestViewController: BaseViewController {
   
+  private let viewModel = InterestViewModel()
+  
+  private var registerInterestModels: [RegisterInterestModel] = [] {
+    didSet {
+      tableView.reloadData()
+    }
+  }
+  
+  private lazy var tableView = UITableView(frame: .zero, style: .grouped).then {
+    $0.separatorStyle = .none
+    $0.backgroundColor = .secondarySystemBackground
+    $0.sectionHeaderHeight = .leastNonzeroMagnitude
+    $0.sectionFooterHeight = .leastNonzeroMagnitude
+    $0.showsVerticalScrollIndicator = false
+    $0.register(RegisterInterestTableViewCell.self, forCellReuseIdentifier: RegisterInterestTableViewCell.identifier)
+    $0.register(RegisterInterestDetailTableViewCell.self, forCellReuseIdentifier: RegisterInterestDetailTableViewCell.identifier)
+    $0.dataSource = self
+    $0.delegate = self
+  }
+  
+  override func setupLayouts() {
+    super.setupLayouts()
+    view.addSubview(tableView)
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    tableView.snp.makeConstraints {
+      $0.directionalEdges.equalToSuperview()
+    }
+  }
+  
+  override func bind() {
+    super.bind()
+  }
+}
+
+// MARK: - UITableViewDataSource
+
+extension InterestViewController: UITableViewDataSource {
+  func numberOfSections(in tableView: UITableView) -> Int {
+    return registerInterestModels.count
+  }
+  
+  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    if registerInterestModels[section].isExpanded {
+      return 2
+    }
+    return 1
+  }
+  
+  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    if indexPath.row == 0 {
+      let cell = tableView.dequeueReusableCell(withIdentifier: RegisterInterestTableViewCell.identifier, for: indexPath) as? RegisterInterestTableViewCell ?? RegisterInterestTableViewCell()
+      cell.configureUI(with: registerInterestModels[indexPath.section])
+      cell.delegate = self
+      return cell
+    } else {
+      let cell = tableView.dequeueReusableCell(withIdentifier: RegisterInterestDetailTableViewCell.identifier, for: indexPath) as? RegisterInterestDetailTableViewCell ?? RegisterInterestDetailTableViewCell()
+      cell.configureUI(with: registerInterestModels[indexPath.section], indexPath: indexPath)
+      cell.delegate = self
+      return cell
+    }
+  }
+}
+
+// MARK: - UITableViewDelegate
+
+extension InterestViewController: UITableViewDelegate {
+  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    tableView.deselectRow(at: indexPath, animated: true)
+    
+    if indexPath.row == 0 {
+      registerInterestModels[indexPath.section].isExpanded.toggle()
+      tableView.reloadSections([indexPath.section], with: .none)
+    }
+  }
+  
+  func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+    return UITableView.automaticDimension
+  }
+  
+  func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    if indexPath.row == 0 {
+      return 80
+    }
+    
+    let valuable = ceil(CGFloat(registerInterestModels[indexPath.section].category.subCategories.count / 4))
+    return (valuable + 1) * 32 + 16 + 16 + valuable * 8
+  }
+}
+
+// MARK: - RegisterInterestTableViewCellDelegate
+
+extension InterestViewController: RegisterInterestTableViewCellDelegate {
+  func didTappedIndicatorButton(cell: RegisterInterestTableViewCell) {
+    guard let indexPath = tableView.indexPath(for: cell) else { return }
+    registerInterestModels[indexPath.section].isExpanded.toggle()
+    tableView.reloadSections([indexPath.section], with: .none)
+  }
+}
+
+// MARK: - RegisterInterestDetailTableViewCellDelegate
+
+extension InterestViewController: RegisterInterestDetailTableViewCellDelegate {
+  func didTappedInterestTypeCollectionViewCell(cell: InterestTypeCollectionViewCell, mainIndexPath: IndexPath, subIndexPath: IndexPath) {
+    registerInterestModels[mainIndexPath.section].category.subCategories[subIndexPath.row].isSelected.toggle()
+    cell.isTapped.toggle()
+  }
 }

--- a/PLUB/Sources/Views/Login/Interest/InterestViewController.swift
+++ b/PLUB/Sources/Views/Login/Interest/InterestViewController.swift
@@ -1,0 +1,17 @@
+//
+//  InterestViewController.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/01/23.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
+
+final class InterestViewController: BaseViewController {
+  
+}

--- a/PLUB/Sources/Views/Login/Interest/InterestViewController.swift
+++ b/PLUB/Sources/Views/Login/Interest/InterestViewController.swift
@@ -48,6 +48,10 @@ final class InterestViewController: BaseViewController {
   
   override func bind() {
     super.bind()
+    
+    viewModel.fetchData
+      .drive(rx.registerInterestModels)
+      .disposed(by: disposeBag)
   }
 }
 
@@ -121,6 +125,9 @@ extension InterestViewController: RegisterInterestTableViewCellDelegate {
 extension InterestViewController: RegisterInterestDetailTableViewCellDelegate {
   func didTappedInterestTypeCollectionViewCell(cell: InterestTypeCollectionViewCell, mainIndexPath: IndexPath, subIndexPath: IndexPath) {
     registerInterestModels[mainIndexPath.section].category.subCategories[subIndexPath.row].isSelected.toggle()
+    let id = registerInterestModels[mainIndexPath.section].category.subCategories[subIndexPath.row].id
     cell.isTapped.toggle()
+    // 카테고리가 선택되거나 취소되었다면, 해당 카테고리의 id를 이용하여 emit
+    cell.isTapped ? viewModel.selectSubCategory.onNext(id) : viewModel.deselectSubCategory.onNext(id)
   }
 }

--- a/PLUB/Sources/Views/Login/Interest/InterestViewModel.swift
+++ b/PLUB/Sources/Views/Login/Interest/InterestViewModel.swift
@@ -10,4 +10,36 @@ import RxCocoa
 
 final class InterestViewModel {
   
+  // Input
+  let selectSubCategory: AnyObserver<Int>   // 선택된 카테고리의 id
+  let deselectSubCategory: AnyObserver<Int> // 취소한 카테고리의 id
+  
+  // Output
+  let fetchData: Driver<[RegisterInterestModel]>  // tableView data fetch
+  let selectedSubCategories: Driver<[Int]>        // 선택된 카테고리의 id 배열
+  let isButtonEnabled: Driver<Bool>               // 버튼 활성화 여부
+  
+  /// fetch한 카테고리 데이터
+  private let fetchedCategoriesSubject = BehaviorSubject<[RegisterInterestModel]>(value: [])
+  
+  /// 선택된 카테고리의 `Subject`
+  private let selectSubject = PublishSubject<Int>()
+  
+  /// 취소된 카테고리의 `Subject`
+  private let deselectSubject = PublishSubject<Int>()
+  
+  /// 선택된 카테고리의 `Relay`
+  private let selectedSubCategoriesRelay = BehaviorRelay<[Int]>(value: [])
+  
+  private let disposeBag = DisposeBag()
+  
+  init() {
+    fetchData = fetchedCategoriesSubject.asDriver(onErrorDriveWith: .empty())
+    selectSubCategory = selectSubject.asObserver()
+    deselectSubCategory = deselectSubject.asObserver()
+    isButtonEnabled = selectedSubCategoriesRelay
+      .map { $0.count != 0 }
+      .asDriver(onErrorJustReturn: false)
+    selectedSubCategories = selectedSubCategoriesRelay.asDriver()
+  }
 }

--- a/PLUB/Sources/Views/Login/Interest/InterestViewModel.swift
+++ b/PLUB/Sources/Views/Login/Interest/InterestViewModel.swift
@@ -20,7 +20,7 @@ final class InterestViewModel {
   let isButtonEnabled: Driver<Bool>               // 버튼 활성화 여부
   
   /// fetch한 카테고리 데이터
-  private let fetchedCategoriesSubject = BehaviorSubject<[RegisterInterestModel]>(value: [])
+  private let fetchedCategoriesRelay = BehaviorRelay<[RegisterInterestModel]>(value: [])
   
   /// 선택된 카테고리의 `Subject`
   private let selectSubject = PublishSubject<Int>()
@@ -34,7 +34,7 @@ final class InterestViewModel {
   private let disposeBag = DisposeBag()
   
   init() {
-    fetchData = fetchedCategoriesSubject.asDriver(onErrorDriveWith: .empty())
+    fetchData = fetchedCategoriesRelay.asDriver()
     selectSubCategory = selectSubject.asObserver()
     deselectSubCategory = deselectSubject.asObserver()
     // emit array of categories when selected categories
@@ -55,7 +55,7 @@ final class InterestViewModel {
         return allCategoryResponse.data?.categories
       }
       .map { return $0.map { RegisterInterestModel(category: $0) } }
-      .bind(to: fetchedCategoriesSubject)
+      .bind(to: fetchedCategoriesRelay)
       .disposed(by: disposeBag)
     
     // insert subcategory's id in `selectedSubCategoriesRelay`

--- a/PLUB/Sources/Views/Login/Interest/InterestViewModel.swift
+++ b/PLUB/Sources/Views/Login/Interest/InterestViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  InterestViewModel.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/01/23.
+//
+
+import RxSwift
+import RxCocoa
+
+final class InterestViewModel {
+  
+}

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -45,7 +45,8 @@ final class SignUpViewController: BaseViewController {
     PolicyViewController().then { $0.delegate = self },
     BirthViewController().then { $0.delegate = self },
     ProfileViewController().then { $0.delegate = self },
-    IntroductionViewController().then { $0.delegate = self }
+    IntroductionViewController().then { $0.delegate = self },
+    InterestViewController().then { $0.delegate = self }
   ]
   
   // MARK: UI Properties


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- Home에서 작업한 관심사 선택 tableView를 재사용하였습니다.
   > 근데 ViewController를 재사용할 수 없어서 `Boilerplate code`가 되어버렸습니다. 재사용할 수 있도록 구현하면 좋겠네요.

🌱 PR 포인트
- tableView 세팅은 Home이랑 똑같습니다. 단지 셀이 선택될 때 `onNext(())`가 `onNext(id)`로 바뀐 것 빼고는 없는 것 같아요.
- ViewModel 역시 비슷하게 가져갔는데, 저는 카테고리의 id값을 처리해야했기에 셀의 선택을 감지하는 Subject의 타입을 `Void`가 아닌 `Int`로 받았습니다.

## 📸 스크린샷
|스크린샷|
|:--:|
|![RPReplay_Final1674571373](https://user-images.githubusercontent.com/57972338/214325062-e125267a-e6c7-4950-9ad8-d8dbacb2c7e6.gif)|
## 📮 관련 이슈
- Resolved: #59

