### PR TITLE
[SignUp] UX 버그 수정(프로필 이미지, 키보드 가림, 인덱스)

### DIFF
--- a/PLUB/Sources/Views/Login/Profile/ProfileViewController.swift
+++ b/PLUB/Sources/Views/Login/Profile/ProfileViewController.swift
@@ -20,25 +20,26 @@ final class ProfileViewController: BaseViewController {
   
   private let viewModel = ProfileViewModel()
   
-  private let wholeStackView: UIStackView = UIStackView().then {
+  private let wholeStackView = UIStackView().then {
     $0.axis = .vertical
     $0.spacing = 48
   }
   
   // MARK: Profile Part
   
-  private let profileStackView: UIStackView = UIStackView().then {
+  private let profileStackView = UIStackView().then {
     $0.axis = .vertical
     $0.alignment = .center
     $0.spacing = 16
   }
   
-  private let profileLabel: UILabel = UILabel().then {
+  private let profileLabel = UILabel().then {
     $0.text = "프로필 사진"
     $0.font = .subtitle
   }
   
-  private let uploadImageButton: UIButton = UIButton().then {
+  private let uploadImageButton = UIButton().then {
+    $0.imageView?.contentMode = .scaleAspectFill
     $0.layer.cornerRadius = 60
     $0.clipsToBounds = true
     $0.setImage(UIImage(named: "userDefaultImage"), for: .normal)

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -297,20 +297,28 @@ extension SignUpViewController {
   @objc
   func keyboardWillShow(_ sender: Notification) {
     if let keyboardSize = (sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-      let keyboardHeight: CGFloat = keyboardSize.height
-      nextButton.snp.updateConstraints {
-        $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(keyboardHeight + 4)
+      let keyboardHeight = keyboardSize.height
+      
+      UIView.animate(withDuration: 1) {
+        if self.currentPage == 2 { // Profile VC가 보이는 경우에만 처리
+          self.view.frame.origin.y -= keyboardHeight
+        } else {
+          self.nextButton.snp.updateConstraints {
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardHeight + 4)
+          }
+        }
       }
-      view.layoutIfNeeded()
     }
   }
   
   @objc
   func keyboardWillHide(_ sender: Notification) {
-    nextButton.snp.updateConstraints {
-      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(4)
+    self.nextButton.snp.updateConstraints {
+      $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(4)
     }
-    view.layoutIfNeeded()
+    UIView.animate(withDuration: 1) {
+      self.view.frame.origin.y = 0
+    }
   }
 }
 

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -319,12 +319,11 @@ extension SignUpViewController {
 extension SignUpViewController: UIScrollViewDelegate {
   
   func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    // 스와이프로 페이지 이동했을 때 보이는 페이지 index를 세팅
-    if velocity.x > 0 { // move right
-      currentPage = lastPageIndex == currentPage ? lastPageIndex : currentPage + 1
-    } else if velocity.x < 0 { // move left
-      currentPage = currentPage == 0 ? 0 : currentPage - 1
-    }
+    
+    // 현재 보여지고 있는 페이지의 x값을 scrollView의 width로 나누면 현재 보여지는 페이지의 인덱스가 도출됨
+    // 만약 scrollView의 width가 375라면, 첫 번째 페이지 pointee.x는 0이고, 두 번째는 375.0이 되는 방식이기 때문
+    let index = Int(targetContentOffset.pointee.x / scrollView.bounds.width)
+    currentPage = index
   }
 }
 


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 키보드가 올라갈 때 닉네임이 가려지는 버그 수정
- 프로필 이미지의 contentMode를 설정하여 이쁘게 보이도록 수정
- 아주 미약하고 빠르게 스와이프할 시 페이지가 이동하지 않음에도 pageControl이 이동하는 증상 수정

🌱 PR 포인트
- 닉네임을 쓰는 곳에서만 키보드가 올라갈 때 모든 뷰가 올라가도록 구현하였고, 그 이외에 키보드가 올라갈 때는 버튼만 띄우도록 구현해두었습니다.

## 📸 스크린샷
|인덱스 버그 수정 전|인덱스 버그 수정 후|
|:-:|:-:|
|![RPReplay_Final1675071103](https://user-images.githubusercontent.com/57972338/215447651-88711036-14d7-4af6-8cc9-dfbd4e288f12.gif)|![RPReplay_Final1675071902](https://user-images.githubusercontent.com/57972338/215447782-11758038-5c84-48ca-bbc1-e10f0adc19d0.gif)|


|닉네임 작성 시 가리는 증상 해결|
|:-:|
|![RPReplay_Final1675072702](https://user-images.githubusercontent.com/57972338/215447958-55bdfc92-2b7b-41b0-9dbd-63f5ca6c8052.gif)|

## 📮 관련 이슈
- #106

