### PR TITLE
[Feat] 이미지 파일 업로드 API 연결

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -158,6 +158,10 @@
 		C3AB7441296B21E6003DD5E2 /* MeetingQuestionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AB7440296B21E6003DD5E2 /* MeetingQuestionViewController.swift */; };
 		C3AD265D296ACC0600C57370 /* MeetingNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AD265C296ACC0600C57370 /* MeetingNameViewController.swift */; };
 		C3AD265F296AD3C100C57370 /* InputTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AD265E296AD3C100C57370 /* InputTextView.swift */; };
+		C3B04E4229816B9C00188E60 /* ImageRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B04E4129816B9C00188E60 /* ImageRouter.swift */; };
+		C3B04E4429816C7E00188E60 /* ImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B04E4329816C7E00188E60 /* ImageService.swift */; };
+		C3B04E462981788800188E60 /* UploadImageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B04E452981788800188E60 /* UploadImageRequest.swift */; };
+		C3B04E482981789A00188E60 /* UploadImageResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B04E472981789A00188E60 /* UploadImageResponse.swift */; };
 		C3D9807A297D982E00B8F5DF /* MeetingQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D98079297D982E00B8F5DF /* MeetingQuestionViewModel.swift */; };
 		C3DE688B2976CF120079B76F /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DE688A2976CF120079B76F /* BottomSheetViewController.swift */; };
 		C3E98EAD2974759800E36C45 /* MeetingNameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E98EAC2974759800E36C45 /* MeetingNameViewModel.swift */; };
@@ -309,6 +313,10 @@
 		C3AB7440296B21E6003DD5E2 /* MeetingQuestionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingQuestionViewController.swift; sourceTree = "<group>"; };
 		C3AD265C296ACC0600C57370 /* MeetingNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingNameViewController.swift; sourceTree = "<group>"; };
 		C3AD265E296AD3C100C57370 /* InputTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputTextView.swift; sourceTree = "<group>"; };
+		C3B04E4129816B9C00188E60 /* ImageRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRouter.swift; sourceTree = "<group>"; };
+		C3B04E4329816C7E00188E60 /* ImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageService.swift; sourceTree = "<group>"; };
+		C3B04E452981788800188E60 /* UploadImageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadImageRequest.swift; sourceTree = "<group>"; };
+		C3B04E472981789A00188E60 /* UploadImageResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadImageResponse.swift; sourceTree = "<group>"; };
 		C3D98079297D982E00B8F5DF /* MeetingQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingQuestionViewModel.swift; sourceTree = "<group>"; };
 		C3DE688A2976CF120079B76F /* BottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
 		C3E98EAC2974759800E36C45 /* MeetingNameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingNameViewModel.swift; sourceTree = "<group>"; };
@@ -682,6 +690,7 @@
 				70F1DFD5297950DD00F9BC83 /* CategoryRouter.swift */,
 				70F1DFDD297A8A6C00F9BC83 /* MeetingRouter.swift */,
 				70F1DFE7297D969000F9BC83 /* RecruitmentRouter.swift */,
+				C3B04E4129816B9C00188E60 /* ImageRouter.swift */,
 			);
 			path = Routers;
 			sourceTree = "<group>";
@@ -695,6 +704,7 @@
 				70F1DFD32979508000F9BC83 /* CategoryService.swift */,
 				70F1DFDF297A90AE00F9BC83 /* MeetingService.swift */,
 				70F1DFE9297D992100F9BC83 /* RecruitmentService.swift */,
+				C3B04E4329816C7E00188E60 /* ImageService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -746,6 +756,7 @@
 				BAC8930829755B87000D44E2 /* SignUpRequest.swift */,
 				BAE5D3342975B10F00268D44 /* ReissuanceRequest.swift */,
 				C38A5B9A297AE05100485355 /* KakaoLocationRequest.swift */,
+				C3B04E452981788800188E60 /* UploadImageRequest.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -756,6 +767,7 @@
 				BA8E2B4729746881009DDF32 /* SignInResponse.swift */,
 				BAE5D3362975B20000268D44 /* TokenResponse.swift */,
 				C38A5B98297ADE8500485355 /* KakaoLocationResponse.swift */,
+				C3B04E472981789A00188E60 /* UploadImageResponse.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -959,6 +971,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C38A5BA5297B234100485355 /* LocationTableViewCell.swift in Sources */,
+				C3B04E462981788800188E60 /* UploadImageRequest.swift in Sources */,
 				C36D337D2975ADD800943B11 /* Ex+CALayer.swift in Sources */,
 				70BD5F35296491C8002CBA89 /* ApplyQuestionHeaderView.swift in Sources */,
 				C3FA748C2974984800A8BE4C /* MeetingIntroduceViewModel.swift in Sources */,
