### PR TITLE
[SignUp] 미비된 UI 수정

### DIFF
--- a/PLUB/Sources/Views/Login/Interest/InterestViewController.swift
+++ b/PLUB/Sources/Views/Login/Interest/InterestViewController.swift
@@ -44,7 +44,8 @@ final class InterestViewController: BaseViewController {
   override func setupConstraints() {
     super.setupConstraints()
     tableView.snp.makeConstraints {
-      $0.directionalEdges.equalToSuperview()
+      $0.directionalVerticalEdges.equalToSuperview()
+      $0.directionalHorizontalEdges.equalToSuperview().inset(24)
     }
   }
   

--- a/PLUB/Sources/Views/Login/Introduction/IntroductionViewController.swift
+++ b/PLUB/Sources/Views/Login/Introduction/IntroductionViewController.swift
@@ -35,7 +35,8 @@ final class IntroductionViewController: BaseViewController {
   override func setupConstraints() {
     super.setupConstraints()
     inputTextView.snp.makeConstraints {
-      $0.top.horizontalEdges.equalToSuperview()
+      $0.top.equalToSuperview()
+      $0.directionalHorizontalEdges.equalToSuperview().inset(24)
     }
   }
   

--- a/PLUB/Sources/Views/Login/Policy/PolicyViewController.swift
+++ b/PLUB/Sources/Views/Login/Policy/PolicyViewController.swift
@@ -65,7 +65,8 @@ final class PolicyViewController: BaseViewController {
     super.setupConstraints()
     
     agreementControl.snp.makeConstraints {
-      $0.top.horizontalEdges.equalToSuperview()
+      $0.top.equalToSuperview()
+      $0.directionalHorizontalEdges.equalToSuperview().inset(24)
       $0.height.equalTo(48)
     }
     
@@ -82,7 +83,8 @@ final class PolicyViewController: BaseViewController {
     
     tableView.snp.makeConstraints {
       $0.top.equalTo(agreementControl.snp.bottom).offset(16)
-      $0.horizontalEdges.bottom.equalToSuperview()
+      $0.bottom.equalToSuperview()
+      $0.directionalHorizontalEdges.equalToSuperview().inset(24)
     }
   }
   

--- a/PLUB/Sources/Views/Login/Profile/ProfileViewController.swift
+++ b/PLUB/Sources/Views/Login/Profile/ProfileViewController.swift
@@ -128,7 +128,8 @@ final class ProfileViewController: BaseViewController {
     super.setupConstraints()
     
     wholeStackView.snp.makeConstraints {
-      $0.top.horizontalEdges.equalToSuperview()
+      $0.top.equalToSuperview()
+      $0.directionalHorizontalEdges.equalToSuperview().inset(24)
     }
     
     uploadImageButton.snp.makeConstraints {

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -34,8 +34,7 @@ final class SignUpViewController: BaseViewController {
     didSet {
       view.endEditing(true)
       pageControl.currentPage = currentPage
-      titleLabel.text = viewModel.titles[currentPage]
-      subtitleLabel.text = viewModel.subtitles[currentPage]
+      updateTitles(index: currentPage)
     }
   }
   
@@ -74,14 +73,14 @@ final class SignUpViewController: BaseViewController {
   private lazy var titleLabel = UILabel().then {
     $0.textColor = .black
     $0.numberOfLines = 0
-    $0.text = viewModel.titles[currentPage]
+    $0.attributedText = viewModel.titles[currentPage]
     $0.font = .h4
   }
   
   private lazy var subtitleLabel = UILabel().then {
     $0.textColor = .black
     $0.numberOfLines = 0
-    $0.text = viewModel.subtitles[currentPage]
+    $0.attributedText = viewModel.subtitles[currentPage]
     $0.font = .body2
   }
   
@@ -238,6 +237,11 @@ final class SignUpViewController: BaseViewController {
   private func scrollToPage(index: Int) {
     let offset: CGPoint = CGPoint(x: view.frame.width * CGFloat(index), y: 0)
     scrollView.setContentOffset(offset, animated: true)
+  }
+  
+  private func updateTitles(index: Int) {
+    titleLabel.attributedText = viewModel.titles[index]
+    subtitleLabel.attributedText = viewModel.subtitles[index]
   }
 }
 

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -35,6 +35,7 @@ final class SignUpViewController: BaseViewController {
       view.endEditing(true)
       pageControl.currentPage = currentPage
       updateTitles(index: currentPage)
+      setRightNavigationItem(index: currentPage)
     }
   }
   
@@ -242,6 +243,36 @@ final class SignUpViewController: BaseViewController {
   private func updateTitles(index: Int) {
     titleLabel.attributedText = viewModel.titles[index]
     subtitleLabel.attributedText = viewModel.subtitles[index]
+  }
+  
+  private func setRightNavigationItem(index: Int) {
+    // 마지막 페이지가 아닌 경우 right button item 없앰
+    if index + 1 != viewControllers.count {
+      navigationItem.rightBarButtonItem = UIBarButtonItem()
+      return
+    }
+    // `다음에 하기` 버튼 생성
+    let button = UIButton().then {
+      $0.setTitle("다음에 하기", for: .normal)
+      $0.setTitleColor(.deepGray, for: .normal)
+      $0.titleLabel?.font = .body1
+      // action으로 회원가입 파트 바로 진행
+      $0.addAction(UIAction { [weak self] _ in
+        guard let self else { return }
+        self.viewModel.signUp()
+          .subscribe(onNext: { succeed in
+            if succeed {
+              self.navigationController?.setViewControllers([HomeViewController(viewModel: HomeViewModel())], animated: true)
+            } else {
+              print("회원가입 실패")
+            }
+          })
+          .disposed(by: self.disposeBag)
+      }, for: .touchUpInside)
+    }
+    
+    // 버튼 등록
+    navigationItem.rightBarButtonItem = UIBarButtonItem(customView: button)
   }
 }
 

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -249,10 +249,14 @@ final class SignUpViewController: BaseViewController {
 
 extension SignUpViewController {
   func registerKeyboardNotification() {
-    NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)),
-                                             name: UIResponder.keyboardWillShowNotification, object: nil)
-    NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)),
-                                             name: UIResponder.keyboardWillHideNotification, object: nil)
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(keyboardWillShow(_:)),
+      name: UIResponder.keyboardWillShowNotification, object: nil
+    )
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(keyboardWillHide(_:)),
+      name: UIResponder.keyboardWillHideNotification, object: nil
+    )
   }
   
   func removeKeyboardNotification() {

--- a/PLUB/Sources/Views/Login/SignUpViewModel.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewModel.swift
@@ -275,11 +275,3 @@ final class SignUpViewModel: SignUpViewModelType {
       }
   }
 }
