### PR TITLE
[Splash] 최초 실행 화면 구현

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		BA94E81C297E706A00DF23CE /* IntroductionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA94E81B297E706A00DF23CE /* IntroductionViewModel.swift */; };
 		BABB011A297ED415004178EC /* InterestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB0119297ED415004178EC /* InterestViewController.swift */; };
 		BABB011C297ED74C004178EC /* InterestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB011B297ED74C004178EC /* InterestViewModel.swift */; };
+		BAC5EF2D298A9E4300F3955E /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC5EF2C298A9E4300F3955E /* SplashViewController.swift */; };
 		BAC8930929755B87000D44E2 /* SignUpRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC8930829755B87000D44E2 /* SignUpRequest.swift */; };
 		BAC923DF29546BF500385841 /* BirthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC923DE29546BF500385841 /* BirthViewController.swift */; };
 		BAE16029292221ED00D595FF /* CheckBoxButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE16028292221ED00D595FF /* CheckBoxButton.swift */; };
@@ -315,6 +316,7 @@
 		BA94E81B297E706A00DF23CE /* IntroductionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionViewModel.swift; sourceTree = "<group>"; };
 		BABB0119297ED415004178EC /* InterestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewController.swift; sourceTree = "<group>"; };
 		BABB011B297ED74C004178EC /* InterestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewModel.swift; sourceTree = "<group>"; };
+		BAC5EF2C298A9E4300F3955E /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		BAC8930829755B87000D44E2 /* SignUpRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequest.swift; sourceTree = "<group>"; };
 		BAC923DE29546BF500385841 /* BirthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthViewController.swift; sourceTree = "<group>"; };
 		BAE058E528EC7CEC00F09BD8 /* PLUB.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PLUB.entitlements; sourceTree = "<group>"; };
@@ -631,6 +633,7 @@
 		BA36EED32954637F00D30169 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				BAC5EF2B298A9E2D00F3955E /* Splash */,
 				BA8AA42B2988FCAC004E9403 /* Onboarding */,
 				BA42D1EE28EDE05000C20061 /* Home */,
 				BA42D1EF28EDE05A00C20061 /* Login */,
@@ -896,6 +899,14 @@
 				BA8AA436298901B9004E9403 /* Onboarding3.json */,
 			);
 			path = Onboarding;
+			sourceTree = "<group>";
+		};
+		BAC5EF2B298A9E2D00F3955E /* Splash */ = {
+			isa = PBXGroup;
+			children = (
+				BAC5EF2C298A9E4300F3955E /* SplashViewController.swift */,
+			);
+			path = Splash;
 			sourceTree = "<group>";
 		};
 		BAC923DD29546BF000385841 /* Birth */ = {
@@ -1164,6 +1175,7 @@
 				C3DE688B2976CF120079B76F /* BottomSheetViewController.swift in Sources */,
 				C34C097029773860001AFF16 /* DateBottomSheetViewController.swift in Sources */,
 				C38A5B9D297AFDCD00485355 /* LocationBottomSheetViewController.swift in Sources */,
+				BAC5EF2D298A9E4300F3955E /* SplashViewController.swift in Sources */,
 				C3B04E4229816B9C00188E60 /* ImageRouter.swift in Sources */,
 				BA8E2B4429746738009DDF32 /* AuthRouter.swift in Sources */,
 				BA94E81C297E706A00DF23CE /* IntroductionViewModel.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		BABB011A297ED415004178EC /* InterestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB0119297ED415004178EC /* InterestViewController.swift */; };
 		BABB011C297ED74C004178EC /* InterestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB011B297ED74C004178EC /* InterestViewModel.swift */; };
 		BAC5EF2D298A9E4300F3955E /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC5EF2C298A9E4300F3955E /* SplashViewController.swift */; };
+		BAC5EF2F298AA23700F3955E /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC5EF2E298AA23700F3955E /* SplashViewModel.swift */; };
 		BAC8930929755B87000D44E2 /* SignUpRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC8930829755B87000D44E2 /* SignUpRequest.swift */; };
 		BAC923DF29546BF500385841 /* BirthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC923DE29546BF500385841 /* BirthViewController.swift */; };
 		BAE16029292221ED00D595FF /* CheckBoxButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE16028292221ED00D595FF /* CheckBoxButton.swift */; };
