### PR TITLE
[FEAT] 모집상세페이지 참여자에 대한 프로필정보 UI 

### DIFF
--- a/PLUB/SceneDelegate.swift
+++ b/PLUB/SceneDelegate.swift
@@ -18,7 +18,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     guard let windowScene = scene as? UIWindowScene else { return }
     window = UIWindow(windowScene: windowScene)
     window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
-    window?.rootViewController = UINavigationController(rootViewController: DetailRecruitmentViewController(plubbingId: 0))
     window?.makeKeyAndVisible()
   }
   

--- a/PLUB/SceneDelegate.swift
+++ b/PLUB/SceneDelegate.swift
@@ -18,6 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     guard let windowScene = scene as? UIWindowScene else { return }
     window = UIWindow(windowScene: windowScene)
     window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
+    window?.rootViewController = UINavigationController(rootViewController: DetailRecruitmentViewController(plubbingId: 0))
     window?.makeKeyAndVisible()
   }
   

--- a/PLUB/Sources/Views/Home/Component/IntroduceCategoryInfoView.swift
+++ b/PLUB/Sources/Views/Home/Component/IntroduceCategoryInfoView.swift
@@ -47,7 +47,8 @@ class IntroduceCategoryInfoView: UIView {
     
     categoryInfoListView.snp.makeConstraints {
       $0.top.equalTo(meetingRecommendedLabel.snp.bottom)
-      $0.centerX.equalToSuperview()
+      $0.left.equalToSuperview()
+      $0.right.lessThanOrEqualToSuperview()
     }
     
     meetingImageView.snp.makeConstraints {

--- a/PLUB/Sources/Views/Home/Component/ParticipantListView.swift
+++ b/PLUB/Sources/Views/Home/Component/ParticipantListView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Kingfisher
 import SnapKit
 import Then
 
@@ -35,7 +36,10 @@ class ParticipantListView: UIView {
   private let moreButton = UIButton().then {
     $0.backgroundColor = .lightGray
     $0.tintColor = .deepGray
+    $0.titleLabel?.textAlignment = .center
     $0.layer.masksToBounds = true
+    $0.clipsToBounds = true
+    $0.isHidden = true
   }
   
   override init(frame: CGRect) {
@@ -49,8 +53,8 @@ class ParticipantListView: UIView {
   
   override func layoutSubviews() {
     super.layoutSubviews()
-    let moreButtonSize = moreButton.frame.size
-    moreButton.layer.cornerRadius = moreButtonSize.width / 2
+    let moreButtonSize = moreButton.bounds.size
+    moreButton.layer.cornerRadius = moreButtonSize.height / 2.0
   }
   
   private func configureUI() {
@@ -62,11 +66,12 @@ class ParticipantListView: UIView {
     
     participantListStackView.snp.makeConstraints {
       $0.top.equalTo(participantTitleLabel.snp.bottom).offset(7)
-      $0.left.right.bottom.equalToSuperview()
+      $0.left.bottom.equalToSuperview()
+      $0.right.lessThanOrEqualToSuperview()
     }
     
     moreButton.snp.makeConstraints {
-      $0.width.height.equalTo(34)
+      $0.size.equalTo(34)
     }
 
     moreButton.addTarget(self, action: #selector(didTappedMoreButton), for: .touchUpInside)
@@ -74,11 +79,25 @@ class ParticipantListView: UIView {
   
   public func configureUI(with model: [AccountInfo]) {
     let joinedCount = model.count
-    guard joinedCount < 1 else { return }
+    guard joinedCount > 0 else { return }
     if joinedCount <= 8 {
-      
-    } else { // 9명 이상일때
-      
+      model.forEach { account in
+        let participantImageView = ParticipantImageView(frame: .zero)
+        participantImageView.configureUI(with: account.profileImage)
+        participantListStackView.addArrangedSubview(participantImageView)
+      }
+    }
+    else { // 9명 이상일때
+      let moreCount = joinedCount - 7
+      moreButton.isHidden = false
+      moreButton.setTitle("+\(moreCount)", for: .normal)
+      for index in 0..<7 {
+        let participantImageView = ParticipantImageView(frame: .zero)
+        participantImageView.configureUI(with: model[index].profileImage)
+        participantListStackView.addArrangedSubview(participantImageView)
+      }
+      participantListStackView.addArrangedSubview(moreButton)
+      moreButton.layoutIfNeeded()
     }
   }
   
@@ -87,9 +106,9 @@ class ParticipantListView: UIView {
   }
 }
 
-final class ParticipantImageView: UIImageView {
+class ParticipantImageView: UIImageView {
   override init(frame: CGRect) {
-    super.init(frame: frame)
+    super.init(frame: .zero)
     configureUI()
   }
   
@@ -99,8 +118,8 @@ final class ParticipantImageView: UIImageView {
   
   override func layoutSubviews() {
     super.layoutSubviews()
-    let imageSize = self.bounds.size.width
-    layer.cornerRadius = imageSize / 2
+    let imageSize = self.bounds.size
+    layer.cornerRadius = imageSize.width / 2.0
   }
   
   private func configureUI() {
@@ -108,8 +127,13 @@ final class ParticipantImageView: UIImageView {
     contentMode = .scaleAspectFit
     image = UIImage(systemName: "person.fill")
     backgroundColor = .yellow
-    snp.makeConstraints { make in
-      make.size.equalTo(34)
+    snp.makeConstraints {
+      $0.size.equalTo(34)
     }
+  }
+  
+  public func configureUI(with model: String?) {
+    guard let url = URL(string: model ?? "") else { return }
+    kf.setImage(with: url)
   }
 }

--- a/PLUB/Sources/Views/Home/Component/ParticipantListView.swift
+++ b/PLUB/Sources/Views/Home/Component/ParticipantListView.swift
@@ -124,9 +124,7 @@ class ParticipantImageView: UIImageView {
   
   private func configureUI() {
     layer.masksToBounds = true
-    contentMode = .scaleAspectFit
-    image = UIImage(systemName: "person.fill")
-    backgroundColor = .yellow
+    contentMode = .scaleAspectFill
     snp.makeConstraints {
       $0.size.equalTo(34)
     }

--- a/PLUB/Sources/Views/Home/Component/ParticipantListView.swift
+++ b/PLUB/Sources/Views/Home/Component/ParticipantListView.swift
@@ -32,10 +32,11 @@ class ParticipantListView: UIView {
     $0.axis = .horizontal
     $0.alignment = .leading
   }
-
+  
   private let moreButton = UIButton().then {
     $0.backgroundColor = .lightGray
     $0.tintColor = .deepGray
+    $0.titleLabel?.font = .overLine
     $0.titleLabel?.textAlignment = .center
     $0.layer.masksToBounds = true
     $0.clipsToBounds = true
@@ -73,18 +74,23 @@ class ParticipantListView: UIView {
     moreButton.snp.makeConstraints {
       $0.size.equalTo(34)
     }
-
+    
     moreButton.addTarget(self, action: #selector(didTappedMoreButton), for: .touchUpInside)
   }
   
+  private func addElement(model: AccountInfo) {
+    let participantImageView = ParticipantImageView(frame: .zero)
+    participantImageView.configureUI(with: model.profileImage)
+    participantListStackView.addArrangedSubview(participantImageView)
+  }
+  
   public func configureUI(with model: [AccountInfo]) {
+    let model = model.compactMap{ $0 }
     let joinedCount = model.count
     guard joinedCount > 0 else { return }
     if joinedCount <= 8 {
       model.forEach { account in
-        let participantImageView = ParticipantImageView(frame: .zero)
-        participantImageView.configureUI(with: account.profileImage)
-        participantListStackView.addArrangedSubview(participantImageView)
+        addElement(model: account)
       }
     }
     else { // 9명 이상일때
@@ -92,9 +98,7 @@ class ParticipantListView: UIView {
       moreButton.isHidden = false
       moreButton.setTitle("+\(moreCount)", for: .normal)
       for index in 0..<7 {
-        let participantImageView = ParticipantImageView(frame: .zero)
-        participantImageView.configureUI(with: model[index].profileImage)
-        participantListStackView.addArrangedSubview(participantImageView)
+        addElement(model: model[index])
       }
       participantListStackView.addArrangedSubview(moreButton)
       moreButton.layoutIfNeeded()

--- a/PLUB/Sources/Views/Home/Component/ParticipantListView.swift
+++ b/PLUB/Sources/Views/Home/Component/ParticipantListView.swift
@@ -26,19 +26,12 @@ class ParticipantListView: UIView {
     $0.sizeToFit()
   }
   
-  private lazy var participantListStackView = UIStackView(arrangedSubviews: [
-    profileImageView, moreButton
-  ]).then {
+  private let participantListStackView = UIStackView().then {
     $0.spacing = 8.05
     $0.axis = .horizontal
     $0.alignment = .leading
   }
-  
-  private let profileImageView = UIImageView().then {
-    $0.contentMode = .scaleAspectFit
-    $0.image = UIImage(systemName: "person.fill")
-  }
-  
+
   private let moreButton = UIButton().then {
     $0.backgroundColor = .lightGray
     $0.tintColor = .deepGray
@@ -72,10 +65,6 @@ class ParticipantListView: UIView {
       $0.left.right.bottom.equalToSuperview()
     }
     
-    profileImageView.snp.makeConstraints {
-      $0.width.height.equalTo(34)
-    }
-    
     moreButton.snp.makeConstraints {
       $0.width.height.equalTo(34)
     }
@@ -83,8 +72,44 @@ class ParticipantListView: UIView {
     moreButton.addTarget(self, action: #selector(didTappedMoreButton), for: .touchUpInside)
   }
   
+  public func configureUI(with model: [AccountInfo]) {
+    let joinedCount = model.count
+    guard joinedCount < 1 else { return }
+    if joinedCount <= 8 {
+      
+    } else { // 9명 이상일때
+      
+    }
+  }
+  
   @objc private func didTappedMoreButton() {
     delegate?.didTappedMoreButton()
   }
 }
 
+final class ParticipantImageView: UIImageView {
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    configureUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    let imageSize = self.bounds.size.width
+    layer.cornerRadius = imageSize / 2
+  }
+  
+  private func configureUI() {
+    layer.masksToBounds = true
+    contentMode = .scaleAspectFit
+    image = UIImage(systemName: "person.fill")
+    backgroundColor = .yellow
+    snp.makeConstraints { make in
+      make.size.equalTo(34)
+    }
+  }
+}

--- a/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
+++ b/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
@@ -79,7 +79,9 @@ final class DetailRecruitmentViewController: BaseViewController {
     $0.sizeToFit()
   }
   
-  private let participantListView = ParticipantListView()
+  private let participantListView = ParticipantListView().then {
+    $0.backgroundColor = .clear
+  }
   
   init(viewModel: DetailRecruitmentViewModelType = DetailRecruitmentViewModel(), plubbingId: Int) {
     self.viewModel = viewModel
@@ -141,7 +143,19 @@ final class DetailRecruitmentViewController: BaseViewController {
       target: self,
       action: #selector(didTappedComponentButton)
     )
-    
+    participantListView.configureUI(with: [
+      .init(accountId: 1, profileImage: ""),
+      .init(accountId: 1, profileImage: ""),
+      .init(accountId: 1, profileImage: ""),
+      .init(accountId: 1, profileImage: ""),
+      .init(accountId: 1, profileImage: ""),
+      .init(accountId: 1, profileImage: ""),
+      .init(accountId: 1, profileImage: ""),
+      .init(accountId: 1, profileImage: ""),
+      .init(accountId: 1, profileImage: ""),
+      .init(accountId: 1, profileImage: ""),
+      .init(accountId: 1, profileImage: ""),
+    ])
   }
   
   override func bind() {

--- a/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
+++ b/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
@@ -68,8 +68,8 @@ final class DetailRecruitmentViewController: BaseViewController {
   private let meetingIntroduceView = MeetingIntroduceView()
   
   private lazy var introduceTagCollectionView = UICollectionView(frame: .zero, collectionViewLayout: LeftAlignedCollectionViewFlowLayout().then({
-    $0.minimumLineSpacing = 3
-    $0.minimumInteritemSpacing = 3
+    $0.minimumLineSpacing = 8
+    $0.minimumInteritemSpacing = 8
   })).then {
     $0.backgroundColor = .background
     $0.register(IntroduceTagCollectionViewCell.self, forCellWithReuseIdentifier: IntroduceTagCollectionViewCell.identifier)

--- a/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
+++ b/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
@@ -113,15 +113,15 @@ final class DetailRecruitmentViewController: BaseViewController {
       $0.height.greaterThanOrEqualTo(48)
     }
     
-    participantListView.snp.makeConstraints { make in
-      make.left.equalToSuperview().offset(17.5)
-      make.right.lessThanOrEqualToSuperview().offset(-14.14)
-      make.height.equalTo(64)
+    participantListView.snp.makeConstraints {
+      $0.left.equalToSuperview().offset(17.5)
+      $0.right.lessThanOrEqualToSuperview().offset(-14.14)
+      $0.height.equalTo(64)
     }
-    participantListView.backgroundColor = .red
-    bottomStackView.snp.makeConstraints { make in
-      make.right.equalToSuperview().offset(-16.5)
-      make.height.equalTo(46)
+    
+    bottomStackView.snp.makeConstraints {
+      $0.right.equalToSuperview().offset(-16.5)
+      $0.height.equalTo(46)
     }
   }
   

--- a/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
+++ b/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
@@ -141,6 +141,7 @@ final class DetailRecruitmentViewController: BaseViewController {
       target: self,
       action: #selector(didTappedComponentButton)
     )
+    
   }
   
   override func bind() {

--- a/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
+++ b/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
@@ -41,7 +41,7 @@ final class DetailRecruitmentViewController: BaseViewController {
     $0.alignment = .center
     $0.distribution = .fill
     $0.isLayoutMarginsRelativeArrangement = true
-    $0.spacing = 16
+    $0.spacing = 24
     $0.layoutMargins = UIEdgeInsets(top: .zero, left: 16.5, bottom: .zero, right: 16.5)
   }
   
@@ -190,7 +190,7 @@ extension DetailRecruitmentViewController: UICollectionViewDelegate, UICollectio
         $0.sizeToFit()
       }
       let size = label.frame.size
-      return CGSize(width: size.width + 16, height: 20)
+      return CGSize(width: size.width + 16, height: size.height + 4)
     }
     return .zero
   }

--- a/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
+++ b/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
@@ -143,19 +143,6 @@ final class DetailRecruitmentViewController: BaseViewController {
       target: self,
       action: #selector(didTappedComponentButton)
     )
-    participantListView.configureUI(with: [
-      .init(accountId: 1, profileImage: ""),
-      .init(accountId: 1, profileImage: ""),
-      .init(accountId: 1, profileImage: ""),
-      .init(accountId: 1, profileImage: ""),
-      .init(accountId: 1, profileImage: ""),
-      .init(accountId: 1, profileImage: ""),
-      .init(accountId: 1, profileImage: ""),
-      .init(accountId: 1, profileImage: ""),
-      .init(accountId: 1, profileImage: ""),
-      .init(accountId: 1, profileImage: ""),
-      .init(accountId: 1, profileImage: ""),
-    ])
   }
   
   override func bind() {


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 참여자의 정보에 따른 처리를 컬렉션 뷰 -> 스택 뷰 변경
- 참여자정보가 nil일 경우에 대한 로직 추가 
- 참여자가 8명이상일 경우에 대한 UI변경 로직 추가

🌱 PR 포인트
- API 연동이 불가해 테스트코드로만 확인 
- 추후 API를 통해 받아온 데이터를 가지고 테스트해볼 예정

## 📸 스크린샷
|스크린샷|
<img width="359" alt="스크린샷 2023-01-26 오후 9 26 14" src="https://user-images.githubusercontent.com/39263235/214835197-36c1401b-ae52-4fd1-9112-cf1e7a454ab7.png">

|파일첨부바람|

## 📮 관련 이슈
- Resolved: #92 

