### PR TITLE
[SignUp] 회원가입 구현 + UploadImageRequest

### DIFF
--- a/PLUB/Sources/Models/Request/SignUpRequest.swift
+++ b/PLUB/Sources/Models/Request/SignUpRequest.swift
@@ -29,3 +29,7 @@ struct SignUpRequest: Codable {
   let usePolicy: Bool
   let agePolicy: Bool
 }
+
+// MARK: - Conform `Then`
+
+extension SignUpRequest: Then { }

--- a/PLUB/Sources/Models/Request/SignUpRequest.swift
+++ b/PLUB/Sources/Models/Request/SignUpRequest.swift
@@ -7,12 +7,19 @@
 
 import Foundation
 
+import Then
+
+enum Sex: String, Codable {
+  case male = "M"
+  case female = "F"
+}
+
 struct SignUpRequest: Codable {
   let signToken: String
   let categoryList: [String]
   let profileImage: String
   let birthday: String
-  let gender: String
+  let gender: Sex
   let introduce: String
   let nickname: String
   

--- a/PLUB/Sources/Models/Request/SignUpRequest.swift
+++ b/PLUB/Sources/Models/Request/SignUpRequest.swift
@@ -15,19 +15,74 @@ enum Sex: String, Codable {
 }
 
 struct SignUpRequest: Codable {
-  let signToken: String
-  let categoryList: [String]
-  let profileImage: String
-  let birthday: String
-  let gender: Sex
-  let introduce: String
-  let nickname: String
+  /// sign token
+  var signToken: String
+
+  /// 선택한 카테고리 리스트
+  var categoryList: [Int]
+
+  /// 등록한 프로필 이미지 사진 링크
+  var profileImageLink: String?
+
+  /// 생일
+  var birthday: String
+
+  /// 성별
+  var sex: Sex
+
+  /// 소개
+  var introduction: String
+
+  /// 닉네임
+  var nickname: String
+
+  /// 이용약관 및 개인정보 취급 방침
+  var termsOfService: Bool
   
-  let marketPolicy: Bool
-  let personalPolicy: Bool
-  let placePolicy: Bool
-  let usePolicy: Bool
-  let agePolicy: Bool
+  /// 위치 기반 서비스 이용 약관
+  var locationBasedService: Bool
+  
+  /// 만 14세 이상 확인
+  var termsAndConditionsForAges: Bool
+  
+  /// 개인정보 수집 이용 동의
+  var privacyPolicy: Bool
+  
+  /// 마케팅 활용 동의
+  var marketing: Bool
+
+  init() {
+    signToken = UserManager.shared.signToken!
+    categoryList = []
+    birthday = ""
+    sex = .male
+    introduction = ""
+    nickname = ""
+    termsOfService = false
+    locationBasedService = false
+    termsAndConditionsForAges = false
+    privacyPolicy = false
+    marketing = false
+  }
+}
+
+// MARK: - CodingKeys
+
+extension SignUpRequest {
+  enum CodingKeys: String, CodingKey {
+    case signToken
+    case categoryList
+    case profileImageLink = "profileImage"
+    case birthday
+    case sex = "gender"
+    case introduction = "introduce"
+    case nickname
+    case termsOfService = "usePolicy"
+    case locationBasedService = "placePolicy"
+    case termsAndConditionsForAges = "agePolicy"
+    case privacyPolicy = "personalPolicy"
+    case marketing = "marketPolicy"
+  }
 }
 
 // MARK: - Conform `Then`

--- a/PLUB/Sources/Models/Request/UploadImageRequest.swift
+++ b/PLUB/Sources/Models/Request/UploadImageRequest.swift
@@ -9,27 +9,14 @@
 struct UploadImageRequest: Codable {
   
   /// 타입 설정
-  let type: String
+  let type: ImageType
 }
 
-enum ImageType {
+enum ImageType: String, Codable {
   
   /// 프로필 이미지
   case profile
   
   /// 플러빙 메인 이미지
-  case plubbingMain
-}
-
-extension ImageType {
-  
-  var value: String {
-    switch self {
-    case .profile:
-      return "profile"
-      
-    case .plubbingMain:
-      return "plubbing-main"
-    }
-  }
+  case plubbingMain = "plubbing-main"
 }

--- a/PLUB/Sources/Network/Services/AuthService.swift
+++ b/PLUB/Sources/Network/Services/AuthService.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxCocoa
 import RxSwift
 
-class AuthService: BaseService {
+final class AuthService: BaseService {
   static let shared = AuthService()
   
   private override init() { }
@@ -28,36 +28,8 @@ extension AuthService {
     )
   }
   
-  func signUpToPLUB(
-    categoryList: [String],
-    profileImageLink: String,
-    birthday: String,
-    gender: String,
-    introduce: String,
-    nickname: String,
-    marketPolicy: Bool,
-    personalPolicy: Bool,
-    placePolicy: Bool,
-    usePolicy: Bool,
-    agePolicy: Bool
-  ) -> Observable<NetworkResult<GeneralResponse<TokenResponse>>> {
-    return sendRequest(
-      AuthRouter.signUpPLUB(SignUpRequest(
-        signToken: UserManager.shared.signToken!,
-        categoryList: categoryList,
-        profileImage: profileImageLink,
-        birthday: birthday,
-        gender: gender,
-        introduce: introduce,
-        nickname: nickname,
-        marketPolicy: marketPolicy,
-        personalPolicy: personalPolicy,
-        placePolicy: placePolicy,
-        usePolicy: usePolicy,
-        agePolicy: agePolicy
-      )),
-      type: TokenResponse.self
-    )
+  func signUpToPLUB(request: SignUpRequest) -> Observable<NetworkResult<GeneralResponse<TokenResponse>>> {
+    return sendRequest(AuthRouter.signUpPLUB(request), type: TokenResponse.self)
   }
   
   func reissuanceAccessToken() -> Observable<NetworkResult<GeneralResponse<TokenResponse>>> {

--- a/PLUB/Sources/Views/Login/Birth/BirthViewController.swift
+++ b/PLUB/Sources/Views/Login/Birth/BirthViewController.swift
@@ -116,7 +116,10 @@ final class BirthViewController: BaseViewController {
     
     maleButton.rx.tap
       .withUnretained(self)
-      .do { $0.0.viewModel.sexButtonTapped.onNext(()) } // 성별 선택이 완료되었다고 알리기
+      .do {
+        $0.0.viewModel.sexButtonTapped.onNext(())  // 성별 선택이 완료되었다고 알리기
+        $0.0.delegate?.information(sex: .male)     // delegate에게 성별 알리기
+      }
       .subscribe(onNext: { owner, _ in
         owner.maleButton.isSelected = true
         owner.femaleButton.isSelected = false
@@ -125,7 +128,10 @@ final class BirthViewController: BaseViewController {
     
     femaleButton.rx.tap
       .withUnretained(self)
-      .do { $0.0.viewModel.sexButtonTapped.onNext(()) } // 성별 선택이 완료되었다고 알리기
+      .do {
+        $0.0.viewModel.sexButtonTapped.onNext(()) // 성별 선택이 완료되었다고 알리기
+        $0.0.delegate?.information(sex: .female)  // delegate에게 성별 알리기
+      }
       .subscribe(onNext: { owner, _ in
         owner.femaleButton.isSelected = true
         owner.maleButton.isSelected = false
@@ -156,6 +162,7 @@ extension BirthViewController: DateBottomSheetDelegate {
     birthSettingControl.date = date
     birthSettingControl.isSelected = true
     viewModel.calendarDidSet.onNext(()) // 생년월일이 세팅되었다고 알리기
+    delegate?.information(birth: date)
   }
 }
 

--- a/PLUB/Sources/Views/Login/Interest/InterestViewController.swift
+++ b/PLUB/Sources/Views/Login/Interest/InterestViewController.swift
@@ -60,8 +60,8 @@ final class InterestViewController: BaseViewController {
         let flag = tuple.0
         let categories = tuple.1
         
-        // TODO: 승현 - delegate에게 카테고리 정보 전달
-        owner.delegate?.checkValidation(index: 4, state: flag)
+        owner.delegate?.information(categories: categories) // 선택한 카테고리 전달
+        owner.delegate?.checkValidation(index: 4, state: flag)  // 부모 뷰컨의 `확인 버튼` 활성화 처리
       })
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Login/LoginViewController.swift
+++ b/PLUB/Sources/Views/Login/LoginViewController.swift
@@ -200,7 +200,8 @@ extension LoginViewController {
   
   private func requestPLUBTokens(socialType: SignInType, token: String? = nil, authorizationCode: String? = nil) {
     AuthService.shared.requestAuth(socialType: socialType, token: token, authorizationCode: authorizationCode)
-      .subscribe(onNext: { result in
+      .withUnretained(self)
+      .subscribe(onNext: { owner, result in
         switch result {
         case .success(let model):
           guard let accessToken  = model.data?.accessToken,
@@ -209,6 +210,7 @@ extension LoginViewController {
           }
           // accessToken, refreshToken 업데이트
           UserManager.shared.updatePLUBToken(accessToken: accessToken, refreshToken: refreshToken)
+          owner.navigationController?.pushViewController(HomeViewController(viewModel: HomeViewModel()), animated: true)
           
         case .requestError(let model):
           guard let signToken = model.data?.signToken else {
@@ -218,6 +220,7 @@ extension LoginViewController {
           // Signin token 업데이트 및 소셜로그인 타입 업데이트
           UserManager.shared.set(signToken: signToken)
           UserManager.shared.set(socialType: socialType)
+          owner.navigationController?.pushViewController(SignUpViewController(), animated: true)
         case .networkError, .serverError, .pathError:
           // TODO: 승현 - PLUB 에러 Alert 띄우기
           break

--- a/PLUB/Sources/Views/Login/Policy/PolicyViewController.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyViewController.swift
@@ -93,19 +93,25 @@ final class PolicyViewController: BaseViewController {
       .disposed(by: disposeBag)
     
     viewModel.checkedButtonListState
-      .do { print($0) }
       .map { $0.reduce(true, { $0 && $1 }) }
-      .drive(onNext: { [weak self] in
-        self?.agreementCheckboxButton.isChecked = $0
-      })
+      .drive(with: self) { owner, flag in
+        owner.agreementCheckboxButton.isChecked = flag
+      }
       .disposed(by: disposeBag)
     
     viewModel.checkedButtonListState
       .map { $0.dropLast(1).reduce(true, { $0 && $1 }) }
-      .drive(with: self, onNext: { owner, flag in
-        // delegate 처리
+      .drive(with: self) { owner, flag in
+        // 부모 뷰컨의 `확인 버튼` 활성화 처리
         owner.delegate?.checkValidation(index: 0, state: flag)
-      })
+      }
+      .disposed(by: disposeBag)
+    
+    viewModel.checkedButtonListState
+      .drive(with: self) { owner, policies in
+        // 설정한 약관 정보 전달
+        owner.delegate?.information(policies: policies)
+      }
       .disposed(by: disposeBag)
   }
 }

--- a/PLUB/Sources/Views/Login/Profile/ProfileViewController.swift
+++ b/PLUB/Sources/Views/Login/Profile/ProfileViewController.swift
@@ -207,10 +207,21 @@ final class ProfileViewController: BaseViewController {
     
     // 닉네임 사용가능여부를 판단하고 UI 업데이트
     viewModel.isAvailableNickname
-      .drive(with: self, onNext: { owner, flag in
+      .drive(with: self) { owner, flag in
         owner.updateNicknameValidationUI(isValid: flag)
+        // 부모 뷰컨의 `확인 버튼` 활성화 처리
         owner.delegate?.checkValidation(index: 2, state: flag)
-      })
+      }
+      .disposed(by: disposeBag)
+    
+    viewModel.isAvailableNickname
+      .filter { $0 }
+      .withLatestFrom(nicknameTextField.rx.text.asDriver())
+      .compactMap { $0 }
+      .drive(with: self) { owner, nickname in
+        // 사용가능한 닉네임 전달
+        owner.delegate?.information(nickname: nickname)
+      }
       .disposed(by: disposeBag)
     
     // 메시지 처리
@@ -259,6 +270,7 @@ final class ProfileViewController: BaseViewController {
 extension ProfileViewController: PhotoBottomSheetDelegate {
   func selectImage(image: UIImage) {
     uploadImageButton.setImage(image, for: .normal)
+    delegate?.information(profile: image) // 프로필 이미지 전달
   }
 }
 

--- a/PLUB/Sources/Views/Login/Profile/ProfileViewModel.swift
+++ b/PLUB/Sources/Views/Login/Profile/ProfileViewModel.swift
@@ -51,7 +51,7 @@ final class ProfileViewModel: ProfileViewModelType {
   
   private func validate(text: String) {
     let characterRegex = "[^a-zA-Z가-힣0-9]" // 한글, 영어, 숫자를 제외한 문자를 찾는 정규표현식 (특수문자 찾기용)
-    print(text)
+    
     // 2~8자가 아닌 경우
     if text.count < 2 || text.count > 8 {
       isAvailableRelay.accept(false)

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -10,8 +10,21 @@ import UIKit
 import SnapKit
 import Then
 
+enum Sex: String {
+  case male = "M"
+  case female = "F"
+}
+
 protocol SignUpChildViewControllerDelegate: BaseViewController {
   func checkValidation(index: Int, state: Bool)
+  
+  func information(categories: [Int])
+  func information(profile image: UIImage)
+  func information(birth date: Date)
+  func information(sex: Sex)
+  func information(introduction: String)
+  func information(nickname: String)
+  func information(policies: [Bool])
 }
 
 final class SignUpViewController: BaseViewController {
@@ -266,5 +279,40 @@ extension SignUpViewController: UIScrollViewDelegate {
 extension SignUpViewController: SignUpChildViewControllerDelegate {
   func checkValidation(index: Int, state: Bool) {
     viewModel.validationState.onNext(ValidationState(index: index, state: state))
+  }
+  
+  func information(categories: [Int]) {
+    print(#function)
+    print(categories)
+  }
+  
+  func information(profile image: UIImage) {
+    print(#function)
+    print(image)
+  }
+  
+  func information(birth date: Date) {
+    print(#function)
+    print(date)
+  }
+  
+  func information(sex: Sex) {
+    print(#function)
+    print(sex.rawValue)
+  }
+  
+  func information(introduction: String) {
+    print(#function)
+    print(introduction)
+  }
+  
+  func information(nickname: String) {
+    print(#function)
+    print(nickname)
+  }
+  
+  func information(policies: [Bool]) {
+    print(#function)
+    print(policies)
   }
 }

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -177,6 +177,21 @@ final class SignUpViewController: BaseViewController {
       .share()
       .withUnretained(self)
     
+    // 유저가 필요한 정부를 전부 기입했을 때 회원가입 진행
+    nextButtonShareObservable
+      .filter { owner, _ in return owner.lastPageIndex + 1 == owner.viewControllers.count }
+      .flatMap { owner, _ in return owner.viewModel.signUp() }
+      .withUnretained(self)
+      .subscribe(onNext: { owner, succeed in
+        if succeed {
+          owner.navigationController?.setViewControllers([HomeViewController(viewModel: HomeViewModel())], animated: true)
+        } else {
+          print("회원가입 실패")
+        }
+      })
+      .disposed(by: disposeBag)
+    
+    // 아직 유저가 필요한 정보를 전부 기입하지 못한 경우(남은 페이지가 있는 경우를 뜻함)
     nextButtonShareObservable
       .subscribe(onNext: { owner, _ in
         if owner.currentPage < owner.lastPageIndex {

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -10,11 +10,6 @@ import UIKit
 import SnapKit
 import Then
 
-enum Sex: String {
-  case male = "M"
-  case female = "F"
-}
-
 protocol SignUpChildViewControllerDelegate: BaseViewController {
   func checkValidation(index: Int, state: Bool)
   

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -277,37 +277,30 @@ extension SignUpViewController: SignUpChildViewControllerDelegate {
   }
   
   func information(categories: [Int]) {
-    print(#function)
-    print(categories)
+    viewModel.categories.onNext(categories)
   }
   
   func information(profile image: UIImage) {
-    print(#function)
-    print(image)
+    viewModel.profileImage.onNext(image)
   }
   
   func information(birth date: Date) {
-    print(#function)
-    print(date)
+    viewModel.birth.onNext(date)
   }
   
   func information(sex: Sex) {
-    print(#function)
-    print(sex.rawValue)
+    viewModel.sex.onNext(sex)
   }
   
   func information(introduction: String) {
-    print(#function)
-    print(introduction)
+    viewModel.introduction.onNext(introduction)
   }
   
   func information(nickname: String) {
-    print(#function)
-    print(nickname)
+    viewModel.nickname.onNext(nickname)
   }
   
   func information(policies: [Bool]) {
-    print(#function)
-    print(policies)
+    viewModel.policies.onNext(policies)
   }
 }

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import RxCocoa
+import RxSwift
 import SnapKit
 import Then
 
@@ -171,8 +173,11 @@ final class SignUpViewController: BaseViewController {
   
   override func bind() {
     super.bind()
-    nextButton.rx.tap
+    let nextButtonShareObservable = nextButton.rx.tap
+      .share()
       .withUnretained(self)
+    
+    nextButtonShareObservable
       .subscribe(onNext: { owner, _ in
         if owner.currentPage < owner.lastPageIndex {
           owner.currentPage += 1

--- a/PLUB/Sources/Views/Login/SignUpViewModel.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewModel.swift
@@ -67,13 +67,13 @@ final class SignUpViewModel: SignUpViewModelType {
   
   private var stateList = [Bool]()
   
-  private let userCategoriesSubject = BehaviorSubject(value: [Int]())     // 유저 카테고리 서브젝트
+  private let userCategoriesSubject = PublishSubject<[Int]>()             // 유저 카테고리 서브젝트
   private let userProfileSubject = BehaviorSubject<UIImage?>(value: nil)  // 유저 프로필 서브젝트
-  private let userBirthSubject = BehaviorSubject(value: Date())           // 유저 생일 서브젝트
-  private let userSexSubject = BehaviorSubject(value: Sex.male)           // 유저 성별 서브젝트
-  private let userIntroductionSubject = BehaviorSubject(value: "")        // 유저 소개글 서브젝트
-  private let userNicknameSubject = BehaviorSubject(value: "")            // 유저 닉네임 서브젝트
-  private let userPoliciesSubject = BehaviorSubject(value: [Bool]())      // 유저 약관 서브젝트
+  private let userBirthSubject = PublishSubject<Date>()                   // 유저 생일 서브젝트
+  private let userSexSubject = PublishSubject<Sex>()                      // 유저 성별 서브젝트
+  private let userIntroductionSubject = PublishSubject<String>()          // 유저 소개글 서브젝트
+  private let userNicknameSubject = BehaviorSubject<String>(value: "")    // 유저 닉네임 서브젝트
+  private let userPoliciesSubject = PublishSubject<[Bool]>()              // 유저 약관 서브젝트
   
   private let signUpRelay = BehaviorRelay(value: SignUpRequest())         // 회원가입 플로우로 사용할 릴레이
   private let validationStateSubject = PublishSubject<ValidationState>()  // 버튼을 활성화할지 검증할 때 필요한 서브젝트

--- a/PLUB/Sources/Views/Login/SignUpViewModel.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewModel.swift
@@ -196,7 +196,7 @@ final class SignUpViewModel: SignUpViewModelType {
     // 2. 이미지가 등록되어있는지 판단
     if let profileImage = try? userProfileSubject.value() {
       // 2-1. 이미지를 request model에 등록한 Observable로 세팅
-      requestObservable = ImageService.shared.uploadImage(images: [profileImage], params: UploadImageRequest(type: ImageType.profile.value))
+      requestObservable = ImageService.shared.uploadImage(images: [profileImage], params: UploadImageRequest(type: .profile))
         .flatMap { response -> Observable<String?> in
           switch response {
           case let .success(imageModel):

--- a/PLUB/Sources/Views/Login/SignUpViewModel.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewModel.swift
@@ -109,7 +109,74 @@ final class SignUpViewModel: SignUpViewModelType {
       .map { owner, _ in
         owner.stateList.firstIndex(of: false) == nil
       }
-      .bind(to: resultSubject)
+      .bind(to: buttonEnabledSubject)
+      .disposed(by: disposeBag)
+    
+    userCategoriesSubject
+      .withUnretained(self)
+      .compactMap { owner, categories in
+        owner.signUpRelay.value.with {
+          $0.categoryList = categories
+        }
+      }
+      .bind(to: signUpRelay)
+      .disposed(by: disposeBag)
+    
+    userBirthSubject
+      .withUnretained(self)
+      .compactMap { owner, birthday in
+        owner.signUpRelay.value.with {
+          let formatter = DateFormatter().then {
+            $0.dateFormat = "yyyy-MM-dd"
+          }
+          $0.birthday = formatter.string(from: birthday)
+        }
+      }
+      .bind(to: signUpRelay)
+      .disposed(by: disposeBag)
+    
+    userSexSubject
+      .withUnretained(self)
+      .compactMap { owner, sex in
+        owner.signUpRelay.value.with {
+          $0.sex = sex
+        }
+      }
+      .bind(to: signUpRelay)
+      .disposed(by: disposeBag)
+    
+    userIntroductionSubject
+      .withUnretained(self)
+      .compactMap { owner, introduction in
+        owner.signUpRelay.value.with {
+          $0.introduction = introduction
+        }
+      }
+      .bind(to: signUpRelay)
+      .disposed(by: disposeBag)
+    
+    userNicknameSubject
+      .withUnretained(self)
+      .compactMap { owner, nickname in
+        owner.signUpRelay.value.with {
+          $0.nickname = nickname
+        }
+      }
+      .bind(to: signUpRelay)
+      .disposed(by: disposeBag)
+    
+    userPoliciesSubject
+      .withUnretained(self)
+      .compactMap { owner, policies in
+        owner.signUpRelay.value.with {
+          $0.termsOfService = policies[0]
+          $0.locationBasedService = policies[1]
+          $0.termsAndConditionsForAges = policies[2]
+          $0.privacyPolicy = policies[3]
+          $0.marketing = policies[4]
+        }
+      }
+      .bind(to: signUpRelay)
       .disposed(by: disposeBag)
   }
   

--- a/PLUB/Sources/Views/Login/SignUpViewModel.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewModel.swift
@@ -35,7 +35,7 @@ final class SignUpViewModel: SignUpViewModelType {
   
   private let disposeBag = DisposeBag()
   
-  var titles = [
+  let titles = [
     "가입을 위한 약관 동의가 필요해요.",
     "먼저, 성별과 태어난 날을 알려주세요.",
     "프로필을 만들어 볼까요?",
@@ -43,12 +43,12 @@ final class SignUpViewModel: SignUpViewModelType {
     "마지막으로, 관심 있는 분야를 모두 선택해주세요."
   ]
   
-  var subtitles = [
+  let subtitles = [
     "서비스를 이용할 때 필요해요.",
     "서비스의 원활한 이용을 위해 정확한 정보를 입력해주세요!",
     "멋진 사진을 등록하고 나만의 닉네임을 만들어 주세요! 닉네임 변경은 1회 가능해요!",
     "취미, 관심사, 가치관, 종사하는 분야, 뭐든 좋아요.",
-    "(닉네임)님이 흥미로워 할 만한 모임을 추천해 드릴게요."
+    "님이 흥미로워 할 만한 모임을 추천해 드릴게요."
   ]
   
   private var stateList = [Bool]()
@@ -66,7 +66,7 @@ final class SignUpViewModel: SignUpViewModelType {
   
   // MARK: - Custom Functions
   
-  func bind() {
+  private func bind() {
     // 어떤 VC의 delegate로 인한 state 변경
     // ==> viewModel의 state 값 변경
     // ==> 값 변동 이후 버튼 활성화 유무 판단

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingIntroduceViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingIntroduceViewController.swift
@@ -180,7 +180,7 @@ extension MeetingIntroduceViewController: PhotoBottomSheetDelegate {
       $0.height.equalTo(width * image.size.height / image.size.width)
     }
     
-    ImageService.shared.uploadImage(images: [image], params: UploadImageRequest(type: ImageType.plubbingMain.value))
+    ImageService.shared.uploadImage(images: [image], params: UploadImageRequest(type: .plubbingMain))
       .subscribe(onNext: { result in
         switch result {
         case .success(let model):


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용

- 로그인 화면에서 소셜로그인 성공 시 HomeVC로 이동, 실패 시 SignUpVC로 이동합니다.
- 회원가입 시 `access token`, `refresh token`을 받아 `UserManager`에 저장합니다. 아직 Interceptor는 구현하지 않았고, 다음 PR때 작업할 예정입니다.
- UploadImageRequest 모델을 일부 수정했습니다(슬랙에서 건의했던 것)

🌱 PR 포인트
- 정보를 담고있는 자식 ViewController가 유저에 의해 정보가 갱신될 때마다 delegate 패턴을 이용하여 부모 ViewController에게 이를 알려줍니다. delegate의 내용은 아래와 같습니다.
   -  ```swift
      protocol SignUpChildViewControllerDelegate: BaseViewController {
        func checkValidation(index: Int, state: Bool)
      
        func information(categories: [Int]) // 사용자가 선택한 카테고리
        func information(profile image: UIImage) // 사용자의 프로필 이미지
        func information(birth date: Date) // 사용자의 생일
        func information(sex: Sex) // 사용자의 성별
        func information(introduction: String) // 사용자의 인사글
        func information(nickname: String) // 사용자의 닉네임
        func information(policies: [Bool]) // 사용자가 선택한 약관 리스트
      }
      ```
- 필요한 정보들이 기입되었다면 회원가입이 진행되며, 성공 시 HomeViewController로 이동합니다.
  - ```swift
    // 유저가 필요한 정부를 전부 기입했을 때 회원가입 진행
    nextButtonShareObservable
      .filter { owner, _ in return owner.lastPageIndex + 1 == owner.viewControllers.count }
      .flatMap { owner, _ in return owner.viewModel.signUp() }
      .withUnretained(self)
      .subscribe(onNext: { owner, succeed in
        if succeed {
          owner.navigationController?.setViewControllers([HomeViewController(viewModel: HomeViewModel())], animated: true)
        } else {
          print("회원가입 실패")
        }
      })
      .disposed(by: disposeBag)
    ```

## 📸 스크린샷

- 별도의 사진은 준비하지 못했습니다 :'(

## 📮 관련 이슈
- Resolved: #58
- Resolved: #71