-
-// MARK: - Constants
-
-extension SignUpViewModel {
-  private enum Constants {
-    static let defaultProfileName = "userDefaultImage"
-  }
-}

--- a/PLUB/Sources/Views/Login/SignUpViewModel.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewModel.swift
@@ -34,6 +34,8 @@ protocol SignUpViewModelType: SignUpViewModel {
 
 final class SignUpViewModel: SignUpViewModelType {
   
+  // MARK: - Protocol Properties
+  
   // Input
   let validationState: AnyObserver<ValidationState> // 자식들에게서 상태값을 받음
   let categories: AnyObserver<[Int]>                // 유저가 선택한 카테고리
@@ -49,7 +51,9 @@ final class SignUpViewModel: SignUpViewModelType {
   
   private let disposeBag = DisposeBag()
   
-  let titles = [
+  // MARK: - Custom Properties
+  
+  private let _titles = [
     "가입을 위한 약관 동의가 필요해요.",
     "먼저, 성별과 태어난 날을 알려주세요.",
     "프로필을 만들어 볼까요?",
@@ -57,7 +61,7 @@ final class SignUpViewModel: SignUpViewModelType {
     "마지막으로, 관심 있는 분야를 모두 선택해주세요."
   ]
   
-  let subtitles = [
+  private let _subtitles = [
     "서비스를 이용할 때 필요해요.",
     "서비스의 원활한 이용을 위해 정확한 정보를 입력해주세요!",
     "멋진 사진을 등록하고 나만의 닉네임을 만들어 주세요! 닉네임 변경은 1회 가능해요!",
@@ -65,7 +69,43 @@ final class SignUpViewModel: SignUpViewModelType {
     "님이 흥미로워 할 만한 모임을 추천해 드릴게요."
   ]
   
+  var titles: [NSAttributedString] {
+    _titles.map {
+      let defaultString = NSAttributedString(string: $0)
+      // 닉네임을 넣어야하는 구간이 아닌 경우
+      if _titles[3] != $0 {
+        return defaultString
+      }
+      
+      // 닉네임 설정이 안된 경우 (발생 가능성 0%)
+      guard let nickname = try? userNicknameSubject.value() else {
+        return defaultString
+      }
+      // 닉네임만 색상을 main컬러로 적용
+      let mutableString = NSMutableAttributedString(string: nickname, attributes: [.foregroundColor: UIColor.main])
+      mutableString.append(defaultString)
+      return mutableString
+    }
+  }
+  
+  var subtitles: [NSAttributedString] {
+    _subtitles.map {
+      let defaultString = NSAttributedString(string: $0)
+      // 닉네임을 넣어야하는 구간이 아닌 경우
+      if _subtitles[4] != $0 {
+        return defaultString
+      }
+      // 닉네임 설정이 안된 경우 (발생 가능성 0%)
+      guard let nickname = try? userNicknameSubject.value() else {
+        return defaultString
+      }
+      return NSAttributedString(string: nickname + $0)
+    }
+  }
+  
   private var stateList = [Bool]()
+  
+  // MARK: - Subjects
   
   private let userCategoriesSubject = PublishSubject<[Int]>()             // 유저 카테고리 서브젝트
   private let userProfileSubject = BehaviorSubject<UIImage?>(value: nil)  // 유저 프로필 서브젝트


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용

- 이제 설정된 닉네임을 title에서 띄워줍니다.
- 카테고리 페이지에 진입시 `다음에 하기`버튼이 보여집니다.
- 회원가입 자식 viewController의 inset을 조정했습니다.

🌱 PR 포인트

- `다음에 하기`버튼이 이전 작업에 영향을 받지는 않습니다. 예를 들면, 필수 약관 선택을 해제하고 `다음에 하기`버튼을 누를 수 있습니다. 이것도 추후에 리팩토링으로 수정해야할 듯 싶습니다.

## 📸 스크린샷

|닉네임 표시 예시|다음에 하기 버튼 표시|
|:--:|:-:|
|![RPReplay_Final1674974964](https://user-images.githubusercontent.com/57972338/215314159-2af2c72f-a120-463a-b10f-156949534317.gif)|![RPReplay_Final1674977288](https://user-images.githubusercontent.com/57972338/215314174-dae14eed-bc97-4a2a-9304-06c06ddd9287.gif)|

## 📮 관련 이슈
- Resolved: #103

