### PR TITLE
[Network] 토큰 자동 재발급 구현

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		BA88126A28E48A8D00BD832A /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = BA88126928E48A8D00BD832A /* Then */; };
 		BA88126D28E48AB700BD832A /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = BA88126C28E48AB700BD832A /* SnapKit */; };
 		BA88127028E48AC800BD832A /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = BA88126F28E48AC800BD832A /* Alamofire */; };
+		BA8AA42A29863ABC004E9403 /* Interceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8AA42929863ABC004E9403 /* Interceptor.swift */; };
 		BA8E2B40297461E6009DDF32 /* SignInRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8E2B3F297461E6009DDF32 /* SignInRequest.swift */; };
 		BA8E2B4429746738009DDF32 /* AuthRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8E2B4329746737009DDF32 /* AuthRouter.swift */; };
 		BA8E2B46297467A2009DDF32 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8E2B45297467A2009DDF32 /* AuthService.swift */; };
@@ -280,6 +281,7 @@
 		BA88125928E48A3000BD832A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		BA88125B28E48A3000BD832A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BA88126128E48A5800BD832A /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		BA8AA42929863ABC004E9403 /* Interceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interceptor.swift; sourceTree = "<group>"; };
 		BA8E2B3F297461E6009DDF32 /* SignInRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInRequest.swift; sourceTree = "<group>"; };
 		BA8E2B4329746737009DDF32 /* AuthRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRouter.swift; sourceTree = "<group>"; };
 		BA8E2B45297467A2009DDF32 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
@@ -713,6 +715,7 @@
 				BA780E0C297133F80032C178 /* Router.swift */,
 				BA780E1229713F370032C178 /* BaseService.swift */,
 				BA5DEB2F2974D8E200650788 /* NetworkResult.swift */,
+				BA8AA42929863ABC004E9403 /* Interceptor.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -1040,6 +1043,7 @@
 				7085678828EEACFB008047DC /* InterestSelectCollectionViewCell.swift in Sources */,
 				BA780E0F297138F10032C178 /* HeaderType.swift in Sources */,
 				70F1DFEF297D9E1C00F9BC83 /* DetailRecruitmentViewModel.swift in Sources */,
+				BA8AA42A29863ABC004E9403 /* Interceptor.swift in Sources */,
 				BA42D1F328EDE10F00C20061 /* LoginViewController.swift in Sources */,
 				70F1DFE4297A919900F9BC83 /* CategoryMeetingResponse.swift in Sources */,
 				BAE5D3372975B20000268D44 /* TokenResponse.swift in Sources */,

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -16,6 +16,8 @@ extension Session: Then { }
 
 class BaseService {
   
+  private let session = Session(configuration: .af.default, interceptor: Interceptor())
+  
   /// Network Response에 대해 값을 검증하고 그 결과값을 리턴합니다.
   /// - Parameters:
   ///   - statusCode: http 상태 코드
@@ -54,7 +56,7 @@ class BaseService {
     type: T.Type = EmptyModel.self
   ) -> Observable<NetworkResult<GeneralResponse<T>>> {
     Single.create { observer in
-      AF.request(router).responseData { response in
+      self.session.request(router).responseData { response in
         switch response.result {
         case .success(let data):
           guard let statusCode = response.response?.statusCode else {
@@ -74,14 +76,13 @@ class BaseService {
   /// PLUB 서버에 필요한 값과 이미지 파일을 동봉하여 요청합니다.
   /// - MultipartFormData:
   ///   - 이미지 formData: byte buffer 형식
-
   func sendRequestWithImage<T: Codable>(
     _ formData: MultipartFormData,
     _ router: Router,
     type: T.Type = EmptyModel.self
   ) -> Observable<NetworkResult<GeneralResponse<T>>> {
     Single.create { observer in
-      AF.upload(multipartFormData: formData, with: router).responseData { response in
+      self.session.upload(multipartFormData: formData, with: router).responseData { response in
         switch response.result {
         case .success(let data):
           guard let statusCode = response.response?.statusCode else {


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- RequestInterceptor를 준수하는 Interceptor 클래스를 추가했습니다.

🌱 PR 포인트
- 변경된 코드에 의문이 있다면 커밋의 body를 봐주시면 감사하겠습니다.
- retry파트를 유심히 보시길 바랍니다. 해당 메서드는 요청 실패 시 불려지는 메서드입니다. 저는 401 에러일 때 토큰을 재발급받도록 구현해두었고, 그 이외에는 retry(재시도)하지 않고 Error를 그대로 리턴하는 식으로 구현해두었습니다.


## 📮 관련 이슈
- Resolved: #104