@@ -317,6 +318,7 @@
 		BABB0119297ED415004178EC /* InterestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewController.swift; sourceTree = "<group>"; };
 		BABB011B297ED74C004178EC /* InterestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewModel.swift; sourceTree = "<group>"; };
 		BAC5EF2C298A9E4300F3955E /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
+		BAC5EF2E298AA23700F3955E /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
 		BAC8930829755B87000D44E2 /* SignUpRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequest.swift; sourceTree = "<group>"; };
 		BAC923DE29546BF500385841 /* BirthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthViewController.swift; sourceTree = "<group>"; };
 		BAE058E528EC7CEC00F09BD8 /* PLUB.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PLUB.entitlements; sourceTree = "<group>"; };
@@ -905,6 +907,7 @@
 			isa = PBXGroup;
 			children = (
 				BAC5EF2C298A9E4300F3955E /* SplashViewController.swift */,
+				BAC5EF2E298AA23700F3955E /* SplashViewModel.swift */,
 			);
 			path = Splash;
 			sourceTree = "<group>";
@@ -1260,6 +1263,7 @@
 				BA88125028E48A2F00BD832A /* SceneDelegate.swift in Sources */,
 				C344E5412986B9D7009F73A9 /* MeetingCategoryViewModel.swift in Sources */,
 				70F1DFDA29795AB900F9BC83 /* AllCategoryListResponse.swift in Sources */,
+				BAC5EF2F298AA23700F3955E /* SplashViewModel.swift in Sources */,
 				C38A5B95297AD5B000485355 /* KakaoLocationRouter.swift in Sources */,
 				70F1DFD42979508000F9BC83 /* CategoryService.swift in Sources */,
 				BA780E1529714AAB0032C178 /* GeneralResponse.swift in Sources */,

