### PR TITLE
[Feat] 모임 생성 > 질문 삭제 동작 개선

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		C3DE688B2976CF120079B76F /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DE688A2976CF120079B76F /* BottomSheetViewController.swift */; };
 		C3E98EAD2974759800E36C45 /* MeetingNameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E98EAC2974759800E36C45 /* MeetingNameViewModel.swift */; };
 		C3FA748C2974984800A8BE4C /* MeetingIntroduceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FA748B2974984800A8BE4C /* MeetingIntroduceViewModel.swift */; };
+		C3FC1815298509C50083039A /* QuestionDeleteBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FC1814298509C50083039A /* QuestionDeleteBottomSheetViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -323,6 +324,7 @@
 		C3DE688A2976CF120079B76F /* BottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
 		C3E98EAC2974759800E36C45 /* MeetingNameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingNameViewModel.swift; sourceTree = "<group>"; };
 		C3FA748B2974984800A8BE4C /* MeetingIntroduceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingIntroduceViewModel.swift; sourceTree = "<group>"; };
+		C3FC1814298509C50083039A /* QuestionDeleteBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionDeleteBottomSheetViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -832,6 +834,7 @@
 				C38A5BA0297B0C4100485355 /* NoLocationView.swift */,
 				C38A5BA6297C549A00485355 /* LocationBaseView.swift */,
 				C34F07F4297DB1DC00C91E90 /* AddQuestionControl.swift */,
+				C3FC1814298509C50083039A /* QuestionDeleteBottomSheetViewController.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -981,6 +984,7 @@
 				70197B7F29549C56000503F6 /* SelectedCategoryViewModel.swift in Sources */,
 				BAF54B7B29487CE900C59FBA /* PolicyViewModel.swift in Sources */,
 				C3D9807A297D982E00B8F5DF /* MeetingQuestionViewModel.swift in Sources */,
+				C3FC1815298509C50083039A /* QuestionDeleteBottomSheetViewController.swift in Sources */,
 				BA117A3D297440D900B37E03 /* UserManager.swift in Sources */,
 				C38A5B97297AD5C300485355 /* KakaoLocationService.swift in Sources */,
 				BA784FA82978EB9100E8B06F /* SignUpViewController.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		C3E98EAD2974759800E36C45 /* MeetingNameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E98EAC2974759800E36C45 /* MeetingNameViewModel.swift */; };
 		C3FA748C2974984800A8BE4C /* MeetingIntroduceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FA748B2974984800A8BE4C /* MeetingIntroduceViewModel.swift */; };
 		C3FC1815298509C50083039A /* QuestionDeleteBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FC1814298509C50083039A /* QuestionDeleteBottomSheetViewController.swift */; };
+		C3FC181729852D370083039A /* QuestionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FC181629852D370083039A /* QuestionHeaderView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -325,6 +326,7 @@
 		C3E98EAC2974759800E36C45 /* MeetingNameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingNameViewModel.swift; sourceTree = "<group>"; };
 		C3FA748B2974984800A8BE4C /* MeetingIntroduceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingIntroduceViewModel.swift; sourceTree = "<group>"; };
 		C3FC1814298509C50083039A /* QuestionDeleteBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionDeleteBottomSheetViewController.swift; sourceTree = "<group>"; };
+		C3FC181629852D370083039A /* QuestionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionHeaderView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -835,6 +837,7 @@
 				C38A5BA6297C549A00485355 /* LocationBaseView.swift */,
 				C34F07F4297DB1DC00C91E90 /* AddQuestionControl.swift */,
 				C3FC1814298509C50083039A /* QuestionDeleteBottomSheetViewController.swift */,
+				C3FC181629852D370083039A /* QuestionHeaderView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -1117,6 +1120,7 @@
 				BA780E1329713F370032C178 /* BaseService.swift in Sources */,
 				70F1DFDC29795C9000F9BC83 /* SubCategoryListResponse.swift in Sources */,
 				70BD5F272959F718002CBA89 /* UIView + extension.swift in Sources */,
