### PR TITLE
[Feat] 모임 생성 > 요청 데이터 세팅

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -153,6 +153,8 @@
 		C36D337F2975B37D00943B11 /* PhotoBottomSheetListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36D337E2975B37D00943B11 /* PhotoBottomSheetListView.swift */; };
 		C371CDB229784F4E008950DD /* WeekDateCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C371CDB129784F4E008950DD /* WeekDateCollectionViewCell.swift */; };
 		C3757688296DC8E900406F39 /* CreateMeetingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3757687296DC8E900406F39 /* CreateMeetingViewController.swift */; };
+		C385D10D2989462300EF88EC /* MeetingSummaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C385D10C2989462300EF88EC /* MeetingSummaryViewController.swift */; };
+		C385D10F29894BF200EF88EC /* CreateMeetingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C385D10E29894BF200EF88EC /* CreateMeetingViewModel.swift */; };
 		C38A5B93297ACF5B00485355 /* LocationControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38A5B92297ACF5B00485355 /* LocationControl.swift */; };
 		C38A5B95297AD5B000485355 /* KakaoLocationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38A5B94297AD5B000485355 /* KakaoLocationRouter.swift */; };
 		C38A5B97297AD5C300485355 /* KakaoLocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38A5B96297AD5C300485355 /* KakaoLocationService.swift */; };
@@ -179,6 +181,8 @@
 		C3D9807A297D982E00B8F5DF /* MeetingQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D98079297D982E00B8F5DF /* MeetingQuestionViewModel.swift */; };
 		C3DE688B2976CF120079B76F /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DE688A2976CF120079B76F /* BottomSheetViewController.swift */; };
 		C3E98EAD2974759800E36C45 /* MeetingNameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E98EAC2974759800E36C45 /* MeetingNameViewModel.swift */; };
+		C3ED8FB52989B189002F689B /* CreateMeetingRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ED8FB42989B189002F689B /* CreateMeetingRequest.swift */; };
+		C3ED8FB72989B87E002F689B /* CreateMeetingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ED8FB62989B87E002F689B /* CreateMeetingResponse.swift */; };
 		C3FA748C2974984800A8BE4C /* MeetingIntroduceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FA748B2974984800A8BE4C /* MeetingIntroduceViewModel.swift */; };
 		C3FC1815298509C50083039A /* QuestionDeleteBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FC1814298509C50083039A /* QuestionDeleteBottomSheetViewController.swift */; };
 		C3FC181729852D370083039A /* QuestionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FC181629852D370083039A /* QuestionHeaderView.swift */; };
@@ -324,6 +328,8 @@
 		C36D337E2975B37D00943B11 /* PhotoBottomSheetListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoBottomSheetListView.swift; sourceTree = "<group>"; };
 		C371CDB129784F4E008950DD /* WeekDateCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekDateCollectionViewCell.swift; sourceTree = "<group>"; };
 		C3757687296DC8E900406F39 /* CreateMeetingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetingViewController.swift; sourceTree = "<group>"; };
+		C385D10C2989462300EF88EC /* MeetingSummaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSummaryViewController.swift; sourceTree = "<group>"; };
+		C385D10E29894BF200EF88EC /* CreateMeetingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetingViewModel.swift; sourceTree = "<group>"; };
 		C38A5B92297ACF5B00485355 /* LocationControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationControl.swift; sourceTree = "<group>"; };
 		C38A5B94297AD5B000485355 /* KakaoLocationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLocationRouter.swift; sourceTree = "<group>"; };
 		C38A5B96297AD5C300485355 /* KakaoLocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLocationService.swift; sourceTree = "<group>"; };
@@ -350,6 +356,8 @@
 		C3D98079297D982E00B8F5DF /* MeetingQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingQuestionViewModel.swift; sourceTree = "<group>"; };
 		C3DE688A2976CF120079B76F /* BottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
 		C3E98EAC2974759800E36C45 /* MeetingNameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingNameViewModel.swift; sourceTree = "<group>"; };
+		C3ED8FB42989B189002F689B /* CreateMeetingRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetingRequest.swift; sourceTree = "<group>"; };
+		C3ED8FB62989B87E002F689B /* CreateMeetingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetingResponse.swift; sourceTree = "<group>"; };
 		C3FA748B2974984800A8BE4C /* MeetingIntroduceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingIntroduceViewModel.swift; sourceTree = "<group>"; };
 		C3FC1814298509C50083039A /* QuestionDeleteBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionDeleteBottomSheetViewController.swift; sourceTree = "<group>"; };
 		C3FC181629852D370083039A /* QuestionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionHeaderView.swift; sourceTree = "<group>"; };
@@ -899,6 +907,8 @@
 			isa = PBXGroup;
 			children = (
 				C3757687296DC8E900406F39 /* CreateMeetingViewController.swift */,
+				C385D10E29894BF200EF88EC /* CreateMeetingViewModel.swift */,
+				C3ED8FB32989B15F002F689B /* Model */,
 				C3E98EAB29744DAF00E36C45 /* ViewModel */,
 				C3AB743B296B1EF4003DD5E2 /* ViewController */,
 				C34F71BF29798C11003DB376 /* Cell */,
@@ -916,6 +926,7 @@
 				C3AB743E296B21C1003DD5E2 /* MeetingDateViewController.swift */,
 				C3AB743C296B2181003DD5E2 /* MeetingPeopleNumberViewController.swift */,
 				C3AB7440296B21E6003DD5E2 /* MeetingQuestionViewController.swift */,
+				C385D10C2989462300EF88EC /* MeetingSummaryViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -932,6 +943,15 @@
 				C3D98079297D982E00B8F5DF /* MeetingQuestionViewModel.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		C3ED8FB32989B15F002F689B /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				C3ED8FB42989B189002F689B /* CreateMeetingRequest.swift */,
+				C3ED8FB62989B87E002F689B /* CreateMeetingResponse.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1034,6 +1054,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C385D10D2989462300EF88EC /* MeetingSummaryViewController.swift in Sources */,
 				C38A5BA5297B234100485355 /* LocationTableViewCell.swift in Sources */,
 				C3B04E462981788800188E60 /* UploadImageRequest.swift in Sources */,
 				C36D337D2975ADD800943B11 /* Ex+CALayer.swift in Sources */,
@@ -1059,6 +1080,7 @@
 				70F1DFD6297950DD00F9BC83 /* CategoryRouter.swift in Sources */,
 				7085678828EEACFB008047DC /* InterestSelectCollectionViewCell.swift in Sources */,
 				BA780E0F297138F10032C178 /* HeaderType.swift in Sources */,
+				C385D10F29894BF200EF88EC /* CreateMeetingViewModel.swift in Sources */,
 				70F1DFEF297D9E1C00F9BC83 /* DetailRecruitmentViewModel.swift in Sources */,
 				BA8AA42A29863ABC004E9403 /* Interceptor.swift in Sources */,
 				BA42D1F328EDE10F00C20061 /* LoginViewController.swift in Sources */,
