### PR TITLE
[SignUp] 날짜 선택 제한 / 버튼 bottom inset 수정

### DIFF
--- a/PLUB/Sources/Views/Login/Birth/BirthViewController.swift
+++ b/PLUB/Sources/Views/Login/Birth/BirthViewController.swift
@@ -141,7 +141,8 @@ final class BirthViewController: BaseViewController {
     birthSettingControl.rx.tap
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
-        let vc = DateBottomSheetViewController(type: .date, buttonTitle: "생일 입력 완료")
+        let date14YearsBefore = Calendar.current.date(byAdding: .year, value: -14, to: Date())!
+        let vc = DateBottomSheetViewController(maximumDate: date14YearsBefore, buttonTitle: "생일 입력 완료")
         vc.modalPresentationStyle = .overFullScreen
         vc.delegate = owner
         owner.parent?.present(vc, animated: false)

--- a/PLUB/Sources/Views/Login/SignUpViewController.swift
+++ b/PLUB/Sources/Views/Login/SignUpViewController.swift
@@ -158,7 +158,7 @@ final class SignUpViewController: BaseViewController {
     }
     
     nextButton.snp.makeConstraints {
-      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(4)
+      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(Metric.nextButtonBottom)
       $0.horizontalEdges.equalToSuperview().inset(24)
       $0.height.equalTo(48)
     }
@@ -304,7 +304,7 @@ extension SignUpViewController {
           self.view.frame.origin.y -= keyboardHeight
         } else {
           self.nextButton.snp.updateConstraints {
-            $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardHeight + 4)
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardHeight + CGFloat(Metric.nextButtonBottom))
           }
         }
       }
@@ -314,11 +314,19 @@ extension SignUpViewController {
   @objc
   func keyboardWillHide(_ sender: Notification) {
     self.nextButton.snp.updateConstraints {
-      $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(4)
+      $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(Metric.nextButtonBottom)
     }
     UIView.animate(withDuration: 1) {
       self.view.frame.origin.y = 0
     }
+  }
+}
+
+// MARK: - Constants
+
+extension SignUpViewController {
+  private enum Metric {
+    static let nextButtonBottom = Device.isNotch ? 4 : 24
   }
 }
 

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Component/DateBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Component/DateBottomSheetViewController.swift
@@ -42,6 +42,11 @@ final class DateBottomSheetViewController: BottomSheetViewController {
     super.init(nibName: nil, bundle: nil)
   }
   
+  convenience init(maximumDate: Date, buttonTitle: String) {
+    self.init(type: .date, buttonTitle: buttonTitle)
+    datePicker.maximumDate = maximumDate
+  }
+  
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 현재 날짜를 기준으로 만 14세가 되는 날짜부터 설정할 수 있도록 구현
- iPhone SE일 때 bottom inset이 너무 붙어있는 것 처럼 보였음 -> 4에서 24로 수정
   > 노치 디자인인 경우 기존 inset인 4 그대로 유지

## 📸 스크린샷
|생년월일 설정 제약|
|:--:|
|![RPReplay_Final1675148902](https://user-images.githubusercontent.com/57972338/215690990-4d4b9790-4d0e-47c1-ad6d-a8da2d5c81b0.gif)|

## 📮 관련 이슈
- Resolved: #106 