--- a/PLUB/Configuration/Manager/UserManager.swift
+++ b/PLUB/Configuration/Manager/UserManager.swift
@@ -15,6 +15,12 @@ final class UserManager {
   
   static let shared = UserManager()
   
+  // MARK: - User Options
+  
+  /// 최초 실행 여부를 확인하는 변수
+  @UserDefaultsWrapper<Bool>(key: "isLaunchedBefore")
+  private(set) var isLaunchedBefore
+  
   // MARK: - PLUB Token
   
   @KeyChainWrapper<String>(key: "signToken")
@@ -59,6 +65,11 @@ extension UserManager {
   /// - Parameter socialType: 소셜로그인 타입(애플, 구글, 카카오)
   func set(socialType: SignInType) {
     loginnedType = socialType
+  }
+  
+  /// 최초 실행 여부를 세팅합니다.
+  func set(isLaunchedBefore: Bool) {
+    self.isLaunchedBefore = isLaunchedBefore
   }
   
   /// 유저의 정보를 전부 초기화합니다.

--- a/PLUB/SceneDelegate.swift
+++ b/PLUB/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     guard let windowScene = scene as? UIWindowScene else { return }
     
     window = UIWindow(windowScene: windowScene)
-    window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
+    window?.rootViewController = UINavigationController(rootViewController: SplashViewController())
     window?.makeKeyAndVisible()
   }
   

--- a/PLUB/Sources/Views/Splash/SplashViewController.swift
+++ b/PLUB/Sources/Views/Splash/SplashViewController.swift
@@ -43,7 +43,8 @@ final class SplashViewController: BaseViewController {
     super.bind()
     
     viewModel.shouldMoveToVC
-      .delay(.milliseconds(1500))
+      .skip(1) // 초기값 무시
+      .delay(.milliseconds(700)) // 어느정도 Splash화면이 보여지도록 0.7초 딜레이
       .drive(with: self) { owner, vc in
         owner.navigationController?.setViewControllers([vc], animated: true)
       }

--- a/PLUB/Sources/Views/Splash/SplashViewController.swift
+++ b/PLUB/Sources/Views/Splash/SplashViewController.swift
@@ -12,6 +12,8 @@ import Then
 
 final class SplashViewController: BaseViewController {
   
+  private let viewModel = SplashViewModel()
+  
   /// PLUB Image
   private let imageView = UIImageView().then {
     $0.image = UIImage(named: "Logo")

--- a/PLUB/Sources/Views/Splash/SplashViewController.swift
+++ b/PLUB/Sources/Views/Splash/SplashViewController.swift
@@ -43,6 +43,7 @@ final class SplashViewController: BaseViewController {
     super.bind()
     
     viewModel.shouldMoveToVC
+      .delay(.milliseconds(1500))
       .drive(with: self) { owner, vc in
         owner.navigationController?.setViewControllers([vc], animated: true)
       }

--- a/PLUB/Sources/Views/Splash/SplashViewController.swift
+++ b/PLUB/Sources/Views/Splash/SplashViewController.swift
@@ -1,0 +1,18 @@
+//
+//  SplashViewController.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/02/01.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class SplashViewController: BaseViewController {
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+  }
+}

--- a/PLUB/Sources/Views/Splash/SplashViewController.swift
+++ b/PLUB/Sources/Views/Splash/SplashViewController.swift
@@ -12,7 +12,26 @@ import Then
 
 final class SplashViewController: BaseViewController {
   
-  override func viewDidLoad() {
-    super.viewDidLoad()
+  /// PLUB Image
+  private let imageView = UIImageView().then {
+    $0.image = UIImage(named: "Logo")
+    $0.contentMode = .scaleAspectFit
+  }
+  
+  override func setupLayouts() {
+    super.setupLayouts()
+    view.addSubview(imageView)
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    imageView.snp.makeConstraints {
+      $0.center.equalToSuperview()
+      $0.directionalHorizontalEdges.equalToSuperview().inset(94)
+    }
+  }
+  
+  override func setupStyles() {
+    super.setupStyles()
   }
 }

--- a/PLUB/Sources/Views/Splash/SplashViewController.swift
+++ b/PLUB/Sources/Views/Splash/SplashViewController.swift
@@ -43,7 +43,6 @@ final class SplashViewController: BaseViewController {
     super.bind()
     
     viewModel.shouldMoveToVC
-      .skip(1) // 초기값 무시
       .delay(.milliseconds(700)) // 어느정도 Splash화면이 보여지도록 0.7초 딜레이
       .drive(with: self) { owner, vc in
         owner.navigationController?.setViewControllers([vc], animated: true)

--- a/PLUB/Sources/Views/Splash/SplashViewController.swift
+++ b/PLUB/Sources/Views/Splash/SplashViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import RxCocoa
+import RxSwift
 import SnapKit
 import Then
 
@@ -35,5 +37,15 @@ final class SplashViewController: BaseViewController {
   
   override func setupStyles() {
     super.setupStyles()
+  }
+  
+  override func bind() {
+    super.bind()
+    
+    viewModel.shouldMoveToVC
+      .drive(with: self) { owner, vc in
+        owner.navigationController?.setViewControllers([vc], animated: true)
+      }
+      .disposed(by: disposeBag)
   }
 }

--- a/PLUB/Sources/Views/Splash/SplashViewModel.swift
+++ b/PLUB/Sources/Views/Splash/SplashViewModel.swift
@@ -34,7 +34,7 @@ final class SplashViewModel: SplashViewModelType {
   
   private func bind() {
     guard let isLaunchedBefore = UserManager.shared.isLaunchedBefore,
-    isLaunchedBefore == false
+          isLaunchedBefore == true
     else {
       UserManager.shared.set(isLaunchedBefore: true) // 최초 실행 로직을 탔으므로 true로 설정
       moveVCRelay.accept(OnboardingViewController()) // 온보딩으로 띄움

--- a/PLUB/Sources/Views/Splash/SplashViewModel.swift
+++ b/PLUB/Sources/Views/Splash/SplashViewModel.swift
@@ -21,11 +21,11 @@ final class SplashViewModel: SplashViewModelType {
   // Output
   let shouldMoveToVC: Driver<UIViewController> // 이동할 ViewController를 받음
   
-  /// Splash화면 이후 보여줄 ViewController를 emit할 `Subject`
-  private let moveVCSubject = PublishSubject<UIViewController>()
+  /// Splash화면 이후 보여줄 ViewController를 emit할 `Relay`
+  private let moveVCRelay = PublishRelay<UIViewController>()
   
   init() {
-    shouldMoveToVC = moveVCSubject.asDriver(onErrorDriveWith: .empty())
+    shouldMoveToVC = moveVCRelay.asDriver(onErrorDriveWith: .empty())
     
     bind()
   }

--- a/PLUB/Sources/Views/Splash/SplashViewModel.swift
+++ b/PLUB/Sources/Views/Splash/SplashViewModel.swift
@@ -22,12 +22,12 @@ final class SplashViewModel: SplashViewModelType {
   let shouldMoveToVC: Driver<UIViewController> // 이동할 ViewController를 받음
   
   /// Splash화면 이후 보여줄 ViewController를 emit할 `Relay`
-  private let moveVCRelay = PublishRelay<UIViewController>()
+  private let moveVCRelay = BehaviorRelay<UIViewController>(value: UIViewController())
   
   private let disposeBag = DisposeBag()
   
   init() {
-    shouldMoveToVC = moveVCRelay.asDriver(onErrorDriveWith: .empty())
+    shouldMoveToVC = moveVCRelay.asDriver()
     
     bind()
   }

--- a/PLUB/Sources/Views/Splash/SplashViewModel.swift
+++ b/PLUB/Sources/Views/Splash/SplashViewModel.swift
@@ -5,11 +5,33 @@
 //  Created by 홍승현 on 2023/02/01.
 //
 
-import Foundation
+import UIKit
 
 import RxSwift
 import RxCocoa
 
-final class SplashViewModel {
+protocol SplashViewModelType: SplashViewModel {
+  
+  // Output
+  var shouldMoveToVC: Driver<UIViewController> { get }
+}
+
+final class SplashViewModel: SplashViewModelType {
+  
+  // Output
+  let shouldMoveToVC: Driver<UIViewController> // 이동할 ViewController를 받음
+  
+  /// Splash화면 이후 보여줄 ViewController를 emit할 `Subject`
+  private let moveVCSubject = PublishSubject<UIViewController>()
+  
+  init() {
+    shouldMoveToVC = moveVCSubject.asDriver(onErrorDriveWith: .empty())
+    
+    bind()
+  }
+  
+  private func bind() {
+    
+  }
   
 }

--- a/PLUB/Sources/Views/Splash/SplashViewModel.swift
+++ b/PLUB/Sources/Views/Splash/SplashViewModel.swift
@@ -24,6 +24,8 @@ final class SplashViewModel: SplashViewModelType {
   /// Splash화면 이후 보여줄 ViewController를 emit할 `Relay`
   private let moveVCRelay = PublishRelay<UIViewController>()
   
+  private let disposeBag = DisposeBag()
+  
   init() {
     shouldMoveToVC = moveVCRelay.asDriver(onErrorDriveWith: .empty())
     
@@ -31,7 +33,26 @@ final class SplashViewModel: SplashViewModelType {
   }
   
   private func bind() {
+    guard let isLaunchedBefore = UserManager.shared.isLaunchedBefore,
+    isLaunchedBefore == false
+    else {
+      UserManager.shared.set(isLaunchedBefore: true) // 최초 실행 로직을 탔으므로 true로 설정
+      moveVCRelay.accept(OnboardingViewController()) // 온보딩으로 띄움
+      return
+    }
     
+    let reissueTokens = UserManager.shared.reissuanceAccessToken().share()
+    
+    reissueTokens
+      .filter { $0 } // 토큰 재발급 성공한 경우
+      .map { _ in HomeViewController(viewModel: HomeViewModel()) } // Home으로 이동할 준비
+      .bind(to: moveVCRelay)
+      .disposed(by: disposeBag)
+    
+    reissueTokens
+      .filter { $0 == false } // 토큰 재발급 실패한 경우
+      .map { _ in LoginViewController() }
+      .bind(to: moveVCRelay)
+      .disposed(by: disposeBag)
   }
-  
 }

--- a/PLUB/Sources/Views/Splash/SplashViewModel.swift
+++ b/PLUB/Sources/Views/Splash/SplashViewModel.swift
@@ -1,0 +1,15 @@
+//
+//  SplashViewModel.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/02/01.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+final class SplashViewModel {
+  
+}

--- a/PLUB/Sources/Views/Splash/SplashViewModel.swift
+++ b/PLUB/Sources/Views/Splash/SplashViewModel.swift
@@ -22,12 +22,12 @@ final class SplashViewModel: SplashViewModelType {
   let shouldMoveToVC: Driver<UIViewController> // 이동할 ViewController를 받음
   
   /// Splash화면 이후 보여줄 ViewController를 emit할 `Relay`
-  private let moveVCRelay = BehaviorRelay<UIViewController>(value: UIViewController())
+  private let moveVCRelay = ReplayRelay<UIViewController>.create(bufferSize: 1)
   
   private let disposeBag = DisposeBag()
   
   init() {
-    shouldMoveToVC = moveVCRelay.asDriver()
+    shouldMoveToVC = moveVCRelay.asDriver(onErrorDriveWith: .empty())
     
     bind()
   }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- UserManager에 최초실행 여부 프로퍼티 추가

🌱 PR 포인트
- SplashVC에서 각 로직에 맞게 필요한 ViewController로 이동하도록 세팅해두었습니다.
   - 최초 실행인 경우 -> OnboardingVC
   - 토큰 만료된 경우 -> LoginVC
   - 그 외 -> HomeVC
- `SplashViewModel`의 37번째 줄과 53번째 줄의 비교값은 가독성을 위해 명시적으로 구현해두었습니다.

## 📸 스크린샷
|최초 실행일 때|토큰 만료되었을 때|토큰이 유효한 경우|
|:--:|:-:|:-:|
|![RPReplay_Final1675268097](https://user-images.githubusercontent.com/57972338/216100528-13886218-49fc-4b9d-8d1c-654a1980a75d.gif)|![RPReplay_Final1675267465](https://user-images.githubusercontent.com/57972338/216100443-779c490a-c10b-4b1e-8006-44a6585f1ad0.gif)|![RPReplay_Final1675268954](https://user-images.githubusercontent.com/57972338/216103739-98114db0-7c91-449a-8d1b-2e18c00a21e2.gif)|

## 📮 관련 이슈
- Resolved: #120