@@ -1148,6 +1170,7 @@
 				BA46CCA028EC9B05004953B1 /* Ex+UIButton.swift in Sources */,
 				BAE2B362297C1D6C0000D5B9 /* AccountRouter.swift in Sources */,
 				BAE2B364297C1D720000D5B9 /* AccountService.swift in Sources */,
+				C3ED8FB52989B189002F689B /* CreateMeetingRequest.swift in Sources */,
 				70F1DFEA297D992100F9BC83 /* RecruitmentService.swift in Sources */,
 				BA8E2B4829746881009DDF32 /* SignInResponse.swift in Sources */,
 				70C42454296C86A400DECA0D /* HomeMainCollectionHeaderView.swift in Sources */,
@@ -1161,6 +1184,7 @@
 				70F1DFE0297A90AE00F9BC83 /* MeetingService.swift in Sources */,
 				BA42D1F528EDE11900C20061 /* MeetingViewController.swift in Sources */,
 				C3E98EAD2974759800E36C45 /* MeetingNameViewModel.swift in Sources */,
+				C3ED8FB72989B87E002F689B /* CreateMeetingResponse.swift in Sources */,
 				BA88125028E48A2F00BD832A /* SceneDelegate.swift in Sources */,
 				C344E5412986B9D7009F73A9 /* MeetingCategoryViewModel.swift in Sources */,
 				70F1DFDA29795AB900F9BC83 /* AllCategoryListResponse.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 		C3E98EAD2974759800E36C45 /* MeetingNameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E98EAC2974759800E36C45 /* MeetingNameViewModel.swift */; };
 		C3ED8FB52989B189002F689B /* CreateMeetingRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ED8FB42989B189002F689B /* CreateMeetingRequest.swift */; };
 		C3ED8FB72989B87E002F689B /* CreateMeetingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ED8FB62989B87E002F689B /* CreateMeetingResponse.swift */; };
+		C3ED8FB92989E13D002F689B /* MeetingSummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ED8FB82989E13D002F689B /* MeetingSummaryViewModel.swift */; };
 		C3FA748C2974984800A8BE4C /* MeetingIntroduceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FA748B2974984800A8BE4C /* MeetingIntroduceViewModel.swift */; };
 		C3FC1815298509C50083039A /* QuestionDeleteBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FC1814298509C50083039A /* QuestionDeleteBottomSheetViewController.swift */; };
 		C3FC181729852D370083039A /* QuestionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FC181629852D370083039A /* QuestionHeaderView.swift */; };
@@ -358,6 +359,7 @@
 		C3E98EAC2974759800E36C45 /* MeetingNameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingNameViewModel.swift; sourceTree = "<group>"; };
 		C3ED8FB42989B189002F689B /* CreateMeetingRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetingRequest.swift; sourceTree = "<group>"; };
 		C3ED8FB62989B87E002F689B /* CreateMeetingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetingResponse.swift; sourceTree = "<group>"; };
+		C3ED8FB82989E13D002F689B /* MeetingSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSummaryViewModel.swift; sourceTree = "<group>"; };
 		C3FA748B2974984800A8BE4C /* MeetingIntroduceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingIntroduceViewModel.swift; sourceTree = "<group>"; };
 		C3FC1814298509C50083039A /* QuestionDeleteBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionDeleteBottomSheetViewController.swift; sourceTree = "<group>"; };
 		C3FC181629852D370083039A /* QuestionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionHeaderView.swift; sourceTree = "<group>"; };
@@ -941,6 +943,7 @@
 				C38A5BA2297B17EF00485355 /* MeetingLocationViewModel.swift */,
 				C3158ECA297D50B60016E231 /* MeetingPeopleNumberViewModel.swift */,
 				C3D98079297D982E00B8F5DF /* MeetingQuestionViewModel.swift */,
+				C3ED8FB82989E13D002F689B /* MeetingSummaryViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1165,6 +1168,7 @@
 				BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */,
 				70197B7029535BDA000503F6 /* RegisterInterestViewModel.swift in Sources */,
 				70A420802982ED9C0026E9F9 /* Ex+String.swift in Sources */,
+				C3ED8FB92989E13D002F689B /* MeetingSummaryViewModel.swift in Sources */,
 				70BD5F3329648DD9002CBA89 /* ApplyQuestionTableViewCell.swift in Sources */,
 				BA117A3B297440B500B37E03 /* UserDefaultsWrapper.swift in Sources */,
 				BA46CCA028EC9B05004953B1 /* Ex+UIButton.swift in Sources */,

--- a/PLUB/Configuration/Extensions/Ex+String.swift
+++ b/PLUB/Configuration/Extensions/Ex+String.swift
@@ -5,6 +5,8 @@
 //  Created by 이건준 on 2023/01/26.
 //
 