@@ -1003,6 +1016,7 @@
 				C3DE688B2976CF120079B76F /* BottomSheetViewController.swift in Sources */,
 				C34C097029773860001AFF16 /* DateBottomSheetViewController.swift in Sources */,
 				C38A5B9D297AFDCD00485355 /* LocationBottomSheetViewController.swift in Sources */,
+				C3B04E4229816B9C00188E60 /* ImageRouter.swift in Sources */,
 				BA8E2B4429746738009DDF32 /* AuthRouter.swift in Sources */,
 				BA94E81C297E706A00DF23CE /* IntroductionViewModel.swift in Sources */,
 				7036A3EB294E3E810041B8DD /* RegisterInterestDetailTableViewCell.swift in Sources */,
@@ -1034,6 +1048,7 @@
 				C371CDB229784F4E008950DD /* WeekDateCollectionViewCell.swift in Sources */,
 				70BD5F3929684EAC002CBA89 /* HomeAlert.swift in Sources */,
 				BA771652296FBF4400762362 /* KeyChainWrapper.swift in Sources */,
+				C3B04E4429816C7E00188E60 /* ImageService.swift in Sources */,
 				BA340E2029782301002BAF2C /* LeftAlignedCollectionViewFlowLayout.swift in Sources */,
 				BA88126228E48A5800BD832A /* BaseViewController.swift in Sources */,
 				BA7AD73E297D6720000E7D5D /* BirthViewModel.swift in Sources */,
@@ -1078,6 +1093,7 @@
 				C3AD265D296ACC0600C57370 /* MeetingNameViewController.swift in Sources */,
 				C38A5B99297ADE8500485355 /* KakaoLocationResponse.swift in Sources */,
 				0A81767F28F3105200C1E074 /* Preview.swift in Sources */,
+				C3B04E482981789A00188E60 /* UploadImageResponse.swift in Sources */,
 				C3AD265F296AD3C100C57370 /* InputTextView.swift in Sources */,
 				BA340E1829782280002BAF2C /* ParticipantListCollectionViewCell.swift in Sources */,
 				BAE1AD972944C16600CE36B9 /* PolicyHeaderTableViewCell.swift in Sources */,

--- a/PLUB/Sources/Models/Request/UploadImageRequest.swift
+++ b/PLUB/Sources/Models/Request/UploadImageRequest.swift
@@ -1,0 +1,35 @@
+//
+//  UploadImageRequest.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/01/25.
+//
+
+/// 이미지 업로드 요청값
+struct UploadImageRequest: Codable {
+  
+  /// 타입 설정
+  let type: String
+}
+
+enum ImageType {
+  
+  /// 프로필 이미지
+  case profile
+  
+  /// 플러빙 메인 이미지
+  case plubbingMain
+}
+
+extension ImageType {
+  
+  var value: String {
+    switch self {
+    case .profile:
+      return "profile"
+      
+    case .plubbingMain:
+      return "plubbing-main"
+    }
+  }
+}

--- a/PLUB/Sources/Models/Response/UploadImageResponse.swift
+++ b/PLUB/Sources/Models/Response/UploadImageResponse.swift
@@ -1,0 +1,20 @@
+//
+//  UploadImageResponse.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/01/25.
+//
+
+struct UploadImageResponse: Codable {
+  var files: [Files]
+}
+
+struct Files: Codable {
+  var fileName: String?
+  var fileUrl: String?
+  
+  enum CodingKeys: String, CodingKey {
+    case fileName = "filename"
+    case fileUrl = "fileUrl"
+  }
+}

--- a/PLUB/Sources/Network/Foundation/HeaderType.swift
+++ b/PLUB/Sources/Network/Foundation/HeaderType.swift
@@ -14,6 +14,7 @@ enum HeaderType {
   case withAccessToken
   case withRefreshToken
   case withKakaoLocationKey
+  case formData
 }
 
 extension HeaderType {
@@ -46,10 +47,25 @@ extension HeaderType {
       defaultHeaders.add(.authorization(bearerToken: token))
       defaultHeaders.add(.contentType("application/json"))
       return defaultHeaders
+      
     case .withKakaoLocationKey:
       // default 헤더 값에 `Authorization kakaoLocationKey 추가`
       var defaultHeaders = HTTPHeaders.default
       defaultHeaders.add(.authorization(KeyConstants.kakaoLocationKey))
+      return defaultHeaders
+      
+    case .formData:
+      // default 헤더 값에 `multipart/form-data` 추가
+      var defaultHeaders = HTTPHeaders.default
+      defaultHeaders.add(.contentType("multipart/form-data"))
+      
+      // 토큰이 존재하지 않는 경우 default 리턴
+      guard let token = UserManager.shared.accessToken else {
+        return defaultHeaders
+      }
+      
+      // 토큰이 존재하는 경우 `Authorization token` 추가
+      defaultHeaders.add(.authorization(bearerToken: token))
       return defaultHeaders
     }
   }

