### PR TITLE
[FEAT] 화면에 따른 백버튼 동작 구현

### DIFF
--- a/PLUB/Sources/Views/Home/HomeViewController.swift
+++ b/PLUB/Sources/Views/Home/HomeViewController.swift
@@ -124,7 +124,6 @@ class HomeViewController: BaseViewController {
   override func bind() {
     super.bind()
     viewModel.fetchedMainCategoryList
-      .do(onNext: { print("메인 =\($0)") })
       .drive(rx.mainCategoryList)
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Home/HomeViewController.swift
+++ b/PLUB/Sources/Views/Home/HomeViewController.swift
@@ -124,6 +124,7 @@ class HomeViewController: BaseViewController {
   override func bind() {
     super.bind()
     viewModel.fetchedMainCategoryList
+      .do(onNext: { print("메인 =\($0)") })
       .drive(rx.mainCategoryList)
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -131,32 +131,26 @@ final class SearchInputViewController: BaseViewController {
       .subscribe(onNext: { owner, text in
         owner.viewModel.whichKeyword.onNext(text)
         owner.interestListCollectionView.isHidden = false
-        self.noResultSearchView.configureUI(with: text)
+        owner.noResultSearchView.configureUI(with: text)
       })
       .disposed(by: disposeBag)
     
     viewModel.fetchedSearchOutput
-      .drive(onNext: { model in
-        self.model = model
-      })
+      .drive(rx.model)
       .disposed(by: disposeBag)
     
     viewModel.currentRecentKeyword
-      .asObservable()
-      .withUnretained(self)
-      .subscribe(onNext: { owner, list in
-        owner.currentKeywordList = list
-      })
+      .drive(rx.currentKeywordList)
       .disposed(by: disposeBag)
     
     searchBar.rx.text.orEmpty
       .skip(1)
       .filter { $0.isEmpty }
-      .subscribe(onNext: { [weak self] _ in
-        guard let `self` = self else { return }
-        self.recentSearchListView.isHidden = false
-        self.interestListCollectionView.isHidden = true
-        self.noResultSearchView.isHidden = true
+      .withUnretained(self)
+      .subscribe(onNext: { owner, _ in
+        owner.recentSearchListView.isHidden = false
+        owner.interestListCollectionView.isHidden = true
+        owner.noResultSearchView.isHidden = true
       })
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -107,7 +107,7 @@ final class SearchInputViewController: BaseViewController {
     }
     
     noResultSearchView.snp.makeConstraints {
-      $0.top.equalTo(view.safeAreaLayoutGuide)
+      $0.top.equalTo(view.safeAreaLayoutGuide).inset(64)
       $0.leading.trailing.equalToSuperview()
       $0.bottom.lessThanOrEqualToSuperview()
     }
@@ -129,9 +129,9 @@ final class SearchInputViewController: BaseViewController {
       .filter { $0.count != 0 }
       .withUnretained(self)
       .subscribe(onNext: { owner, text in
+        owner.noResultSearchView.configureUI(with: text)
         owner.viewModel.whichKeyword.onNext(text)
         owner.interestListCollectionView.isHidden = false
-        owner.noResultSearchView.configureUI(with: text)
       })
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -167,7 +167,13 @@ final class SearchInputViewController: BaseViewController {
   }
   
   @objc private func didTappedBackButton() {
-    self.navigationController?.popViewController(animated: true)
+    if interestListCollectionView.isHidden == false || noResultSearchView.isHidden == false {
+      interestListCollectionView.isHidden = true
+      noResultSearchView.isHidden = true
+    }
+    else {
+      self.navigationController?.popViewController(animated: true)
+    }
   }
 }
 

--- a/PLUB/Sources/Views/Home/ViewModel/ApplyQuestionViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/ApplyQuestionViewModel.swift
@@ -36,10 +36,10 @@ final class ApplyQuestionViewModel: ApplyQuestionViewModelType {
     let isActivating = BehaviorSubject<Bool>(value: false)
     let entireQuestionStatus = PublishSubject<[QuestionStatus]>()
     
-    self.whichRecruitment = currentPlubbing.asObserver()
-    self.allQuestion = questions.asDriver(onErrorJustReturn: [])
-    self.whichQuestion = currentQuestion.asObserver()
-    self.isActivated = isActivating.asDriver(onErrorJustReturn: false)
+    whichRecruitment = currentPlubbing.asObserver()
+    allQuestion = questions.asDriver(onErrorJustReturn: [])
+    whichQuestion = currentQuestion.asObserver()
+    isActivated = isActivating.asDriver(onErrorJustReturn: false)
     
     /// 받아온 질문들을 초기화된 각각의 textView에 대한 상태값을 저장
     questions.map { questionModels in

--- a/PLUB/Sources/Views/Home/ViewModel/DetailRecruitmentViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/DetailRecruitmentViewModel.swift
@@ -48,22 +48,22 @@ final class DetailRecruitmentViewModel: DetailRecruitmentViewModelType {
     .bind(to: successFetchingDetail)
     .disposed(by: disposeBag)
     
-    self.introduceCategoryTitleViewModel = successFetchingDetail.map { response -> IntroduceCategoryTitleViewModel in
+    introduceCategoryTitleViewModel = successFetchingDetail.map { response -> IntroduceCategoryTitleViewModel in
       return IntroduceCategoryTitleViewModel(title: response.title, name: response.name, infoText: response.placeName)
     }
     .asDriver(onErrorDriveWith: .empty())
     
-    self.introduceCategoryInfoViewModel = successFetchingDetail.map { response -> IntroduceCategoryInfoViewModel in
+    introduceCategoryInfoViewModel = successFetchingDetail.map { response -> IntroduceCategoryInfoViewModel in
       return IntroduceCategoryInfoViewModel(recommendedText: response.goal, meetingImageURL: "", meetingImage: nil, categoryInfoListModel: .init(placeName: response.placeName, peopleCount: response.remainAccountNum, dateTime: ""))
     }
     .asDriver(onErrorDriveWith: .empty())
     
-    self.participantListViewModel = successFetchingDetail.map { response -> [AccountInfo] in
+    participantListViewModel = successFetchingDetail.map { response -> [AccountInfo] in
       return response.joinedAccounts
     }
     .asDriver(onErrorDriveWith: .empty())
     
-    self.meetingIntroduceModel = successFetchingDetail.map { response -> MeetingIntroduceModel in
+    meetingIntroduceModel = successFetchingDetail.map { response -> MeetingIntroduceModel in
       return MeetingIntroduceModel(title: response.title, introduce: response.introduce)
     }
     .asDriver(onErrorDriveWith: .empty())

--- a/PLUB/Sources/Views/Home/ViewModel/HomeViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/HomeViewModel.swift
@@ -32,7 +32,7 @@ final class HomeViewModel: HomeViewModelType {
   let isBookmarked: Signal<Bool> // [북마크][북마크해제] 성공 유무
   
   init() {
-    let fetchingMainCategoryList = BehaviorSubject<[MainCategory]>(value: [])
+    let fetchingMainCategoryList = BehaviorRelay<[MainCategory]>(value: [])
     let whichBookmark = PublishSubject<String>()
     let isSelectingInterest = BehaviorSubject<Bool>(value: false)
     
@@ -45,7 +45,9 @@ final class HomeViewModel: HomeViewModelType {
     let inquireInterest = AccountService.shared.inquireInterest().share()
     
     let successFetchingMainCategoryList = inquireMainCategoryList.compactMap { result -> [MainCategory]? in
+      print("결과=\(result)")
       guard case .success(let mainCategoryListResponse) = result else { return nil }
+      print("결과123=\(mainCategoryListResponse)")
       return mainCategoryListResponse.data?.categories
     }
     
@@ -88,6 +90,7 @@ final class HomeViewModel: HomeViewModelType {
     }.asDriver(onErrorDriveWith: .empty())
     
     successFetchingMainCategoryList
+      .do(onNext: {print("뭐냐=\($0)")})
       .bind(to: fetchingMainCategoryList)
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Home/ViewModel/HomeViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/HomeViewModel.swift
@@ -36,18 +36,16 @@ final class HomeViewModel: HomeViewModelType {
     let whichBookmark = PublishSubject<String>()
     let isSelectingInterest = BehaviorSubject<Bool>(value: false)
     
-    self.isSelectedInterest = isSelectingInterest.asDriver(onErrorDriveWith: .empty())
-    self.tappedBookmark = whichBookmark.asObserver()
-    self.fetchedMainCategoryList = fetchingMainCategoryList.asDriver(onErrorDriveWith: .empty())
+    isSelectedInterest = isSelectingInterest.asDriver(onErrorDriveWith: .empty())
+    tappedBookmark = whichBookmark.asObserver()
+    fetchedMainCategoryList = fetchingMainCategoryList.asDriver(onErrorDriveWith: .empty())
     
     let inquireMainCategoryList = CategoryService.shared.inquireMainCategoryList().share()
     let inquireRecommendationMeeting = MeetingService.shared.inquireRecommendationMeeting().share()
     let inquireInterest = AccountService.shared.inquireInterest().share()
     
     let successFetchingMainCategoryList = inquireMainCategoryList.compactMap { result -> [MainCategory]? in
-      print("결과=\(result)")
       guard case .success(let mainCategoryListResponse) = result else { return nil }
-      print("결과123=\(mainCategoryListResponse)")
       return mainCategoryListResponse.data?.categories
     }
     
@@ -90,7 +88,6 @@ final class HomeViewModel: HomeViewModelType {
     }.asDriver(onErrorDriveWith: .empty())
     
     successFetchingMainCategoryList
-      .do(onNext: {print("뭐냐=\($0)")})
       .bind(to: fetchingMainCategoryList)
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Home/ViewModel/RegisterInterestViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/RegisterInterestViewModel.swift
@@ -22,21 +22,21 @@ final class RegisterInterestViewModel: RegisterInterestViewModelType {
   let disposeBag = DisposeBag()
 
   // Input
-  var selectDetailCell: AnyObserver<Void> // 관심사 등록을 위한 셀을 클릭했는지
-  var deselectDetailCell: AnyObserver<Void> // 관심사 등록해제를 위한 셀을 클릭했는지
+  let selectDetailCell: AnyObserver<Void> // 관심사 등록을 위한 셀을 클릭했는지
+  let deselectDetailCell: AnyObserver<Void> // 관심사 등록해제를 위한 셀을 클릭했는지
   
   // Output
-  var fetchedRegisterInterest: Driver<[RegisterInterestModel]> // 관심사 등록을 위한 데이터 방출
-  var isEnabledFloatingButton: Driver<Bool> // 하나의 셀이라도 눌렸는지에 대한 값 방출
+  let fetchedRegisterInterest: Driver<[RegisterInterestModel]> // 관심사 등록을 위한 데이터 방출
+  let isEnabledFloatingButton: Driver<Bool> // 하나의 셀이라도 눌렸는지에 대한 값 방출
   
   init() {
     let fetchingRegisterInterest = BehaviorSubject<[RegisterInterestModel]>(value: [])
     let selectingDetailCellCount = BehaviorSubject<Int>(value: 0)
     let selectingDetailCell = PublishSubject<Void>()
     let deselectingDetailCell = PublishSubject<Void>()
-    self.fetchedRegisterInterest = fetchingRegisterInterest.asDriver(onErrorDriveWith: .empty())
-    self.selectDetailCell = selectingDetailCell.asObserver()
-    self.deselectDetailCell = deselectingDetailCell.asObserver()
+    fetchedRegisterInterest = fetchingRegisterInterest.asDriver(onErrorDriveWith: .empty())
+    selectDetailCell = selectingDetailCell.asObserver()
+    deselectDetailCell = deselectingDetailCell.asObserver()
     
     let inquireAllCategoryList = CategoryService.shared.inquireAll().share()
     let successFetching = inquireAllCategoryList.map { result -> [Category]? in

--- a/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
@@ -47,12 +47,12 @@ final class SearchInputViewModel: SearchInputViewModelType {
     let removeKeyword = PublishSubject<Int>()
     let removeAllKeyword = PublishSubject<Void>()
     
-    self.whichKeywordRemove = removeKeyword.asObserver()
-    self.whichKeyword = searchKeyword.asObserver()
-    self.whichSortType = searchSortType.asObserver()
-    self.fetchedSearchOutput = fetchingSearchOutput.asDriver(onErrorDriveWith: .empty())
-    self.currentRecentKeyword = recentKeywordList.asDriver(onErrorDriveWith: .empty())
-    self.tappedRemoveAll = removeAllKeyword.asObserver()
+    whichKeywordRemove = removeKeyword.asObserver()
+    whichKeyword = searchKeyword.asObserver()
+    whichSortType = searchSortType.asObserver()
+    fetchedSearchOutput = fetchingSearchOutput.asDriver(onErrorDriveWith: .empty())
+    currentRecentKeyword = recentKeywordList.asDriver(onErrorDriveWith: .empty())
+    tappedRemoveAll = removeAllKeyword.asObserver()
     
     let requestSearch = Observable.combineLatest(searchKeyword, searchSortType) { ($0, $1) }
       .flatMapLatest { (keyword, sortType) in

--- a/PLUB/Sources/Views/Home/ViewModel/SelectedCategoryViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/SelectedCategoryViewModel.swift
@@ -36,10 +36,10 @@ final class SelectedCategoryViewModel: SelectedCategoryViewModelType {
     let searchSortType = BehaviorSubject<SortType>(value: .popular)
     let dataIsEmpty = PublishSubject<Bool>()
     
-    self.isEmpty = dataIsEmpty.asSignal(onErrorSignalWith: .empty())
-    self.whichSortType = searchSortType.asObserver()
-    self.selectCategoryID = selectingCategoryID.asObserver()
-    self.updatedCellData = updatingCellData.asDriver(onErrorDriveWith: .empty())
+    isEmpty = dataIsEmpty.asSignal(onErrorSignalWith: .empty())
+    whichSortType = searchSortType.asObserver()
+    selectCategoryID = selectingCategoryID.asObserver()
+    updatedCellData = updatingCellData.asDriver(onErrorDriveWith: .empty())
     
     let fetchingSelectedCategory = Observable.combineLatest(
       selectingCategoryID,


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 최근검색어리스트 혹은 초기화면일때 백 버튼 클릭 시 이전 화면으로 이동 
- Output화면일때 백 버튼 클릭 시 최근검색어리스트 혹은 초기화면으로 이동 
- 이전 PR 리뷰에 따른 일부 코드 수정 
- Input -> Output으로 이동하기 직전 이전 화면 잔상이 보이는 문제 해결

🌱 PR 포인트
- Input -> Output 이동시에 제가 보기엔 해결된거 같은데 한번 영상 확인해보시고 해결된거같은지 말씀해주세요 👍✔️✔️
- 제가 보기에는 잔상이라기보다는 키워드에 따른 API를 통해 데이터를 가져오는 과정에서 0.1초 정도의 딜레이됨에 따른 부분은 어쩔 수 없다 생각합니다 🧐🧐
- 인디케이터뷰와 같은 부분으로 개선할 수 있겠지만 이는 개인적인 의견입니다 👍👍

## 📸 동작영상
https://user-images.githubusercontent.com/39263235/217147079-18719901-e1f7-4fab-a667-e8b0678986d5.mp4

## 📮 관련 이슈
- Resolved: #135 