+import Foundation
+
 extension String {
   
   func fromENGToKOR() -> Self {
@@ -12,48 +14,8 @@ extension String {
     return day.kor
   }
   
-  enum Day: String, CaseIterable {
-    case monday
-    case tuesday
-    case wednesday
-    case thursday
-    case friday
-    case saturday
-    case sunday
-    case all
-    
-    var kor: String {
-      switch self {
-      case .monday:
-        return "월"
-      case .tuesday:
-        return "화"
-      case .wednesday:
-        return "수"
-      case .thursday:
-        return "목"
-      case .friday:
-        return "금"
-      case .saturday:
-        return "토"
-      case .sunday:
-        return "일"
-      case .all:
-        return "요일 무관"
-      }
-    }
-    
-    var eng: String {
-      switch self {
-      case .monday: return "MON"
-      case .tuesday: return "TUE"
-      case .wednesday: return "WED"
-      case .thursday: return "THR"
-      case .friday: return "FRI"
-      case .saturday: return "SAT"
-      case .sunday: return "SUN"
-      case .all: return "ALL"
-      }
-     }
+  func fromKORToENG() -> Self {
+    guard let day = Day.allCases.filter({ $0.kor == self }).first else { return "" }
+    return day.eng
   }
 }

--- a/PLUB/Sources/Models/Response/KakaoLocationResponse.swift
+++ b/PLUB/Sources/Models/Response/KakaoLocationResponse.swift
@@ -11,14 +11,14 @@ struct KakaoLocationResponse: Codable {
 }
 
 struct KakaoLocationDocuments: Codable {
-  var addressName: String?
+  var address: String?
   var placeName: String?
   var roadAddress: String?
   var placePositionX: String?
   var placePositionY: String?
   
   enum CodingKeys: String, CodingKey {
-    case addressName = "address_name"
+    case address = "address_name"
     case placeName = "place_name"
     case roadAddress = "road_address_name"
     case placePositionX = "x"

--- a/PLUB/Sources/Network/Routers/MeetingRouter.swift
+++ b/PLUB/Sources/Network/Routers/MeetingRouter.swift
@@ -8,6 +8,7 @@
 import Alamofire
 
 enum MeetingRouter {
+  case createMeeting(CreateMeetingRequest)
   case inquireCategoryMeeting(String, Int, String)
   case inquireRecommendationMeeting
 }
@@ -15,6 +16,8 @@ enum MeetingRouter {
 extension MeetingRouter: Router {
   var method: HTTPMethod {
     switch self {
+    case .createMeeting:
+      return .post
     case .inquireCategoryMeeting, .inquireRecommendationMeeting:
       return .get
     }
@@ -22,6 +25,8 @@ extension MeetingRouter: Router {
   
   var path: String {
     switch self {
+    case .createMeeting:
+      return "/plubbings"
     case .inquireCategoryMeeting(let categoryId, _, _):
       return "/plubbings/categories/\(categoryId)"
     case .inquireRecommendationMeeting:
@@ -31,6 +36,8 @@ extension MeetingRouter: Router {
   
   var parameters: ParameterType {
     switch self {
+    case let .createMeeting(model):
+      return .body(model)
     case .inquireCategoryMeeting(_, let page, let sort):
       return .query(["page": "\(page)", "sort": sort])
     case .inquireRecommendationMeeting:
@@ -40,7 +47,7 @@ extension MeetingRouter: Router {
   
   var headers: HeaderType {
     switch self {
-    case .inquireCategoryMeeting, .inquireRecommendationMeeting:
+    case .createMeeting, .inquireCategoryMeeting, .inquireRecommendationMeeting:
       return .withAccessToken
     }
   }

--- a/PLUB/Sources/Network/Services/MeetingService.swift
+++ b/PLUB/Sources/Network/Services/MeetingService.swift
@@ -15,6 +15,13 @@ class MeetingService: BaseService {
 }
 
 extension MeetingService {
+  func createMeeting(request: CreateMeetingRequest) -> Observable<NetworkResult<GeneralResponse<CreateMeetingResponse>>> {
+    return sendRequest(
+      MeetingRouter.createMeeting(request),
+      type: CreateMeetingResponse.self
+    )
+  }
+  
   func inquireCategoryMeeting(categoryId: String, page: Int = 1, sort: String = "popular") -> Observable<NetworkResult<GeneralResponse<CategoryMeetingResponse>>>  {
     return sendRequest(MeetingRouter.inquireCategoryMeeting(categoryId, page, sort), type: CategoryMeetingResponse.self)
   }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Component/LocationBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Component/LocationBottomSheetViewController.swift
@@ -171,7 +171,7 @@ final class LocationBottomSheetViewController: BottomSheetViewController {
         cell.setupData(
           with: LocationTableViewCellModel(
             title: item.placeName ?? "",
-            subTitle: item.addressName ?? ""
+            subTitle: item.address ?? ""
           )
         )
         return cell
@@ -205,12 +205,14 @@ final class LocationBottomSheetViewController: BottomSheetViewController {
       .asDriver(onErrorDriveWith: .empty())
       .drive(onNext: { _ in
         guard let data = self.viewModel.selectedLocation.value,
+              let address = data.address,
               let roadAddress = data.roadAddress,
               let placeName = data.placeName,
               let positionX = data.placePositionX,
               let positionY = data.placePositionY else { return }
         self.delegate?.selectLocation(
           location: Location(
+            address: address,
             roadAddress: roadAddress,
             placeName: placeName,
             positionX: Double(positionX) ?? 0,

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Component/LocationBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Component/LocationBottomSheetViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol LocationBottomSheetDelegate: AnyObject {
-  func selectLocation(placeName: String)
+  func selectLocation(location: Location)
 }
 
 final class LocationBottomSheetViewController: BottomSheetViewController {
@@ -205,8 +205,18 @@ final class LocationBottomSheetViewController: BottomSheetViewController {
       .asDriver(onErrorDriveWith: .empty())
       .drive(onNext: { _ in
         guard let data = self.viewModel.selectedLocation.value,
-              let placeName = data.placeName else { return}
-        self.delegate?.selectLocation(placeName: placeName)
+              let roadAddress = data.roadAddress,
+              let placeName = data.placeName,
+              let positionX = data.placePositionX,
+              let positionY = data.placePositionY else { return }
+        self.delegate?.selectLocation(
+          location: Location(
+            roadAddress: roadAddress,
+            placeName: placeName,
+            positionX: Double(positionX) ?? 0,
+            positionY: Double(positionY) ?? 0
+          )
+        )
         self.dismiss(animated: false)
       })
       .disposed(by: disposeBag)

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewController.swift
@@ -11,13 +11,7 @@ import RxSwift
 
 final class CreateMeetingViewController: BaseViewController {
   
-  init() {
-    super.init(nibName: nil, bundle: nil)
-  }
-  
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
+  private let viewModel = CreateMeetingViewModel()
   
   private var currentPage = 0 {
     didSet {
@@ -59,42 +53,42 @@ final class CreateMeetingViewController: BaseViewController {
   }
   
   private lazy var meetingCategoryViewController = MeetingCategoryViewController(
-    viewModel: MeetingCategoryViewModel(),
+    viewModel: viewModel.categoryViewModel,
     childIndex: 0
   ).then {
     $0.delegate = self
   }
   
   private lazy var meetingNameViewController = MeetingNameViewController(
-    viewModel: MeetingNameViewModel(),
+    viewModel: viewModel.nameViewModel,
     childIndex: 1
   ).then {
     $0.delegate = self
   }
   
   private lazy var meetingIntroduceViewController = MeetingIntroduceViewController(
-    viewModel: MeetingIntroduceViewModel(),
+    viewModel: viewModel.introduceViewModel,
     childIndex: 2
   ).then {
     $0.delegate = self
   }
   
   private lazy var meetingDateViewController = MeetingDateViewController(
-    viewModel: MeetingDateViewModel(),
+    viewModel: viewModel.dateViewModel,
     childIndex: 3
   ).then {
     $0.delegate = self
   }
   
   private lazy var meetingPeopleNumberViewController = MeetingPeopleNumberViewController(
-    viewModel: MeetingPeopleNumberViewModel(),
+    viewModel: viewModel.peopleNumberViewModel,
     childIndex: 4
   ).then {
     $0.delegate = self
   }
   
   private lazy var meetinQuestionViewController = MeetingQuestionViewController(
-    viewModel: MeetingQuestionViewModel(),
+    viewModel: viewModel.questionViewModel,
     childIndex: 5
   ).then {
     $0.delegate = self
@@ -111,6 +105,14 @@ final class CreateMeetingViewController: BaseViewController {
   
   //TODO: 수빈 - viewModel로 빼기
   private var isNextButtonEnable = [Bool]()
+  
+  init() {
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
   
   // MARK: - Life Cycle
   
@@ -181,6 +183,9 @@ final class CreateMeetingViewController: BaseViewController {
         } else if owner.lastPageIndex + 1 < owner.viewControllers.count {
           owner.lastPageIndex += 1
           owner.currentPage = owner.lastPageIndex
+        } else {
+          let vc = MeetingSummaryViewController()
+          owner.navigationController?.pushViewController(vc, animated: true)
         }
       })
       .disposed(by: disposeBag)

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewController.swift
@@ -184,7 +184,11 @@ final class CreateMeetingViewController: BaseViewController {
           owner.lastPageIndex += 1
           owner.currentPage = owner.lastPageIndex
         } else {
-          let vc = MeetingSummaryViewController()
+          let vc = MeetingSummaryViewController(
+            viewModel: MeetingSummaryViewModel(
+              meetingData: owner.viewModel.setupMeetingData()
+            )
+          )
           owner.navigationController?.pushViewController(vc, animated: true)
         }
       })

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewModel.swift
@@ -1,0 +1,27 @@
+//
+//  CreateMeetingViewModel.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/01/31.
+//
+
+import RxSwift
+
+final class CreateMeetingViewModel {
+  private let disposeBag = DisposeBag()
+  
+  init() {
+  }
+  
+  func createMeeting(
+    categoryViewModel: MeetingCategoryViewModel,
+    nameViewModel: MeetingNameViewModel,
+    introduceViewModel: MeetingIntroduceViewModel,
+    dateViewModel: MeetingDateViewModel,
+    locationViewModel: MeetingLocationViewModel,
+    pepleNumber: MeetingPeopleNumberViewModel,
+    questionViewModel: MeetingQuestionViewModel
+  ) {
+    
+  }
+}

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewModel.swift
@@ -10,7 +10,6 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-
 final class CreateMeetingViewModel {
   private let disposeBag = DisposeBag()
   
@@ -47,9 +46,6 @@ final class CreateMeetingViewModel {
   
   /// 온/오프라인
   private var onOffRelay = BehaviorRelay<OnOff>(value: .on)
-  
-  /// 주소
-  private var addressRelay = BehaviorRelay<String?>(value: nil)
   
   /// 장소
   private var locationRelay = BehaviorRelay<Location?>(value: nil)
@@ -143,5 +139,26 @@ final class CreateMeetingViewModel {
       .do { print($0) }
       .bind(to: questionsRelay)
       .disposed(by: disposeBag)
+  }
+  
+  func setupMeetingData() -> CreateMeetingRequest {
+    CreateMeetingRequest(
+      categoryIDs: categoryIDsRelay.value,
+      title: titleRelay.value,
+      name: nameRelay.value,
+      goal: goalRelay.value,
+      introduce: introduceRelay.value,
+      mainImage: nil,
+      time: timeRelay.value,
+      days: daysRelay.value,
+      onOff: onOffRelay.value,
+      address: locationRelay.value?.address,
+      roadAddress: locationRelay.value?.roadAddress,
+      placeName: locationRelay.value?.placeName,
+      positionX: locationRelay.value?.positionX,
+      positionY: locationRelay.value?.positionY,
+      peopleNumber: peopleNumberRelay.value,
+      questions: questionOnOffRelay.value ? questionsRelay.value : nil
+    )
   }
 }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewModel.swift
@@ -21,7 +21,6 @@ final class CreateMeetingViewModel {
   let peopleNumberViewModel = MeetingPeopleNumberViewModel()
   let questionViewModel = MeetingQuestionViewModel()
   
-  
   /// 선택한 카테고리 리스트
   private let categoryIDsRelay = BehaviorRelay<[Int]>(value: [])
   
@@ -102,6 +101,12 @@ final class CreateMeetingViewModel {
       .do { print($0) }
       .asObservable()
       .bind(to: introduceRelay)
+      .disposed(by: disposeBag)
+    
+    introduceViewModel.imageInputRelay
+      .do { print($0) }
+      .asObservable()
+      .bind(to: mainImageRelay)
       .disposed(by: disposeBag)
     
     dateViewModel.dateInputRelay

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewModel.swift
@@ -51,17 +51,8 @@ final class CreateMeetingViewModel {
   /// 주소
   private var addressRelay = BehaviorRelay<String?>(value: nil)
   
-  /// 도로명 주소
-  private var roadAddressRelay = BehaviorRelay<String?>(value: nil)
-  
-  /// 장소 이름
-  private var placeNameRelay = BehaviorRelay<String?>(value: nil)
-  
-  /// x 좌표
-  private var positionXRelay = BehaviorRelay<Double?>(value: nil)
-  
-  /// y 좌표
-  private var positionYRelay = BehaviorRelay<Double?>(value: nil)
+  /// 장소
+  private var locationRelay = BehaviorRelay<Location?>(value: nil)
   
   /// 인원 수
   private var peopleNumberRelay = BehaviorRelay<Int>(value: 4)
@@ -130,7 +121,7 @@ final class CreateMeetingViewModel {
     dateViewModel.locationInputRelay
       .do { print($0) }
       .asObservable()
-      .bind(to: placeNameRelay)
+      .bind(to: locationRelay)
       .disposed(by: disposeBag)
     
     peopleNumberViewModel.peopleNumber

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewModel.swift
@@ -24,40 +24,40 @@ final class CreateMeetingViewModel {
   private let categoryIDsRelay = BehaviorRelay<[Int]>(value: [])
   
   /// 플러빙 타이틀
-  private var titleRelay = BehaviorRelay<String>(value: "")
+  private let titleRelay = BehaviorRelay<String>(value: "")
   
   /// 플러빙 이름
-  private var nameRelay = BehaviorRelay<String>(value: "")
+  private let nameRelay = BehaviorRelay<String>(value: "")
   
   /// 플러빙 목표
-  private var goalRelay = BehaviorRelay<String>(value: "")
+  private let goalRelay = BehaviorRelay<String>(value: "")
   
   /// 소개
-  private var introduceRelay = BehaviorRelay<String>(value: "")
+  private let introduceRelay = BehaviorRelay<String>(value: "")
   
   /// 메인 이미지
-  private var mainImageRelay = BehaviorRelay<UIImage?>(value: nil)
+  private let mainImageRelay = BehaviorRelay<UIImage?>(value: nil)
   
   /// 시간
-  private var timeRelay = BehaviorRelay<String>(value: "")
+  private let timeRelay = BehaviorRelay<String>(value: "")
   
   /// 요일
-  private var daysRelay = BehaviorRelay<[String]>(value: [])
+  private let daysRelay = BehaviorRelay<[String]>(value: [])
   
   /// 온/오프라인
-  private var onOffRelay = BehaviorRelay<OnOff>(value: .on)
+  private let onOffRelay = BehaviorRelay<OnOff>(value: .on)
   
   /// 장소
-  private var locationRelay = BehaviorRelay<Location?>(value: nil)
+  private let locationRelay = BehaviorRelay<Location?>(value: nil)
   
   /// 인원 수
-  private var peopleNumberRelay = BehaviorRelay<Int>(value: 4)
+  private let peopleNumberRelay = BehaviorRelay<Int>(value: 4)
   
   /// 질문 여부
-  private var questionOnOffRelay = BehaviorRelay<Bool>(value: true)
+  private let questionOnOffRelay = BehaviorRelay<Bool>(value: true)
   
   /// 질문 리스트
-  private var questionsRelay = BehaviorRelay<[String]>(value: [])
+  private let questionsRelay = BehaviorRelay<[String]>(value: [])
   
   init() {
     categoryViewModel.selectedSubCategories
@@ -66,63 +66,51 @@ final class CreateMeetingViewModel {
       .disposed(by: disposeBag)
     
     nameViewModel.introduceTitleInputRelay
-      .asObservable()
       .bind(to: titleRelay)
       .disposed(by: disposeBag)
     
     nameViewModel.nameTitleInputRelay
-      .asObservable()
       .bind(to: nameRelay)
       .disposed(by: disposeBag)
     
     introduceViewModel.goalInputRelay
-      .asObservable()
       .bind(to: goalRelay)
       .disposed(by: disposeBag)
     
     introduceViewModel.introduceInputRelay
-      .asObservable()
       .bind(to: introduceRelay)
       .disposed(by: disposeBag)
     
     introduceViewModel.imageInputRelay
-      .asObservable()
       .bind(to: mainImageRelay)
       .disposed(by: disposeBag)
     
     dateViewModel.dateInputRelay
-      .asObservable()
       .bind(to: daysRelay)
       .disposed(by: disposeBag)
     
     dateViewModel.timeInputRelay
-      .asObservable()
       .bind(to: timeRelay)
       .disposed(by: disposeBag)
     
     dateViewModel.onOffInputRelay
-      .asObservable()
       .bind(to: onOffRelay)
       .disposed(by: disposeBag)
     
     dateViewModel.locationInputRelay
-      .asObservable()
       .bind(to: locationRelay)
       .disposed(by: disposeBag)
     
     peopleNumberViewModel.peopleNumber
-      .asObservable()
       .bind(to: peopleNumberRelay)
       .disposed(by: disposeBag)
     
     questionViewModel.noQuestionMode
-      .asObservable()
       .map { !$0 }
       .bind(to: questionOnOffRelay)
       .disposed(by: disposeBag)
     
     questionViewModel.questionListBehaviorRelay
-      .asObservable()
       .map { $0.map { $0.question } }
       .bind(to: questionsRelay)
       .disposed(by: disposeBag)

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewModel.swift
@@ -61,67 +61,56 @@ final class CreateMeetingViewModel {
   
   init() {
     categoryViewModel.selectedSubCategories
-      .do { print($0) }
       .asObservable()
       .bind(to: categoryIDsRelay)
       .disposed(by: disposeBag)
     
     nameViewModel.introduceTitleInputRelay
-      .do { print($0) }
       .asObservable()
       .bind(to: titleRelay)
       .disposed(by: disposeBag)
     
     nameViewModel.nameTitleInputRelay
-      .do { print($0) }
       .asObservable()
       .bind(to: nameRelay)
       .disposed(by: disposeBag)
     
     introduceViewModel.goalInputRelay
-      .do { print($0) }
       .asObservable()
       .bind(to: goalRelay)
       .disposed(by: disposeBag)
     
     introduceViewModel.introduceInputRelay
-      .do { print($0) }
       .asObservable()
       .bind(to: introduceRelay)
       .disposed(by: disposeBag)
     
     introduceViewModel.imageInputRelay
-      .do { print($0) }
       .asObservable()
       .bind(to: mainImageRelay)
       .disposed(by: disposeBag)
     
     dateViewModel.dateInputRelay
-      .do { print($0) }
       .asObservable()
       .bind(to: daysRelay)
       .disposed(by: disposeBag)
     
     dateViewModel.timeInputRelay
-      .do { print($0) }
       .asObservable()
       .bind(to: timeRelay)
       .disposed(by: disposeBag)
     
     dateViewModel.onOffInputRelay
-      .do { print($0) }
       .asObservable()
       .bind(to: onOffRelay)
       .disposed(by: disposeBag)
     
     dateViewModel.locationInputRelay
-      .do { print($0) }
       .asObservable()
       .bind(to: locationRelay)
       .disposed(by: disposeBag)
     
     peopleNumberViewModel.peopleNumber
-      .do { print($0) }
       .asObservable()
       .bind(to: peopleNumberRelay)
       .disposed(by: disposeBag)
@@ -129,14 +118,12 @@ final class CreateMeetingViewModel {
     questionViewModel.noQuestionMode
       .asObservable()
       .map { !$0 }
-      .do { print($0) }
       .bind(to: questionOnOffRelay)
       .disposed(by: disposeBag)
     
     questionViewModel.questionListBehaviorRelay
       .asObservable()
       .map { $0.map { $0.question } }
-      .do { print($0) }
       .bind(to: questionsRelay)
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/CreateMeetingViewModel.swift
@@ -5,23 +5,147 @@
 //  Created by 김수빈 on 2023/01/31.
 //
 
+import UIKit
+
 import RxSwift
+import RxCocoa
+
 
 final class CreateMeetingViewModel {
   private let disposeBag = DisposeBag()
   
-  init() {
-  }
+  let categoryViewModel = MeetingCategoryViewModel()
+  let nameViewModel = MeetingNameViewModel()
+  let introduceViewModel = MeetingIntroduceViewModel()
+  let dateViewModel = MeetingDateViewModel()
+  let peopleNumberViewModel = MeetingPeopleNumberViewModel()
+  let questionViewModel = MeetingQuestionViewModel()
   
-  func createMeeting(
-    categoryViewModel: MeetingCategoryViewModel,
-    nameViewModel: MeetingNameViewModel,
-    introduceViewModel: MeetingIntroduceViewModel,
-    dateViewModel: MeetingDateViewModel,
-    locationViewModel: MeetingLocationViewModel,
-    pepleNumber: MeetingPeopleNumberViewModel,
-    questionViewModel: MeetingQuestionViewModel
-  ) {
+  
+  /// 선택한 카테고리 리스트
+  private let categoryIDsRelay = BehaviorRelay<[Int]>(value: [])
+  
+  /// 플러빙 타이틀
+  private var titleRelay = BehaviorRelay<String>(value: "")
+  
+  /// 플러빙 이름
+  private var nameRelay = BehaviorRelay<String>(value: "")
+  
+  /// 플러빙 목표
+  private var goalRelay = BehaviorRelay<String>(value: "")
+  
+  /// 소개
+  private var introduceRelay = BehaviorRelay<String>(value: "")
+  
+  /// 메인 이미지
+  private var mainImageRelay = BehaviorRelay<UIImage?>(value: nil)
+  
+  /// 시간
+  private var timeRelay = BehaviorRelay<String>(value: "")
+  
+  /// 요일
+  private var daysRelay = BehaviorRelay<[String]>(value: [])
+  
+  /// 온/오프라인
+  private var onOffRelay = BehaviorRelay<OnOff>(value: .on)
+  
+  /// 주소
+  private var addressRelay = BehaviorRelay<String?>(value: nil)
+  
+  /// 도로명 주소
+  private var roadAddressRelay = BehaviorRelay<String?>(value: nil)
+  
+  /// 장소 이름
+  private var placeNameRelay = BehaviorRelay<String?>(value: nil)
+  
+  /// x 좌표
+  private var positionXRelay = BehaviorRelay<Double?>(value: nil)
+  
+  /// y 좌표
+  private var positionYRelay = BehaviorRelay<Double?>(value: nil)
+  
+  /// 인원 수
+  private var peopleNumberRelay = BehaviorRelay<Int>(value: 4)
+  
+  /// 질문 여부
+  private var questionOnOffRelay = BehaviorRelay<Bool>(value: true)
+  
+  /// 질문 리스트
+  private var questionsRelay = BehaviorRelay<[String]>(value: [])
+  
+  init() {
+    categoryViewModel.selectedSubCategories
+      .do { print($0) }
+      .asObservable()
+      .bind(to: categoryIDsRelay)
+      .disposed(by: disposeBag)
     
+    nameViewModel.introduceTitleInputRelay
+      .do { print($0) }
+      .asObservable()
+      .bind(to: titleRelay)
+      .disposed(by: disposeBag)
+    
+    nameViewModel.nameTitleInputRelay
+      .do { print($0) }
+      .asObservable()
+      .bind(to: nameRelay)
+      .disposed(by: disposeBag)
+    
+    introduceViewModel.goalInputRelay
+      .do { print($0) }
+      .asObservable()
+      .bind(to: goalRelay)
+      .disposed(by: disposeBag)
+    
+    introduceViewModel.introduceInputRelay
+      .do { print($0) }
+      .asObservable()
+      .bind(to: introduceRelay)
+      .disposed(by: disposeBag)
+    
+    dateViewModel.dateInputRelay
+      .do { print($0) }
+      .asObservable()
+      .bind(to: daysRelay)
+      .disposed(by: disposeBag)
+    
+    dateViewModel.timeInputRelay
+      .do { print($0) }
+      .asObservable()
+      .bind(to: timeRelay)
+      .disposed(by: disposeBag)
+    
+    dateViewModel.onOffInputRelay
+      .do { print($0) }
+      .asObservable()
+      .bind(to: onOffRelay)
+      .disposed(by: disposeBag)
+    
+    dateViewModel.locationInputRelay
+      .do { print($0) }
+      .asObservable()
+      .bind(to: placeNameRelay)
+      .disposed(by: disposeBag)
+    
+    peopleNumberViewModel.peopleNumber
+      .do { print($0) }
+      .asObservable()
+      .bind(to: peopleNumberRelay)
+      .disposed(by: disposeBag)
+    
+    questionViewModel.noQuestionMode
+      .asObservable()
+      .map { !$0 }
+      .do { print($0) }
+      .bind(to: questionOnOffRelay)
+      .disposed(by: disposeBag)
+    
+    questionViewModel.questionListBehaviorRelay
+      .asObservable()
+      .map { $0.map { $0.question } }
+      .do { print($0) }
+      .bind(to: questionsRelay)
+      .disposed(by: disposeBag)
   }
 }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Model/CreateMeetingRequest.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Model/CreateMeetingRequest.swift
@@ -29,7 +29,7 @@ struct CreateMeetingRequest: Codable {
   var introduce: String
   
   /// 메인 이미지
-  var mainImage: String
+  var mainImage: String?
   
   /// 시간
   var time: String
@@ -41,7 +41,7 @@ struct CreateMeetingRequest: Codable {
   var onOff: OnOff
   
   /// 주소
-  var address: String
+  var address: String?
   
   /// 도로명 주소
   var roadAddress: String?
@@ -59,7 +59,7 @@ struct CreateMeetingRequest: Codable {
   var peopleNumber: Int
   
   /// 질문 리스트
-  var questions: [String]
+  var questions: [String]?
 }
 
 extension CreateMeetingRequest {

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Model/CreateMeetingRequest.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Model/CreateMeetingRequest.swift
@@ -1,0 +1,84 @@
+//
+//  CreateMeetingRequest.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/02/01.
+//
+
+import Foundation
+
+enum OnOff: String, Codable {
+  case on = "ON"
+  case off = "OFF"
+}
+
+struct CreateMeetingRequest: Codable {
+  /// 선택한 카테고리 리스트
+  var categoryIDs: [Int]
+  
+  /// 플러빙 타이틀
+  var title: String
+  
+  /// 플러빙 이름
+  var name: String
+  
+  /// 플러빙 목표
+  var goal: String
+  
+  /// 소개
+  var introduce: String
+  
+  /// 메인 이미지
+  var mainImage: String
+  
+  /// 시간
+  var time: String
+  
+  /// 요일
+  var days: [String]
+  
+  /// 온/오프라인
+  var onOff: OnOff
+  
+  /// 주소
+  var address: String
+  
+  /// 도로명 주소
+  var roadAddress: String?
+  
+  /// 장소 이름
+  var placeName: String?
+  
+  /// x 좌표
+  var positionX: Double?
+  
+  /// y 좌표
+  var positionY: Double?
+  
+  /// 인원 수
+  var peopleNumber: Int
+  
+  /// 질문 리스트
+  var questions: [String]
+}
+
+extension CreateMeetingRequest {
+  enum CodingKeys: String, CodingKey {
+    case categoryIDs = "subCategoryIds"
+    case title
+    case name
+    case goal
+    case introduce
+    case mainImage
+    case time
+    case days
+    case onOff
+    case address
+    case roadAddress
+    case placeName
+    case positionX = "placePositionX"
+    case positionY = "placePositionY"
+    case peopleNumber = "maxAccountNum"
+    case questions
+  }
+}

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Model/CreateMeetingResponse.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Model/CreateMeetingResponse.swift
@@ -1,0 +1,18 @@
+//
+//  CreateMeetingResponse.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/02/01.
+//
+
+import Foundation
+
+struct CreateMeetingResponse: Codable {
+  
+  /// 플러빙 ID
+  let plubbingID: String
+  
+  enum CodingKeys: String, CodingKey {
+    case plubbingID = "plubbingId"
+  }
+}

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingDateViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingDateViewController.swift
@@ -256,10 +256,10 @@ extension MeetingDateViewController: DateBottomSheetDelegate {
 }
 
 extension MeetingDateViewController: LocationBottomSheetDelegate {
-  func selectLocation(placeName: String) {
-    locationControl.setLocationLabelText(text: placeName)
+  func selectLocation(location: Location) {
+    locationControl.setLocationLabelText(text: location.placeName ?? "")
     locationControl.isSelected = true
-    viewModel.locationInputRelay.accept(placeName)
+    viewModel.locationInputRelay.accept(location)
   }
 }
 

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingDateViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingDateViewController.swift
@@ -198,7 +198,7 @@ final class MeetingDateViewController: BaseViewController {
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
         owner.changeOnOffButton(state: true)
-        owner.viewModel.onOffInputRelay.accept("ON")
+        owner.viewModel.onOffInputRelay.accept(.on)
       })
       .disposed(by: disposeBag)
     
@@ -206,7 +206,7 @@ final class MeetingDateViewController: BaseViewController {
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
         owner.changeOnOffButton(state: false)
-        owner.viewModel.onOffInputRelay.accept("OFF")
+        owner.viewModel.onOffInputRelay.accept(.off)
       })
        .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingIntroduceViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingIntroduceViewController.swift
@@ -179,19 +179,6 @@ extension MeetingIntroduceViewController: PhotoBottomSheetDelegate {
       $0.height.equalTo(width * image.size.height / image.size.width)
     }
     
-    ImageService.shared.uploadImage(images: [image], params: UploadImageRequest(type: .plubbingMain))
-      .subscribe(onNext: { result in
-        switch result {
-        case .success(let model):
-          print(model)
-          
-        case .requestError(let model):
-          print(model)
-        case .networkError, .serverError, .pathError:
-          // TODO: 수빈 - PLUB 에러 Alert 띄우기
-          break
-        }
-      })
-      .disposed(by: disposeBag)
+    viewModel.imageInputRelay.accept(image)
   }
 }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingSummaryViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingSummaryViewController.swift
@@ -1,0 +1,37 @@
+//
+//  MeetingSummaryViewController.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/01/31.
+//
+
+import UIKit
+
+final class MeetingSummaryViewController: BaseViewController {
+  
+  
+  // MARK: - Life Cycle
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+  }
+  
+  // MARK: - Configuration
+  
+  override func setupLayouts() {
+    super.setupLayouts()
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+  }
+  
+  override func setupStyles() {
+    super.setupStyles()
+    view.backgroundColor = .systemBackground
+  }
+  
+  override func bind() {
+    super.bind()
+  }
+}

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingSummaryViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingSummaryViewController.swift
@@ -9,6 +9,18 @@ import UIKit
 
 final class MeetingSummaryViewController: BaseViewController {
   
+  private var viewModel: MeetingSummaryViewModel
+  
+  init(
+    viewModel: MeetingSummaryViewModel
+  ) {
+    self.viewModel = viewModel
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
   
   // MARK: - Life Cycle
   

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingDateViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingDateViewModel.swift
@@ -5,39 +5,46 @@
 //  Created by 김수빈 on 2023/01/19.
 //
 
+import Foundation
+
 import RxSwift
 import RxCocoa
 
-enum Day: CaseIterable {
-  case MON
-  case TUE
-  case WED
-  case THR
-  case FRI
-  case SAT
-  case SUN
-  case ALL
+enum Day: String, CaseIterable {
+  case monday
+  case tuesday
+  case wednesday
+  case thursday
+  case friday
+  case saturday
+  case sunday
+  case all
   
-  var toKOR: String {
+  var kor: String {
     switch self {
-    case .MON:
-      return "월"
-    case .TUE:
-      return "화"
-    case .WED:
-      return "수"
-    case .THR:
-      return "목"
-    case .FRI:
-      return "금"
-    case .SAT:
-      return "토"
-    case .SUN:
-      return "일"
-    case .ALL:
-      return "요일 무관"
+    case .monday: return "월"
+    case .tuesday: return "화"
+    case .wednesday: return "수"
+    case .thursday: return "목"
+    case .friday: return "금"
+    case .saturday: return "토"
+    case .sunday: return "일"
+    case .all: return "요일 무관"
     }
   }
+  
+  var eng: String {
+    switch self {
+    case .monday: return "MON"
+    case .tuesday: return "TUE"
+    case .wednesday: return "WED"
+    case .thursday: return "THR"
+    case .friday: return "FRI"
+    case .saturday: return "SAT"
+    case .sunday: return "SUN"
+    case .all: return "ALL"
+    }
+   }
 }
 
 final class MeetingDateViewModel {
@@ -57,7 +64,7 @@ final class MeetingDateViewModel {
   
   init() {
     let dateList = Day.allCases
-      .map { $0.toKOR }
+      .map { $0.kor }
       .map {
         MeetingDateCollectionViewCellModel(
           date: $0,
@@ -95,7 +102,7 @@ final class MeetingDateViewModel {
     let cellDatas = dateCellData.value // collectionView 셀 데이터 (date: 요일, isSelected: 선택 여부)
     
     if data.isSelected { // CASE 1) 선택 해제
-      dateInputRelay.accept(dates.filter { $0 != data.date.fromENGToKOR() }) // 선택된 요일 값 삭제
+      dateInputRelay.accept(dates.filter { $0 != data.date.fromKORToENG() }) // 선택된 요일 값 삭제
       dateCellData.accept(
         cellDatas.map {
           MeetingDateCollectionViewCellModel(
@@ -105,20 +112,20 @@ final class MeetingDateViewModel {
         }
       )
     }
-    else if data.date == "요일 무관" { // CASE 2) 요일 무관 선택
-      dateInputRelay.accept([data.date.fromENGToKOR()]) // "요일 무관"만 존재
+    else if data.date == Day.all.kor { // CASE 2) 요일 무관 선택
+      dateInputRelay.accept([data.date.fromKORToENG()]) // "요일 무관"만 존재
       dateCellData.accept(
         cellDatas.map {
           MeetingDateCollectionViewCellModel(
             date: $0.date,
-            isSelected: $0.date == "요일 무관" ? true : false // "요일 무관"만 isSelected true, 나머지는 false로 변경
+            isSelected: $0.date == Day.all.kor ? true : false // "요일 무관"만 isSelected true, 나머지는 false로 변경
           )
         }
       )
     }
     else { // CASE 3) 요일 무관 제외한 요일 선택
-      var filterDates = dates.filter { $0 != "요일 무관" } // "요일 무관" 삭제하고,
-      filterDates.append(data.date.fromENGToKOR()) // 선택된 요일 값 추가
+      var filterDates = dates.filter { $0 != Day.all.eng } // "요일 무관" 삭제하고,
+      filterDates.append(data.date.fromKORToENG()) // 선택된 요일 값 추가
       dateInputRelay.accept(filterDates)
       
       dateCellData.accept(
@@ -126,7 +133,7 @@ final class MeetingDateViewModel {
           return MeetingDateCollectionViewCellModel(
             date: $0.date,
             isSelected: {
-              if $0.date == "요일 무관" { // "요일 무관"은 isSelected false
+              if $0.date == Day.all.kor { // "요일 무관"은 isSelected false
                 return false
               } else if $0.date == data.date { // 선택된 요일은 isSelected true
                 return true

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingDateViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingDateViewModel.swift
@@ -48,6 +48,7 @@ enum Day: String, CaseIterable {
 }
 
 struct Location {
+  let address: String?
   let roadAddress: String?
   let placeName: String?
   let positionX: Double?

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingDateViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingDateViewModel.swift
@@ -47,6 +47,13 @@ enum Day: String, CaseIterable {
    }
 }
 
+struct Location {
+  let roadAddress: String?
+  let placeName: String?
+  let positionX: Double?
+  let positionY: Double?
+}
+
 final class MeetingDateViewModel {
   private let disposeBag = DisposeBag()
 
@@ -57,7 +64,7 @@ final class MeetingDateViewModel {
   let dateInputRelay = BehaviorRelay<[String]>.init(value: .init())
   let timeInputRelay = BehaviorRelay<String>.init(value: .init())
   let onOffInputRelay = BehaviorRelay<OnOff>.init(value: .on)
-  let locationInputRelay = BehaviorRelay<String>.init(value: .init())
+  let locationInputRelay = BehaviorRelay<Location?>.init(value: nil)
   
   // OutPut
   let isBtnEnabled: Observable<Bool>
@@ -79,7 +86,7 @@ final class MeetingDateViewModel {
     ).map {
       if $0.0 == OnOff.on {
         return true
-      } else if $0.0 == OnOff.off && !$0.1.isEmpty {
+      } else if $0.0 == OnOff.off && !($0.1 == nil) {
         return true
       } else {
         return false

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingDateViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingDateViewModel.swift
@@ -49,7 +49,7 @@ final class MeetingDateViewModel {
   // Input
   let dateInputRelay = BehaviorRelay<[String]>.init(value: .init())
   let timeInputRelay = BehaviorRelay<String>.init(value: .init())
-  let onOffInputRelay = BehaviorRelay<String>.init(value: "ON")
+  let onOffInputRelay = BehaviorRelay<OnOff>.init(value: .on)
   let locationInputRelay = BehaviorRelay<String>.init(value: .init())
   
   // OutPut
@@ -70,9 +70,9 @@ final class MeetingDateViewModel {
       onOffInputRelay,
       locationInputRelay
     ).map {
-      if $0.0.contains("ON") {
+      if $0.0 == OnOff.on {
         return true
-      } else if $0.0.contains("OFF") && !$0.1.isEmpty {
+      } else if $0.0 == OnOff.off && !$0.1.isEmpty {
         return true
       } else {
         return false

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingIntroduceViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingIntroduceViewModel.swift
@@ -5,6 +5,8 @@
 //  Created by 김수빈 on 2023/01/16.
 //
 
+import UIKit
+
 import RxSwift
 import RxCocoa
 
@@ -13,6 +15,7 @@ final class MeetingIntroduceViewModel: ViewModelType {
   
   let goalInputRelay = BehaviorRelay<String>.init(value: .init())
   let introduceInputRelay = BehaviorRelay<String>.init(value: .init())
+  let imageInputRelay = BehaviorRelay<UIImage>.init(value: UIImage())
   
   struct Input {
     let goalText: Observable<String>

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingIntroduceViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingIntroduceViewModel.swift
@@ -11,8 +11,8 @@ import RxCocoa
 final class MeetingIntroduceViewModel: ViewModelType {
   private let disposeBag = DisposeBag()
   
-  private let goalInputRelay = BehaviorRelay<String>.init(value: .init())
-  private let introduceInputRelay = BehaviorRelay<String>.init(value: .init())
+  let goalInputRelay = BehaviorRelay<String>.init(value: .init())
+  let introduceInputRelay = BehaviorRelay<String>.init(value: .init())
   
   struct Input {
     let goalText: Observable<String>

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingNameViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingNameViewModel.swift
@@ -18,8 +18,8 @@ protocol ViewModelType {
 final class MeetingNameViewModel: ViewModelType {
   private lazy var disposeBag = DisposeBag()
   
-  private let introduceTitleInputRelay = BehaviorRelay<String>.init(value: .init())
-  private let nameTitleInputRelay = BehaviorRelay<String>.init(value: .init())
+  let introduceTitleInputRelay = BehaviorRelay<String>.init(value: .init())
+  let nameTitleInputRelay = BehaviorRelay<String>.init(value: .init())
   
   struct Input {
     let introduceTitleText: Observable<String>

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingQuestionViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingQuestionViewModel.swift
@@ -19,7 +19,7 @@ final class MeetingQuestionViewModel {
   // Input
   var questionList: [String]
   let questionListBehaviorRelay: BehaviorRelay<[MeetingQuestionCellModel]>
-  var noQuestionMode: BehaviorRelay<Bool>
+  let noQuestionMode: BehaviorRelay<Bool>
   
   // Output
   let allQuestionFilled: BehaviorRelay<Bool>

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingSummaryViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingSummaryViewModel.swift
@@ -15,6 +15,5 @@ final class MeetingSummaryViewModel {
   
   init(meetingData: CreateMeetingRequest) {
     self.meetingData = meetingData
-    print(meetingData)
   }
 }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingSummaryViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewModel/MeetingSummaryViewModel.swift
@@ -1,0 +1,20 @@
+//
+//  MeetingSummaryViewModel.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/02/01.
+//
+
+import RxSwift
+import RxCocoa
+
+final class MeetingSummaryViewModel {
+  private let disposeBag = DisposeBag()
+  
+  let meetingData: CreateMeetingRequest
+  
+  init(meetingData: CreateMeetingRequest) {
+    self.meetingData = meetingData
+    print(meetingData)
+  }
+}


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 모임생성에 필요한 데이터를 취합해 모임생성 요약뷰에 전달

🌱 PR 포인트

- parent viewModel에서 child viewModel들을 가지고 있고, child viewModel안에 필요한 데이터들을 parent viewModel이 bind하는 형태
- 실시간으로 child viewModel -> parent viewModel로 데이터를 전달
- ❗️이미지 데이터는 아직 전달하지 않았습니다!
- ❗️모임 요약뷰 & 모임 생성 API까지 연결하면 pr이 너무 커질 것 같아 쪼개서 올리겠습니다!

```swift
final class CreateMeetingViewModel {
  private let disposeBag = DisposeBag()
  
  let categoryViewModel = MeetingCategoryViewModel()
  let nameViewModel = MeetingNameViewModel()
  let introduceViewModel = MeetingIntroduceViewModel()
  let dateViewModel = MeetingDateViewModel()
  let peopleNumberViewModel = MeetingPeopleNumberViewModel()
  let questionViewModel = MeetingQuestionViewModel()

  /// 선택한 카테고리 리스트
  private let categoryIDsRelay = BehaviorRelay<[Int]>(value: [])

  init() {
    categoryViewModel.selectedSubCategories
      .asObservable()
      .bind(to: categoryIDsRelay)
      .disposed(by: disposeBag)
  }
}
```

## 📸 스크린샷
|스크린샷|
|:--:|
|![스크린샷 2023-02-01 오전 9 11 50](https://user-images.githubusercontent.com/77331348/215913312-e3a8b679-0e14-4251-929a-920c7a4b582c.png)
|

## 📮 관련 이슈
- #24 