--- a/PLUB/Sources/Network/Routers/ImageRouter.swift
+++ b/PLUB/Sources/Network/Routers/ImageRouter.swift
@@ -1,0 +1,57 @@
+//
+//  ImageRouter.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/01/25.
+//
+
+import Alamofire
+
+enum ImageRouter {
+  case uploadImage
+  case updateImage
+  case deleteImage
+}
+
+extension ImageRouter: Router {
+  
+  var method: HTTPMethod {
+    switch self {
+    case .uploadImage, .updateImage:
+      return .post
+    case .deleteImage:
+      return .delete
+    }
+  }
+  
+  var path: String {
+    switch self {
+    case .uploadImage:
+      return "/files"
+    case .updateImage:
+      return "/files/change"
+    case .deleteImage:
+      return "/api/files"
+    }
+  }
+  
+  var parameters: ParameterType {
+    switch self {
+    case .uploadImage:
+      return .plain
+    case .updateImage:
+      return .plain
+    case .deleteImage:
+      return .plain
+    }
+  }
+  
+  var headers: HeaderType {
+    switch self {
+    case .uploadImage, .updateImage:
+      return .formData
+    case .deleteImage:
+      return .withAccessToken
+    }
+  }
+}

--- a/PLUB/Sources/Network/Routers/ImageRouter.swift
+++ b/PLUB/Sources/Network/Routers/ImageRouter.swift
@@ -37,11 +37,7 @@ extension ImageRouter: Router {
   
   var parameters: ParameterType {
     switch self {
-    case .uploadImage:
-      return .plain
-    case .updateImage:
-      return .plain
-    case .deleteImage:
+    case .uploadImage, .updateImage, .deleteImage:
       return .plain
     }
   }

--- a/PLUB/Sources/Network/Services/ImageService.swift
+++ b/PLUB/Sources/Network/Services/ImageService.swift
@@ -5,14 +5,13 @@
 //  Created by 김수빈 on 2023/01/25.
 //
 
-import Foundation
 import UIKit
 
 import Alamofire
 import RxCocoa
 import RxSwift
 
-class ImageService: BaseService {
+final class ImageService: BaseService {
   static let shared = ImageService()
   
   private override init() { }

--- a/PLUB/Sources/Network/Services/ImageService.swift
+++ b/PLUB/Sources/Network/Services/ImageService.swift
@@ -24,7 +24,10 @@ extension ImageService {
     params: UploadImageRequest
   ) -> Observable<NetworkResult<GeneralResponse<UploadImageResponse>>> {
     return sendRequestWithImage(
-      setUpImageData(images: images, params: params.toDictionary),
+      setUpImageData(
+        images: images,
+        params: params.toDictionary
+      ),
       ImageRouter.uploadImage,
       type: UploadImageResponse.self
     )
@@ -36,20 +39,22 @@ extension ImageService {
   ) -> MultipartFormData {
     let formData = MultipartFormData()
 
-    for i in 0..<images.count {
-      guard let imageData = images[i].jpegData(compressionQuality: 0.1)
-      else { continue }
+    for image in images {
+      guard let imageData = image.jpegData(compressionQuality: 0.1) else { continue }
       formData.append(
         imageData,
         withName: "files",
-        fileName: "\(images[i]).jpeg",
+        fileName: "\(image).jpeg",
         mimeType: "image/jpeg"
       )
     }
     
     for (key, value) in params {
       guard let value = value as? String else { continue }
-      formData.append(Data(value.utf8), withName: key)
+      formData.append(
+        Data(value.utf8),
+        withName: key
+      )
     }
     
     return formData

--- a/PLUB/Sources/Network/Services/ImageService.swift
+++ b/PLUB/Sources/Network/Services/ImageService.swift
@@ -1,0 +1,57 @@
+//
+//  ImageService.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/01/25.
+//
+
+import Foundation
+import UIKit
+
+import Alamofire
+import RxCocoa
+import RxSwift
+
+class ImageService: BaseService {
+  static let shared = ImageService()
+  
+  private override init() { }
+}
+
+extension ImageService {
+  func uploadImage(
+    images: [UIImage],
+    params: UploadImageRequest
+  ) -> Observable<NetworkResult<GeneralResponse<UploadImageResponse>>> {
+    return sendRequestWithImage(
+      setUpImageData(images: images, params: params.toDictionary),
+      ImageRouter.uploadImage,
+      type: UploadImageResponse.self
+    )
+  }
+  
+  private func setUpImageData(
+    images: [UIImage],
+    params: [String: Any]
+  ) -> MultipartFormData {
+    let formData = MultipartFormData()
+
+    for i in 0..<images.count {
+      guard let imageData = images[i].jpegData(compressionQuality: 0.1)
+      else { continue }
+      formData.append(
+        imageData,
+        withName: "files",
+        fileName: "\(images[i]).jpeg",
+        mimeType: "image/jpeg"
+      )
+    }
+    
+    for (key, value) in params {
+      guard let value = value as? String else { continue }
+      formData.append(Data(value.utf8), withName: key)
+    }
+    
+    return formData
+  }
+}

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingIntroduceViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingIntroduceViewController.swift
@@ -179,5 +179,20 @@ extension MeetingIntroduceViewController: PhotoBottomSheetDelegate {
     photoSelectView.snp.updateConstraints {
       $0.height.equalTo(width * image.size.height / image.size.width)
     }
+    
+    ImageService.shared.uploadImage(images: [image], params: UploadImageRequest(type: ImageType.plubbingMain.value))
+      .subscribe(onNext: { result in
+        switch result {
+        case .success(let model):
+          print(model)
+          
+        case .requestError(let model):
+          print(model)
+        case .networkError, .serverError, .pathError:
+          // TODO: 수빈 - PLUB 에러 Alert 띄우기
+          break
+        }
+      })
+      .disposed(by: disposeBag)
   }
 }


### PR DESCRIPTION
## 📌 PR 요약
이미지 파일 업로드 로직 설계 및 API를 연결해보았습니다.

## 🌱 작업한 내용

- HeaderType에 `formData` type 추가
: contentType("multipart/form-data")으로 보내기 위한 type을 추가하였습니다.
--> 토큰 존재하면 같이 동봉하도록 하였습니다.(이미지 수정 API 시에도 동일하게 활용하기 위함)

- BaseService에 `sendRequestWithImage` 함수 추가
: 기존 sendRequest 함수와 거의 동일하지만, `MultipartFormData`를 추가로 동봉합니다.
--> AF.upload 함수 활용, 응답값은 sendRequest와 동일합니다.

- ImageRouter 추가
: 기존 라우터들과 동일하게 구현
--> parameters에 아무것도 보내지 않음(.plain)
--> MultipartFormData에 image/param 데이터를 둘다 동봉하기 때문
--> deleteImage는 아직 작업 전입니다. 참고만 해주세요.

- ImageService 추가
: 기존의 서비스들과 동일하게 구현
--> `setUpImageData`함수로 `MultipartFormData` 생성
--> `uploadImage`: 이미지 업로드 함수입니다. 이미지배열과 params를 따로 받아와야함.

## 🌱 pr 포인트

- 이미지 포맷은 안드로이드와 `jpeg`로 맞췄습니다.
- `압축 퀄리티(compressionQuality)`는 0.5를 초과해서 보낼 경우 서버에서 용량 초과 에러가 떨어져서 임시로 0.1로 지정했습니다. 
--> 추후 이미지 용량이 20MB를 초과할 경우 압축을 진행하는 형태로 로직을 수정할 계획입니다.

- 테스트 코드
    
    ```jsx
    ImageService.shared.uploadImage(images: [image], params: UploadImageRequest(type: ImageType.plubbingMain.value))
    	.subscribe(onNext: { result in
    	  switch result {
    	  case .success(let model):
    	    print(model)
    	    
    	  case .requestError(let model):
    	    print(model)
    	
    	  case .networkError, .serverError, .pathError:
    	    // TODO: 수빈 - PLUB 에러 Alert 띄우기
    	    break
    	  }
    	})
    	.disposed(by: disposeBag)
    ```

## 📸 스크린샷

- response 값

![스크린샷 2023-01-26 오전 1 49 44](https://user-images.githubusercontent.com/77331348/214635403-3c4071fc-0b55-471d-96d7-0cf6ba704391.png)

- fileUrl
https://s3.ap-northeast-2.amazonaws.com/plub/plubbing/mainImage/anonymousUser_d42113b9-4c00-4b99-ac40-4fb43c9f396b_.jpeg

## 📮 관련 이슈
- Resolved: #68 