+				C3FC181729852D370083039A /* QuestionHeaderView.swift in Sources */,
 				7085678C28EFBDC1008047DC /* RegisterInterestViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Cell/QuestionTableViewCell.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Cell/QuestionTableViewCell.swift
@@ -118,7 +118,7 @@ extension QuestionTableViewCell {
   func setCellData(text: String) {
     inputTextView.setTitleText(text: "질문 \(indexPathRow + 1)")
     
-    if text.isEmpty { return }
+    if text.isEmpty || text == "질문을 입력해주세요" { return }
     inputTextView.textView.text = text
     inputTextView.textView.textColor = .black
   }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Cell/QuestionTableViewCell.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Cell/QuestionTableViewCell.swift
@@ -17,6 +17,7 @@ protocol QuestionTableViewCellDelegate: AnyObject {
   func addQuestion()
   func presentQuestionDeleteBottomSheet(index: Int)
   func updateQuestion(index: Int, data: MeetingQuestionCellModel)
+  func scrollToRow(_ cell: QuestionTableViewCell)
 }
 
 final class QuestionTableViewCell: UITableViewCell {
@@ -102,6 +103,13 @@ private extension QuestionTableViewCell {
             isFilled: !textUnfilled
           )
         )
+      })
+      .disposed(by: disposeBag)
+    
+    inputTextView.textView.rx.didBeginEditing
+      .withUnretained(self)
+      .subscribe(onNext: { owner, _ in
+        owner.delegate?.scrollToRow(owner)
       })
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Cell/QuestionTableViewCell.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Cell/QuestionTableViewCell.swift
@@ -15,7 +15,7 @@ import RxCocoa
 protocol QuestionTableViewCellDelegate: AnyObject {
   func updateHeightOfRow(_ cell: QuestionTableViewCell, _ textView: UITextView)
   func addQuestion()
-  func removeQuestion(index: Int)
+  func presentQuestionDeleteBottomSheet(index: Int)
   func updateQuestion(index: Int, data: MeetingQuestionCellModel)
 }
 
@@ -108,7 +108,7 @@ private extension QuestionTableViewCell {
     removeButton.rx.tap
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
-        owner.delegate?.removeQuestion(index: owner.indexPathRow)
+        owner.delegate?.presentQuestionDeleteBottomSheet(index: owner.indexPathRow)
       })
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Component/QuestionDeleteBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Component/QuestionDeleteBottomSheetViewController.swift
@@ -8,13 +8,14 @@
 import UIKit
 
 protocol QuestionDeleteBottomSheetDelegate: AnyObject {
-  func removeQuestion(index: Int)
+  func removeQuestion(index: Int, lastQuestion: Bool)
 }
 
 final class QuestionDeleteBottomSheetViewController: BottomSheetViewController {
   weak var delegate: QuestionDeleteBottomSheetDelegate?
   
   private var questionIndex: Int
+  private var lastQuestion: Bool
   
   private let lineView = UIView().then {
     $0.backgroundColor = .mediumGray
@@ -22,7 +23,11 @@ final class QuestionDeleteBottomSheetViewController: BottomSheetViewController {
   }
   
   private lazy var titleLabel = UILabel().then {
-    $0.attributedText = setTitleAttributeText(count: questionIndex)
+    $0.attributedText = setTitleAttributeText(
+      count: questionIndex,
+      lastQuestion: lastQuestion
+    )
+    $0.numberOfLines = 0
     $0.font = .subtitle
     $0.textAlignment = .left
   }
@@ -50,9 +55,11 @@ final class QuestionDeleteBottomSheetViewController: BottomSheetViewController {
   }
   
   init(
-    index: Int
+    index: Int,
+    lastQuestion: Bool
   ) {
     questionIndex = index
+    self.lastQuestion = lastQuestion
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -91,7 +98,7 @@ final class QuestionDeleteBottomSheetViewController: BottomSheetViewController {
     
     titleLabel.snp.makeConstraints {
       $0.top.equalTo(lineView.snp.bottom).offset(31)
-      $0.height.equalTo(19)
+      $0.height.greaterThanOrEqualTo(19)
       $0.leading.trailing.equalToSuperview().inset(24)
     }
     
@@ -114,23 +121,23 @@ final class QuestionDeleteBottomSheetViewController: BottomSheetViewController {
     deleteButton.rx.tap
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
-        owner.delegate?.removeQuestion(index: owner.questionIndex)
+        owner.delegate?.removeQuestion(index: owner.questionIndex, lastQuestion: owner.lastQuestion)
         owner.dismiss(animated: false)
       })
       .disposed(by: disposeBag)
   }
   
-  private func setTitleAttributeText(count: Int) -> NSMutableAttributedString {
+  private func setTitleAttributeText(count: Int, lastQuestion: Bool) -> NSMutableAttributedString {
     let purpleCharacters = NSAttributedString(
       string: "질문 \(count + 1)",
       attributes: [.foregroundColor: UIColor.main]
     )
     
     let blackCharacters = NSAttributedString(
-      string: "를 삭제 할까요?",
+      string: "를 삭제 할까요?" + (lastQuestion ? "\n삭제할 경우 질문 없이 모집하기로 변경돼요." : ""),
       attributes: [.foregroundColor: UIColor.black]
     )
-    
+
     return NSMutableAttributedString(attributedString: purpleCharacters).then {
       $0.append(blackCharacters)
     }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Component/QuestionDeleteBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Component/QuestionDeleteBottomSheetViewController.swift
@@ -1,0 +1,138 @@
+//
+//  QuestionDeleteBottomSheetViewController.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/01/28.
+//
+
+import UIKit
+
+protocol QuestionDeleteBottomSheetDelegate: AnyObject {
+  func removeQuestion(index: Int)
+}
+
+final class QuestionDeleteBottomSheetViewController: BottomSheetViewController {
+  weak var delegate: QuestionDeleteBottomSheetDelegate?
+  
+  private var questionIndex: Int
+  
+  private let lineView = UIView().then {
+    $0.backgroundColor = .mediumGray
+    $0.layer.cornerRadius = 2
+  }
+  
+  private lazy var titleLabel = UILabel().then {
+    $0.attributedText = setTitleAttributeText(count: questionIndex)
+    $0.font = .subtitle
+    $0.textAlignment = .left
+  }
+  
+  private let buttonStackView = UIStackView().then {
+    $0.axis = .horizontal
+    $0.spacing = 16
+    $0.distribution = .fillEqually
+  }
+  
+  private let backButton = UIButton().then {
+    $0.setTitle("아니요! 그냥 둘게요.", for: .normal)
+    $0.setTitleColor(.deepGray, for: .normal)
+    $0.titleLabel?.font = .button
+    $0.layer.cornerRadius = 10
+    $0.backgroundColor = .lightGray
+  }
+  
+  private let deleteButton = UIButton().then {
+    $0.setTitle("네, 삭제할게요.", for: .normal)
+    $0.setTitleColor(.white, for: .normal)
+    $0.titleLabel?.font = .button
+    $0.layer.cornerRadius = 10
+    $0.backgroundColor = .error
+  }
+  
+  init(
+    index: Int
+  ) {
+    questionIndex = index
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+  }
+  
+  override func setupLayouts() {
+    super.setupLayouts()
+    [lineView, titleLabel, buttonStackView].forEach {
+      contentView.addSubview($0)
+    }
+    
+    [backButton, deleteButton].forEach {
+      buttonStackView.addArrangedSubview($0)
+    }
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    contentView.snp.remakeConstraints {
+      $0.leading.trailing.bottom.equalToSuperview()
+      $0.height.equalTo(206)
+    }
+    
+    lineView.snp.makeConstraints {
+      $0.top.equalToSuperview().inset(8)
+      $0.height.equalTo(4)
+      $0.width.equalTo(48)
+      $0.centerX.equalToSuperview()
+    }
+    
+    titleLabel.snp.makeConstraints {
+      $0.top.equalTo(lineView.snp.bottom).offset(31)
+      $0.height.equalTo(19)
+      $0.leading.trailing.equalToSuperview().inset(24)
+    }
+    
+    buttonStackView.snp.makeConstraints {
+      $0.top.equalTo(titleLabel.snp.bottom).offset(15)
+      $0.leading.trailing.equalToSuperview().inset(24)
+      $0.height.equalTo(48)
+    }
+  }
+  
+  override func bind() {
+    super.bind()
+    backButton.rx.tap
+      .withUnretained(self)
+      .subscribe(onNext: { owner, _ in
+        owner.dismiss(animated: false)
+      })
+      .disposed(by: disposeBag)
+    
+    deleteButton.rx.tap
+      .withUnretained(self)
+      .subscribe(onNext: { owner, _ in
+        owner.delegate?.removeQuestion(index: owner.questionIndex)
+        owner.dismiss(animated: false)
+      })
+      .disposed(by: disposeBag)
+  }
+  
+  private func setTitleAttributeText(count: Int) -> NSMutableAttributedString {
+    let purpleCharacters = NSAttributedString(
+      string: "질문 \(count + 1)",
+      attributes: [.foregroundColor: UIColor.main]
+    )
+    
+    let blackCharacters = NSAttributedString(
+      string: "를 삭제 할까요?",
+      attributes: [.foregroundColor: UIColor.black]
+    )
+    
+    return NSMutableAttributedString(attributedString: purpleCharacters).then {
+      $0.append(blackCharacters)
+    }
+  }
+}

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Component/QuestionHeaderView.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Component/QuestionHeaderView.swift
@@ -94,8 +94,7 @@ private extension QuestionHeaderView {
     questionButton.rx.tap
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
-        owner.questionButton.isSelected = true
-        owner.noquestionButton.isSelected = false
+        owner.setQuestionButtonState(state: true)
         owner.delegate?.chageQuestionMode(state: false)
       })
       .disposed(by: disposeBag)
@@ -103,10 +102,16 @@ private extension QuestionHeaderView {
     noquestionButton.rx.tap
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
-        owner.questionButton.isSelected = false
-        owner.noquestionButton.isSelected = true
+        owner.setQuestionButtonState(state: false)
         owner.delegate?.chageQuestionMode(state: true)
       })
       .disposed(by: disposeBag)
+  }
+}
+
+extension QuestionHeaderView {
+  func setQuestionButtonState(state: Bool) {
+    questionButton.isSelected = state
+    noquestionButton.isSelected = !state
   }
 }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Component/QuestionHeaderView.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Component/QuestionHeaderView.swift
@@ -1,0 +1,112 @@
+//
+//  QuestionHeaderView.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/01/28.
+//
+
+import UIKit
+
+import SnapKit
+import RxSwift
+
+protocol QuestionHeaderViewCellDelegate: AnyObject {
+  func chageQuestionMode(state: Bool)
+}
+
+final class QuestionHeaderView: UIView {
+  private let disposeBag = DisposeBag()
+  
+  weak var delegate: QuestionHeaderViewCellDelegate?
+  
+  private let contentStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 48
+  }
+  
+  private let titleView = CreateMeetingTitleView(
+    title: "어떤 게스트가 오면 좋을까요?",
+    description: "함께 할 게스트에게 질문하고 싶은 내용을 적어주세요!\n꼭 적지 않아도 괜찮아요."
+  )
+  
+  private let questionStackView = UIStackView().then {
+    $0.axis = .horizontal
+    $0.spacing = 16
+    $0.distribution = .fillEqually
+  }
+  
+  private let questionButton: UIButton = UIButton(configuration: .plain()).then {
+    $0.configurationUpdateHandler = $0.configuration?.list(label: "질문 하고 모집하기")
+    $0.isSelected = true
+  }
+  
+  private let noquestionButton = UIButton(configuration: .plain()).then {
+    $0.configurationUpdateHandler = $0.configuration?.list(label: "질문 없이 모집하기")
+  }
+  
+  
+  init() {
+    super.init(frame: .zero)
+    setupLayouts()
+    setupConstraints()
+    setupStyles()
+    bind()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+private extension QuestionHeaderView {
+  func setupLayouts() {
+    [contentStackView].forEach {
+      addSubview($0)
+    }
+    
+    [titleView, questionStackView].forEach {
+      contentStackView.addArrangedSubview($0)
+    }
+    
+    [questionButton, noquestionButton].forEach {
+      questionStackView.addArrangedSubview($0)
+    }
+  }
+  
+  func setupConstraints() {
+    contentStackView.snp.makeConstraints {
+      $0.top.equalToSuperview()
+      $0.leading.trailing.equalToSuperview().inset(24)
+    }
+    
+    [questionButton, noquestionButton].forEach{
+      $0.snp.makeConstraints {
+        $0.height.equalTo(46)
+      }
+    }
+  }
+  
+  func setupStyles() {
+
+  }
+  
+  func bind() {
+    questionButton.rx.tap
+      .withUnretained(self)
+      .subscribe(onNext: { owner, _ in
+        owner.questionButton.isSelected = true
+        owner.noquestionButton.isSelected = false
+        owner.delegate?.chageQuestionMode(state: false)
+      })
+      .disposed(by: disposeBag)
+    
+    noquestionButton.rx.tap
+      .withUnretained(self)
+      .subscribe(onNext: { owner, _ in
+        owner.questionButton.isSelected = false
+        owner.noquestionButton.isSelected = true
+        owner.delegate?.chageQuestionMode(state: true)
+      })
+      .disposed(by: disposeBag)
+  }
+}

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
@@ -8,11 +8,9 @@
 import UIKit
 
 import RxSwift
+import RxCocoa
 
 enum MeetingQuestionSectionType: Int, CaseIterable {
-  //TODO: 수빈 - title, button 뷰 tableViewCell에 넣기
-  //  case titleSection = 0
-  //  case buttonSection = 1
   case questionSection = 0
   case addQuestionSection = 1
   
@@ -22,11 +20,6 @@ enum MeetingQuestionSectionType: Int, CaseIterable {
   
   var height: CGFloat {
     switch self {
-      //TODO: 수빈 - title, button 뷰 tableViewCell에 넣기
-      //    case .titleSection:
-      //      return 70
-      //    case .buttonSection:
-      //      return 142
     case .questionSection, .addQuestionSection:
       return UITableView.automaticDimension
     }
@@ -39,36 +32,18 @@ final class MeetingQuestionViewController: BaseViewController {
   weak var delegate: CreateMeetingChildViewControllerDelegate?
   private var childIndex: Int
   
-  private let contentStackView = UIStackView().then {
-    $0.axis = .vertical
-    $0.spacing = 48
+  private lazy var questionHeaderView = QuestionHeaderView().then {
+    $0.delegate = self
   }
   
-  private let titleView = CreateMeetingTitleView(
-    title: "어떤 게스트가 오면 좋을까요?",
-    description: "함께 할 게스트에게 질문하고 싶은 내용을 적어주세요!\n꼭 적지 않아도 괜찮아요."
-  )
-  
-  private let questionStackView = UIStackView().then {
-    $0.axis = .horizontal
-    $0.spacing = 16
-    $0.distribution = .fillEqually
-  }
-  
-  private let questionButton: UIButton = UIButton(configuration: .plain()).then {
-    $0.configurationUpdateHandler = $0.configuration?.list(label: "질문 하고 모집하기")
-  }
-  
-  private let noquestionButton = UIButton(configuration: .plain()).then {
-    $0.configurationUpdateHandler = $0.configuration?.list(label: "질문 없이 모집하기")
-  }
-  
-  private lazy var tableView = UITableView().then {
+  private lazy var tableView = UITableView(frame: CGRect.zero, style: .grouped).then {
     $0.separatorStyle = .none
     $0.showsVerticalScrollIndicator = false
     $0.backgroundColor = .background
     $0.delegate = self
     $0.dataSource = self
+    $0.tableHeaderView = questionHeaderView
+    $0.tableHeaderView?.frame.size.height = 212
     $0.register(QuestionTableViewCell.self, forCellReuseIdentifier: QuestionTableViewCell.identifier)
     $0.register(AddQuestionTableViewCell.self, forCellReuseIdentifier: AddQuestionTableViewCell.identifier)
   }
@@ -85,37 +60,17 @@ final class MeetingQuestionViewController: BaseViewController {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+  
   override func setupLayouts() {
     super.setupLayouts()
-    [contentStackView, tableView].forEach {
-      view.addSubview($0)
-    }
-    
-    [titleView, questionStackView].forEach {
-      contentStackView.addArrangedSubview($0)
-    }
-    
-    [questionButton, noquestionButton].forEach {
-      questionStackView.addArrangedSubview($0)
-    }
+    view.addSubview(tableView)
   }
   
   override func setupConstraints() {
     super.setupConstraints()
-    contentStackView.snp.makeConstraints {
-      $0.top.equalTo(view.safeAreaLayoutGuide)
-      $0.leading.trailing.equalToSuperview().inset(24)
-    }
-    
     tableView.snp.makeConstraints {
-      $0.top.equalTo(contentStackView.snp.bottom).offset(48)
+      $0.top.equalTo(view.safeAreaLayoutGuide)
       $0.leading.trailing.bottom.equalToSuperview()
-    }
-    
-    [questionButton, noquestionButton].forEach{
-      $0.snp.makeConstraints {
-        $0.height.equalTo(46)
-      }
     }
   }
   
@@ -125,33 +80,22 @@ final class MeetingQuestionViewController: BaseViewController {
   
   override func bind() {
     super.bind()
-    questionButton.rx.tap
-      .withUnretained(self)
-      .subscribe(onNext: { owner, _ in
-        owner.questionButton.isSelected = true
-        owner.noquestionButton.isSelected = false
-      })
-      .disposed(by: disposeBag)
-    
-    noquestionButton.rx.tap
-      .withUnretained(self)
-      .subscribe(onNext: { owner, _ in
-        owner.questionButton.isSelected = false
-        owner.noquestionButton.isSelected = true
-      })
-      .disposed(by: disposeBag)
-    
     viewModel.allQuestionFilled
       .subscribe(onNext: { state in
-        self.delegate?.checkValidation(
-          index: self.childIndex,
-          state: state
-        )
         let addQuestionIndex = IndexPath(row: 0, section: MeetingQuestionSectionType.addQuestionSection.index)
         guard let currentCell = self.tableView.cellForRow(at: addQuestionIndex) as? AddQuestionTableViewCell else {
           return
         }
         currentCell.addQuestionControl.isHidden = !(state && self.viewModel.questionList.count < 5)
+      })
+      .disposed(by: disposeBag)
+    
+    Observable.combineLatest(viewModel.allQuestionFilled, viewModel.noQuestionMode)
+      .subscribe(onNext: { tuple in
+        self.delegate?.checkValidation(
+          index: self.childIndex,
+          state: tuple.0 || tuple.1
+        )
       })
       .disposed(by: disposeBag)
   }
@@ -179,17 +123,23 @@ extension MeetingQuestionViewController: UITableViewDataSource {
         withIdentifier: QuestionTableViewCell.identifier,
         for: indexPath
       ) as? QuestionTableViewCell else { return UITableViewCell() }
+      
       cell.indexPathRow = indexPath.row
       cell.setCellData(text: viewModel.questionList[indexPath.row])
       cell.delegate = self
+      
       return cell
+      
     case MeetingQuestionSectionType.addQuestionSection.index:
       guard let cell = tableView.dequeueReusableCell(
         withIdentifier: AddQuestionTableViewCell.identifier,
         for: indexPath
       ) as? AddQuestionTableViewCell else { return UITableViewCell() }
+      
       cell.delegate = self
+      
       return cell
+      
     default:
       return UITableViewCell()
     }
@@ -203,19 +153,24 @@ extension MeetingQuestionViewController: UITableViewDataSource {
     return UIView()
   }
   
+  func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    return UIView()
+  }
+  
+  func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+    return 0
+  }
+  
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    let noQuestionMode = viewModel.noQuestionMode.value
     switch section {
     case MeetingQuestionSectionType.questionSection.index:
-      return viewModel.questionList.count
+      return noQuestionMode ? 0 : viewModel.questionList.count
     case MeetingQuestionSectionType.addQuestionSection.index:
-      return 1
+      return noQuestionMode ? 0 : 1
     default:
       return 0
     }
-  }
-  
-  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    
   }
 }
 
@@ -266,5 +221,12 @@ extension MeetingQuestionViewController: QuestionDeleteBottomSheetDelegate {
     viewModel.removeQuestion(index: index)
     tableView.reloadData()
     view.endEditing(true)
+  }
+}
+
+extension MeetingQuestionViewController: QuestionHeaderViewCellDelegate {
+  func chageQuestionMode(state: Bool) {
+    viewModel.noQuestionMode.accept(state)
+    tableView.reloadData()
   }
 }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
@@ -241,10 +241,11 @@ extension MeetingQuestionViewController: QuestionTableViewCellDelegate {
     currentCell.inputTextView.textView.becomeFirstResponder()
   }
   
-  func removeQuestion(index: Int) {
-    viewModel.questionList.remove(at: index)
-    viewModel.removeQuestion(index: index)
-    self.tableView.reloadData()
+  func presentQuestionDeleteBottomSheet(index: Int) {
+    let vc = QuestionDeleteBottomSheetViewController(index: index)
+    vc.delegate = self
+    vc.modalPresentationStyle = .overFullScreen
+    present(vc, animated: false)
   }
   
   func updateHeightOfRow(_ cell: QuestionTableViewCell, _ textView: UITextView) {
@@ -256,5 +257,14 @@ extension MeetingQuestionViewController: QuestionTableViewCellDelegate {
       tableView.endUpdates()
       UIView.setAnimationsEnabled(true)
     }
+  }
+}
+
+extension MeetingQuestionViewController: QuestionDeleteBottomSheetDelegate {
+  func removeQuestion(index: Int) {
+    viewModel.questionList.remove(at: index)
+    viewModel.removeQuestion(index: index)
+    tableView.reloadData()
+    view.endEditing(true)
   }
 }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
@@ -61,6 +61,16 @@ final class MeetingQuestionViewController: BaseViewController {
     fatalError("init(coder:) has not been implemented")
   }
   
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    registerKeyboardNotification()
+  }
+  
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    removeKeyboardNotification()
+  }
+  
   override func setupLayouts() {
     super.setupLayouts()
     view.addSubview(tableView)
@@ -70,7 +80,8 @@ final class MeetingQuestionViewController: BaseViewController {
     super.setupConstraints()
     tableView.snp.makeConstraints {
       $0.top.equalTo(view.safeAreaLayoutGuide)
-      $0.leading.trailing.bottom.equalToSuperview()
+      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(56)
+      $0.leading.trailing.equalToSuperview()
     }
   }
   
@@ -264,5 +275,32 @@ extension MeetingQuestionViewController {
       return
     }
     currentCell.addQuestionControl.isHidden = state
+  }
+}
+
+// MARK: - Keyboard
+
+extension MeetingQuestionViewController {
+  func registerKeyboardNotification() {
+    NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)),
+                                             name: UIResponder.keyboardWillShowNotification, object: nil)
+    NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)),
+                                             name: UIResponder.keyboardWillHideNotification, object: nil)
+  }
+  
+  func removeKeyboardNotification() {
+    NotificationCenter.default.removeObserver(self)
+  }
+  
+  @objc
+  func keyboardWillShow(_ sender: Notification) {
+    if let keyboardRect = (sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue, view.frame.origin.y == 0{
+      view.frame.origin.y -= keyboardRect.height
+    }
+  }
+  
+  @objc
+  func keyboardWillHide(_ sender: Notification) {
+    view.frame.origin.y = 0
   }
 }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
@@ -82,15 +82,14 @@ final class MeetingQuestionViewController: BaseViewController {
     super.bind()
     viewModel.allQuestionFilled
       .subscribe(onNext: { state in
-        let addQuestionIndex = IndexPath(row: 0, section: MeetingQuestionSectionType.addQuestionSection.index)
-        guard let currentCell = self.tableView.cellForRow(at: addQuestionIndex) as? AddQuestionTableViewCell else {
-          return
-        }
-        currentCell.addQuestionControl.isHidden = !(state && self.viewModel.questionList.count < 5)
+        self.hideAddQuestionButton(state: !(state && self.viewModel.questionList.count < 5))
       })
       .disposed(by: disposeBag)
     
-    Observable.combineLatest(viewModel.allQuestionFilled, viewModel.noQuestionMode)
+    Observable.combineLatest(
+      viewModel.allQuestionFilled,
+      viewModel.noQuestionMode
+    )
       .subscribe(onNext: { tuple in
         self.delegate?.checkValidation(
           index: self.childIndex,
@@ -232,6 +231,7 @@ extension MeetingQuestionViewController: QuestionDeleteBottomSheetDelegate {
     } else {
       tableView.reloadData()
       view.endEditing(true)
+      hideAddQuestionButton(state: !viewModel.allQuestionFilled.value)
     }
   }
 }
@@ -244,5 +244,15 @@ extension MeetingQuestionViewController: QuestionHeaderViewCellDelegate {
     }
     viewModel.noQuestionMode.accept(state)
     tableView.reloadData()
+  }
+}
+
+extension MeetingQuestionViewController {
+  private func hideAddQuestionButton(state: Bool) {
+    let addQuestionIndex = IndexPath(row: 0, section: MeetingQuestionSectionType.addQuestionSection.index)
+    guard let currentCell = self.tableView.cellForRow(at: addQuestionIndex) as? AddQuestionTableViewCell else {
+      return
+    }
+    currentCell.addQuestionControl.isHidden = state
   }
 }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
@@ -44,6 +44,7 @@ final class MeetingQuestionViewController: BaseViewController {
     $0.dataSource = self
     $0.tableHeaderView = questionHeaderView
     $0.tableHeaderView?.frame.size.height = 212
+    $0.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: 56))
     $0.register(QuestionTableViewCell.self, forCellReuseIdentifier: QuestionTableViewCell.identifier)
     $0.register(AddQuestionTableViewCell.self, forCellReuseIdentifier: AddQuestionTableViewCell.identifier)
   }
@@ -80,8 +81,7 @@ final class MeetingQuestionViewController: BaseViewController {
     super.setupConstraints()
     tableView.snp.makeConstraints {
       $0.top.equalTo(view.safeAreaLayoutGuide)
-      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(56)
-      $0.leading.trailing.equalToSuperview()
+      $0.leading.bottom.trailing.equalToSuperview()
     }
   }
   
@@ -296,11 +296,13 @@ extension MeetingQuestionViewController {
   func keyboardWillShow(_ sender: Notification) {
     if let keyboardRect = (sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue, view.frame.origin.y == 0{
       view.frame.origin.y -= keyboardRect.height
+      tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: 56 + 26))
     }
   }
   
   @objc
   func keyboardWillHide(_ sender: Notification) {
     view.frame.origin.y = 0
+    tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: 56))
   }
 }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
@@ -233,6 +233,12 @@ extension MeetingQuestionViewController: QuestionTableViewCellDelegate {
       UIView.setAnimationsEnabled(true)
     }
   }
+  
+  func scrollToRow(_ cell: QuestionTableViewCell) {
+    if let thisIndexPath = tableView.indexPath(for: cell) {
+      tableView.scrollToRow(at: thisIndexPath, at: .middle, animated: false)
+    }
+  }
 }
 
 // MARK: - QuestionDeleteBottomSheetDelegate

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingQuestionViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingQuestionViewModel.swift
@@ -19,13 +19,17 @@ final class MeetingQuestionViewModel {
   // Input
   var questionList: [String]
   let questionListBehaviorRelay: BehaviorRelay<[MeetingQuestionCellModel]>
+  var noQuestionMode: BehaviorRelay<Bool>
   
   // Output
   let allQuestionFilled = PublishRelay<Bool>()
+  let addQuestionButtonHidden: BehaviorRelay<Bool>
   
   init() {
     questionList = [""]
     questionListBehaviorRelay = .init(value: [MeetingQuestionCellModel(question: "", isFilled: false)])
+    addQuestionButtonHidden = .init(value: true)
+    noQuestionMode = .init(value: false)
     
     questionListBehaviorRelay
       .map { $0.map { $0.isFilled } }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingQuestionViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingQuestionViewModel.swift
@@ -22,15 +22,13 @@ final class MeetingQuestionViewModel {
   var noQuestionMode: BehaviorRelay<Bool>
   
   // Output
-  let allQuestionFilled = PublishRelay<Bool>()
-  let addQuestionButtonHidden: BehaviorRelay<Bool>
+  let allQuestionFilled: BehaviorRelay<Bool>
   
   init() {
     questionList = [""]
     questionListBehaviorRelay = .init(value: [MeetingQuestionCellModel(question: "", isFilled: false)])
-    addQuestionButtonHidden = .init(value: true)
     noQuestionMode = .init(value: false)
-    
+    allQuestionFilled = .init(value: false)
     questionListBehaviorRelay
       .map { $0.map { $0.isFilled } }
       .map { !$0.contains(false) }


### PR DESCRIPTION
## 📌 PR 요약
- 질문 삭제 동작을 개선했습니다.

🌱 작업한 내용
- 질문 삭제 바텀 시트 구현
- 질문이 1개 있을 때 삭제 동작 시, 질문없이 모집하기로 변경 처리
- 질문O/X 버튼 변경해도 기존 질문 유지
- 키보드 Notification 추가
- QuestionHeaderView 추가
- 질문셀 textView에 포커싱 시, 해당 셀로 스크롤 동작 추가

🌱 PR 포인트
- 질문 추가, 수정, 삭제 프로세스를 완료했습니다. 추가 이슈가 발견되면 공유부탁드립니다..!

## 📸 스크린샷

<img src="https://user-images.githubusercontent.com/77331348/215273742-3194b303-53f0-4d57-b26d-fa72fbc6f0f3.PNG" width="300"> <img src="https://user-images.githubusercontent.com/77331348/215273738-b157527f-c999-4ee4-9559-ec69d2ca8827.PNG" width="300">


## 📮 관련 이슈
- Resolved: #86 

