### PR TITLE
[FEAT] PLUB 상단 탭바 구현

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -158,6 +158,8 @@
 		C3158ECB297D50B60016E231 /* MeetingPeopleNumberViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3158ECA297D50B60016E231 /* MeetingPeopleNumberViewModel.swift */; };
 		C317F2BA298C1D15005703CE /* MeetingCreateSuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C317F2B9298C1D15005703CE /* MeetingCreateSuccessViewController.swift */; };
 		C332DFD52976E5440023B70B /* PhotoBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C332DFD42976E5440023B70B /* PhotoBottomSheetViewController.swift */; };
+		C33FB0722993F84A00BEB15B /* EditMeetingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33FB0712993F84A00BEB15B /* EditMeetingViewController.swift */; };
+		C33FB0742993FAC600BEB15B /* EditMeetingRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33FB0732993FAC600BEB15B /* EditMeetingRequest.swift */; };
 		C344E53F2986B938009F73A9 /* MeetingCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C344E53E2986B938009F73A9 /* MeetingCategoryViewController.swift */; };
 		C344E5412986B9D7009F73A9 /* MeetingCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C344E5402986B9D7009F73A9 /* MeetingCategoryViewModel.swift */; };
 		C34C097029773860001AFF16 /* DateBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34C096F29773860001AFF16 /* DateBottomSheetViewController.swift */; };
@@ -353,6 +355,8 @@
 		C3158ECA297D50B60016E231 /* MeetingPeopleNumberViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingPeopleNumberViewModel.swift; sourceTree = "<group>"; };
 		C317F2B9298C1D15005703CE /* MeetingCreateSuccessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCreateSuccessViewController.swift; sourceTree = "<group>"; };
 		C332DFD42976E5440023B70B /* PhotoBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoBottomSheetViewController.swift; sourceTree = "<group>"; };
+		C33FB0712993F84A00BEB15B /* EditMeetingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMeetingViewController.swift; sourceTree = "<group>"; };
+		C33FB0732993FAC600BEB15B /* EditMeetingRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMeetingRequest.swift; sourceTree = "<group>"; };
 		C344E53E2986B938009F73A9 /* MeetingCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCategoryViewController.swift; sourceTree = "<group>"; };
 		C344E5402986B9D7009F73A9 /* MeetingCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCategoryViewModel.swift; sourceTree = "<group>"; };
 		C34C096F29773860001AFF16 /* DateBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateBottomSheetViewController.swift; sourceTree = "<group>"; };
@@ -688,6 +692,7 @@
 			children = (
 				BA42D1F428EDE11900C20061 /* MeetingViewController.swift */,
 				C3AB743A296B1EC3003DD5E2 /* CreateMeeting */,
+				C33FB0702993F81800BEB15B /* EditMeeting */,
 			);
 			path = Meeting;
 			sourceTree = "<group>";
@@ -837,38 +842,6 @@
 			path = Lottie;
 			sourceTree = "<group>";
 		};
-		BA8E2B3D297461C8009DDF32 /* Request */ = {
-			isa = PBXGroup;
-			children = (
-				BA8E2B3F297461E6009DDF32 /* SignInRequest.swift */,
-				BAC8930829755B87000D44E2 /* SignUpRequest.swift */,
-				BAE5D3342975B10F00268D44 /* ReissuanceRequest.swift */,
-				C38A5B9A297AE05100485355 /* KakaoLocationRequest.swift */,
-				C3B04E452981788800188E60 /* UploadImageRequest.swift */,
-			);
-			path = Request;
-			sourceTree = "<group>";
-		};
-		BA8E2B3E297461D5009DDF32 /* Response */ = {
-			isa = PBXGroup;
-			children = (
-				BA8E2B4729746881009DDF32 /* SignInResponse.swift */,
-				BAE5D3362975B20000268D44 /* TokenResponse.swift */,
-				C38A5B98297ADE8500485355 /* KakaoLocationResponse.swift */,
-				C3B04E472981789A00188E60 /* UploadImageResponse.swift */,
-			);
-			path = Response;
-			sourceTree = "<group>";
-		};
-		BABB0118297ED405004178EC /* Interest */ = {
-			isa = PBXGroup;
-			children = (
-				BABB0119297ED415004178EC /* InterestViewController.swift */,
-				BABB011B297ED74C004178EC /* InterestViewModel.swift */,
-			);
-			path = Interest;
-			sourceTree = "<group>";
-		};
 		BAC5EF2A2989F58900F3955E /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
@@ -939,6 +912,14 @@
 				BA784FA72978EB9100E8B06F /* SignUpViewController.swift */,
 			);
 			path = ViewController;
+			sourceTree = "<group>";
+		};
+		C33FB0702993F81800BEB15B /* EditMeeting */ = {
+			isa = PBXGroup;
+			children = (
+				C33FB0712993F84A00BEB15B /* EditMeetingViewController.swift */,
+			);
+			path = EditMeeting;
 			sourceTree = "<group>";
 		};
 		C34F71BF29798C11003DB376 /* Cell */ = {
@@ -1157,6 +1138,7 @@
 			isa = PBXGroup;
 			children = (
 				C3ED8FB42989B189002F689B /* CreateMeetingRequest.swift */,
+				C33FB0732993FAC600BEB15B /* EditMeetingRequest.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -1331,6 +1313,7 @@
 				C3757688296DC8E900406F39 /* CreateMeetingViewController.swift in Sources */,
 				BA340E1E297822ED002BAF2C /* IntroduceCategoryTitleView.swift in Sources */,
 				BAE16029292221ED00D595FF /* CheckBoxButton.swift in Sources */,
+				C33FB0722993F84A00BEB15B /* EditMeetingViewController.swift in Sources */,
 				70BD5F3729657E3E002CBA89 /* ApplyQuestionViewModel.swift in Sources */,
 				C332DFD52976E5440023B70B /* PhotoBottomSheetViewController.swift in Sources */,
 				70197B812955A68C000503F6 /* CategoryInfoListView.swift in Sources */,
@@ -1464,6 +1447,7 @@
 				BABB011C297ED74C004178EC /* InterestViewModel.swift in Sources */,
 				BA780E1329713F370032C178 /* BaseService.swift in Sources */,
 				70BD5F272959F718002CBA89 /* UIView + extension.swift in Sources */,
+				C33FB0742993FAC600BEB15B /* EditMeetingRequest.swift in Sources */,
 				C3FC181729852D370083039A /* QuestionHeaderView.swift in Sources */,
 				7085678C28EFBDC1008047DC /* RegisterInterestViewController.swift in Sources */,
 			);

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -160,6 +160,10 @@
 		C332DFD52976E5440023B70B /* PhotoBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C332DFD42976E5440023B70B /* PhotoBottomSheetViewController.swift */; };
 		C33FB0722993F84A00BEB15B /* EditMeetingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33FB0712993F84A00BEB15B /* EditMeetingViewController.swift */; };
 		C33FB0742993FAC600BEB15B /* EditMeetingRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33FB0732993FAC600BEB15B /* EditMeetingRequest.swift */; };
+		C3413E122995450B004B8DBD /* UnderlineSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3413E112995450B004B8DBD /* UnderlineSegmentedControl.swift */; };
+		C3413E15299548FB004B8DBD /* RecruitPostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3413E14299548FB004B8DBD /* RecruitPostViewController.swift */; };
+		C3413E1729954910004B8DBD /* MeetingInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3413E1629954910004B8DBD /* MeetingInfoViewController.swift */; };
+		C3413E192995492D004B8DBD /* GuestQuestionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3413E182995492D004B8DBD /* GuestQuestionViewController.swift */; };
 		C344E53F2986B938009F73A9 /* MeetingCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C344E53E2986B938009F73A9 /* MeetingCategoryViewController.swift */; };
 		C344E5412986B9D7009F73A9 /* MeetingCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C344E5402986B9D7009F73A9 /* MeetingCategoryViewModel.swift */; };
 		C34C097029773860001AFF16 /* DateBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34C096F29773860001AFF16 /* DateBottomSheetViewController.swift */; };
@@ -357,6 +361,10 @@
 		C332DFD42976E5440023B70B /* PhotoBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoBottomSheetViewController.swift; sourceTree = "<group>"; };
 		C33FB0712993F84A00BEB15B /* EditMeetingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMeetingViewController.swift; sourceTree = "<group>"; };
 		C33FB0732993FAC600BEB15B /* EditMeetingRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMeetingRequest.swift; sourceTree = "<group>"; };
+		C3413E112995450B004B8DBD /* UnderlineSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnderlineSegmentedControl.swift; sourceTree = "<group>"; };
+		C3413E14299548FB004B8DBD /* RecruitPostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecruitPostViewController.swift; sourceTree = "<group>"; };
+		C3413E1629954910004B8DBD /* MeetingInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingInfoViewController.swift; sourceTree = "<group>"; };
+		C3413E182995492D004B8DBD /* GuestQuestionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestQuestionViewController.swift; sourceTree = "<group>"; };
 		C344E53E2986B938009F73A9 /* MeetingCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCategoryViewController.swift; sourceTree = "<group>"; };
 		C344E5402986B9D7009F73A9 /* MeetingCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCategoryViewModel.swift; sourceTree = "<group>"; };
 		C34C096F29773860001AFF16 /* DateBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateBottomSheetViewController.swift; sourceTree = "<group>"; };
@@ -472,6 +480,7 @@
 				C3AD265E296AD3C100C57370 /* InputTextView.swift */,
 				C3DE688A2976CF120079B76F /* BottomSheetViewController.swift */,
 				C38D6565298852F80052013F /* PaddingLabel.swift */,
+				C3413E112995450B004B8DBD /* UnderlineSegmentedControl.swift */,
 			);
 			path = CommonClass;
 			sourceTree = "<group>";
@@ -918,8 +927,19 @@
 			isa = PBXGroup;
 			children = (
 				C33FB0712993F84A00BEB15B /* EditMeetingViewController.swift */,
+				C3413E13299548C8004B8DBD /* ViewController */,
 			);
 			path = EditMeeting;
+			sourceTree = "<group>";
+		};
+		C3413E13299548C8004B8DBD /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				C3413E14299548FB004B8DBD /* RecruitPostViewController.swift */,
+				C3413E1629954910004B8DBD /* MeetingInfoViewController.swift */,
+				C3413E182995492D004B8DBD /* GuestQuestionViewController.swift */,
+			);
+			path = ViewController;
 			sourceTree = "<group>";
 		};
 		C34F71BF29798C11003DB376 /* Cell */ = {
@@ -1308,6 +1328,7 @@
 				70F1DFEF297D9E1C00F9BC83 /* DetailRecruitmentViewModel.swift in Sources */,
 				BA8AA42A29863ABC004E9403 /* Interceptor.swift in Sources */,
 				BA42D1F328EDE10F00C20061 /* LoginViewController.swift in Sources */,
+				C3413E122995450B004B8DBD /* UnderlineSegmentedControl.swift in Sources */,
 				BAE5D3372975B20000268D44 /* TokenResponse.swift in Sources */,
 				C38A5B9F297B022A00485355 /* SearchView.swift in Sources */,
 				C3757688296DC8E900406F39 /* CreateMeetingViewController.swift in Sources */,
@@ -1372,6 +1393,7 @@
 				C3B04E4429816C7E00188E60 /* ImageService.swift in Sources */,
 				BA340E2029782301002BAF2C /* LeftAlignedCollectionViewFlowLayout.swift in Sources */,
 				BA8AA42D2988FCC3004E9403 /* OnboardingViewController.swift in Sources */,
+				C3413E15299548FB004B8DBD /* RecruitPostViewController.swift in Sources */,
 				BA88126228E48A5800BD832A /* BaseViewController.swift in Sources */,
 				BA7AD73E297D6720000E7D5D /* BirthViewModel.swift in Sources */,
 				BA340E1C297822CC002BAF2C /* IntroduceCategoryInfoView.swift in Sources */,
@@ -1405,6 +1427,7 @@
 				C3ED8FB52989B189002F689B /* CreateMeetingRequest.swift in Sources */,
 				70F1DFEA297D992100F9BC83 /* RecruitmentService.swift in Sources */,
 				BA8E2B4829746881009DDF32 /* SignInResponse.swift in Sources */,
+				C3413E1729954910004B8DBD /* MeetingInfoViewController.swift in Sources */,
 				70C42454296C86A400DECA0D /* HomeMainCollectionHeaderView.swift in Sources */,
 				BAC5EF31298B6F2D00F3955E /* CongratulationViewController.swift in Sources */,
 				70F1DFE8297D969000F9BC83 /* RecruitmentRouter.swift in Sources */,
@@ -1416,6 +1439,7 @@
 				70197B6E29535BAA000503F6 /* HomeViewModel.swift in Sources */,
 				70F1DFE0297A90AE00F9BC83 /* MeetingService.swift in Sources */,
 				BA42D1F528EDE11900C20061 /* MeetingViewController.swift in Sources */,
+				C3413E192995492D004B8DBD /* GuestQuestionViewController.swift in Sources */,
 				C3E98EAD2974759800E36C45 /* MeetingNameViewModel.swift in Sources */,
 				C3ED8FB72989B87E002F689B /* CreateMeetingResponse.swift in Sources */,
 				BA88125028E48A2F00BD832A /* SceneDelegate.swift in Sources */,

--- a/PLUB/Configuration/CommonClass/UnderlineSegmentedControl.swift
+++ b/PLUB/Configuration/CommonClass/UnderlineSegmentedControl.swift
@@ -1,0 +1,88 @@
+//
+//  UnderlineSegmentedControl.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/02/10.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class UnderlineSegmentedControl: UISegmentedControl {
+  private var bottomLineView = UIView().then {
+    $0.backgroundColor = .mediumGray
+  }
+  
+  private lazy var highlightedView = UIView(
+    frame: CGRect(
+      x: CGFloat(selectedSegmentIndex * Int(bounds.size.width / CGFloat(numberOfSegments))),
+      y: bounds.size.height - 2,
+      width: bounds.size.width / CGFloat(numberOfSegments),
+      height: 2
+    )
+  ).then {
+    $0.backgroundColor = .main
+    addSubview($0)
+  }
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    removeBackgroundAndDivider()
+  }
+  
+  override init(items: [Any]?) {
+    super.init(items: items)
+    setupLayouts()
+    setupConstraints()
+    removeBackgroundAndDivider()
+  }
+  
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    underlineAnimation()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError()
+  }
+    
+  private func removeBackgroundAndDivider() {
+    let image = UIImage()
+    setBackgroundImage(image, for: .normal, barMetrics: .default)
+    setBackgroundImage(image, for: .selected, barMetrics: .default)
+    setBackgroundImage(image, for: .highlighted, barMetrics: .default)
+    setDividerImage(
+      image,
+      forLeftSegmentState: .selected,
+      rightSegmentState: .normal,
+      barMetrics: .default
+    )
+    backgroundColor = .clear
+  }
+    
+  private func setupLayouts() {
+    addSubview(bottomLineView)
+  }
+  
+  private func setupConstraints() {
+    bottomLineView.snp.makeConstraints {
+      $0.height.equalTo(1)
+      $0.bottom.leading.trailing.equalToSuperview()
+    }
+  }
+  
+  private func underlineAnimation() {
+    layer.cornerRadius = 0
+    let segmentIndex = CGFloat(selectedSegmentIndex)
+    let segmentWidth = frame.width / CGFloat(numberOfSegments)
+    let leadingDistance = segmentWidth * segmentIndex
+    UIView.animate(
+      withDuration: 0.1,
+      animations: {
+        self.highlightedView.frame.origin.x = leadingDistance
+      }
+    )
+  }
+}

--- a/PLUB/Sources/Models/Meeting/Request/EditMeetingRequest.swift
+++ b/PLUB/Sources/Models/Meeting/Request/EditMeetingRequest.swift
@@ -1,0 +1,47 @@
+//
+//  EditMeetingRequest.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/02/09.
+//
+
+import Foundation
+
+struct EditMeetingRequest: Codable {
+  /// 요일
+  var days: [String]
+  
+  /// 온/오프라인
+  var onOff: OnOff
+  
+  /// 인원 수
+  var peopleNumber: Int
+  
+  /// 주소
+  var address: String?
+  
+  /// 도로명 주소
+  var roadAddress: String?
+  
+  /// 장소 이름
+  var placeName: String?
+  
+  /// x 좌표
+  var positionX: Double?
+  
+  /// y 좌표
+  var positionY: Double?
+}
+
+extension EditMeetingRequest {
+  enum CodingKeys: String, CodingKey {
+    case days
+    case onOff
+    case address
+    case roadAddress
+    case placeName
+    case positionX = "placePositionX"
+    case positionY = "placePositionY"
+    case peopleNumber = "maxAccountNum"
+  }
+}

--- a/PLUB/Sources/Network/Routers/MeetingRouter.swift
+++ b/PLUB/Sources/Network/Routers/MeetingRouter.swift
@@ -9,6 +9,7 @@ import Alamofire
 
 enum MeetingRouter {
   case createMeeting(CreateMeetingRequest)
+  case editMeeting(Int, EditMeetingRequest)
   case inquireCategoryMeeting(String, Int, String)
   case inquireRecommendationMeeting
 }
@@ -18,6 +19,8 @@ extension MeetingRouter: Router {
     switch self {
     case .createMeeting:
       return .post
+    case .editMeeting:
+      return .put
     case .inquireCategoryMeeting, .inquireRecommendationMeeting:
       return .get
     }
@@ -27,6 +30,8 @@ extension MeetingRouter: Router {
     switch self {
     case .createMeeting:
       return "/plubbings"
+    case .editMeeting(let plubbingId, _):
+      return "/plubbings/\(plubbingId)"
     case .inquireCategoryMeeting(let categoryId, _, _):
       return "/plubbings/categories/\(categoryId)"
     case .inquireRecommendationMeeting:
@@ -38,6 +43,8 @@ extension MeetingRouter: Router {
     switch self {
     case let .createMeeting(model):
       return .body(model)
+    case let .editMeeting(_, model):
+      return .body(model)
     case .inquireCategoryMeeting(_, let page, let sort):
       return .query(["page": "\(page)", "sort": sort])
     case .inquireRecommendationMeeting:
@@ -47,7 +54,7 @@ extension MeetingRouter: Router {
   
   var headers: HeaderType {
     switch self {
-    case .createMeeting, .inquireCategoryMeeting, .inquireRecommendationMeeting:
+    case .createMeeting, .editMeeting, .inquireCategoryMeeting, .inquireRecommendationMeeting:
       return .withAccessToken
     }
   }

--- a/PLUB/Sources/Network/Services/MeetingService.swift
+++ b/PLUB/Sources/Network/Services/MeetingService.swift
@@ -22,6 +22,13 @@ extension MeetingService {
     )
   }
   
+  func editMeeting(plubbingId: Int, request: EditMeetingRequest) -> Observable<NetworkResult<GeneralResponse<CreateMeetingResponse>>> {
+    return sendRequest(
+      MeetingRouter.editMeeting(plubbingId, request),
+      type: CreateMeetingResponse.self
+    )
+  }
+  
   func inquireCategoryMeeting(categoryId: String, page: Int = 1, sort: String) -> Observable<NetworkResult<GeneralResponse<CategoryMeetingResponse>>>  {
     return sendRequest(MeetingRouter.inquireCategoryMeeting(categoryId, page, sort), type: CategoryMeetingResponse.self)
   }

--- a/PLUB/Sources/Views/Meeting/EditMeeting/EditMeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/EditMeeting/EditMeetingViewController.swift
@@ -5,4 +5,104 @@
 //  Created by 김수빈 on 2023/02/09.
 //
 
-import Foundation
+import UIKit
+
+final class EditMeetingViewController: BaseViewController {
+  
+  private let segmentedControl = UnderlineSegmentedControl(
+    items: ["모집글", "모임 정보", "게스트 질문"]
+  ).then {
+    $0.setTitleTextAttributes([.foregroundColor: UIColor.black, .font: UIFont.h5!], for: .normal)
+    $0.setTitleTextAttributes([.foregroundColor: UIColor.main, .font: UIFont.h5!], for: .selected)
+    $0.selectedSegmentIndex = 0
+  }
+  
+  private lazy var pageViewController = UIPageViewController(
+    transitionStyle: .scroll,
+    navigationOrientation: .horizontal,
+    options: nil
+  ).then {
+      $0.setViewControllers([viewControllers[0]], direction: .forward, animated: true)
+      $0.delegate = self
+      $0.dataSource = self
+  }
+  
+  private let recruitPostViewController = RecruitPostViewController()
+  private let meetingInfoViewController = MeetingInfoViewController()
+  private let guestQuestionViewController = GuestQuestionViewController()
+  
+  private var viewControllers: [UIViewController] {
+      [recruitPostViewController, meetingInfoViewController, guestQuestionViewController]
+  }
+  
+  var currentPage = 0 {
+    didSet {
+      let direction: UIPageViewController.NavigationDirection = oldValue <= currentPage ? .forward : .reverse
+      pageViewController.setViewControllers(
+          [viewControllers[currentPage]], direction: direction, animated: true
+      )
+    }
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+  }
+  
+  override func setupLayouts() {
+    super.setupLayouts()
+
+    [segmentedControl, pageViewController.view].forEach {
+      view.addSubview($0)
+    }
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    segmentedControl.snp.makeConstraints {
+      $0.top.equalTo(view.safeAreaLayoutGuide)
+      $0.leading.trailing.equalToSuperview().inset(16)
+      $0.height.equalTo(52)
+    }
+    
+    pageViewController.view.snp.makeConstraints {
+      $0.top.equalTo(segmentedControl.snp.bottom)
+      $0.leading.trailing.equalToSuperview()
+      $0.bottom.equalToSuperview()
+    }
+  }
+  
+  override func setupStyles() {
+    super.setupStyles()
+  }
+  
+  override func bind() {
+    super.bind()
+    segmentedControl.rx.value
+      .asDriver()
+      .drive(with: self) { owner, index in
+        owner.currentPage = index
+      }
+      .disposed(by: disposeBag)
+  }
+}
+
+extension EditMeetingViewController: UIPageViewControllerDataSource, UIPageViewControllerDelegate {
+  func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
+    guard let index = viewControllers.firstIndex(of: viewController),
+          index - 1 >= 0 else { return nil }
+    return viewControllers[index - 1]
+  }
+
+  func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
+    guard let index = viewControllers.firstIndex(of: viewController),
+          index + 1 < viewControllers.count else { return nil }
+    return viewControllers[index + 1]
+  }
+    
+  func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
+    guard let viewController = pageViewController.viewControllers?[0],
+          let index = viewControllers.firstIndex(of: viewController) else { return }
+    currentPage = index
+    segmentedControl.selectedSegmentIndex = index
+  }
+}

--- a/PLUB/Sources/Views/Meeting/EditMeeting/EditMeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/EditMeeting/EditMeetingViewController.swift
@@ -1,0 +1,8 @@
+//
+//  EditMeetingViewController.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/02/09.
+//
+
+import Foundation

--- a/PLUB/Sources/Views/Meeting/EditMeeting/ViewController/GuestQuestionViewController.swift
+++ b/PLUB/Sources/Views/Meeting/EditMeeting/ViewController/GuestQuestionViewController.swift
@@ -1,0 +1,31 @@
+//
+//  GuestQuestionViewController.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/02/10.
+//
+
+import UIKit
+
+final class GuestQuestionViewController: BaseViewController {
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+  }
+
+  override func setupLayouts() {
+    super.setupLayouts()
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+  }
+  
+  override func setupStyles() {
+    super.setupStyles()
+  }
+  
+  override func bind() {
+    super.bind()
+  }
+}

--- a/PLUB/Sources/Views/Meeting/EditMeeting/ViewController/MeetingInfoViewController.swift
+++ b/PLUB/Sources/Views/Meeting/EditMeeting/ViewController/MeetingInfoViewController.swift
@@ -1,0 +1,31 @@
+//
+//  MeetingInfoViewController.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/02/10.
+//
+
+import UIKit
+
+final class MeetingInfoViewController: BaseViewController {
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+  }
+
+  override func setupLayouts() {
+    super.setupLayouts()
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+  }
+  
+  override func setupStyles() {
+    super.setupStyles()
+  }
+  
+  override func bind() {
+    super.bind()
+  }
+}

--- a/PLUB/Sources/Views/Meeting/EditMeeting/ViewController/RecruitPostViewController.swift
+++ b/PLUB/Sources/Views/Meeting/EditMeeting/ViewController/RecruitPostViewController.swift
@@ -1,0 +1,31 @@
+//
+//  RecruitPostViewController.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/02/10.
+//
+
+import UIKit
+
+final class RecruitPostViewController: BaseViewController {
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+  }
+
+  override func setupLayouts() {
+    super.setupLayouts()
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+  }
+  
+  override func setupStyles() {
+    super.setupStyles()
+  }
+  
+  override func bind() {
+    super.bind()
+  }
+}


### PR DESCRIPTION
## 📌 PR 요약
PLUB 상단 탭바 구현

🌱 작업한 내용
- PLUB에서 자주 쓰이는 상단 탭바를 구현하고 pageViewController와 연결해보았습니다.
- 모임 수정 네트워크 파일도 추가했습니다.

🌱 PR 포인트
- commonClass의 `UnderlineSegmentedControl` 파일입니다.
- 예제 코드

```swift
private let segmentedControl = UnderlineSegmentedControl(
    items: ["모집글", "모임 정보", "게스트 질문"]
  ).then {
    $0.setTitleTextAttributes([.foregroundColor: UIColor.black, .font: UIFont.h5!], for: .normal)
    $0.setTitleTextAttributes([.foregroundColor: UIColor.main, .font: UIFont.h5!], for: .selected)
    $0.selectedSegmentIndex = 0
  }
```

## 📸 스크린샷

https://user-images.githubusercontent.com/77331348/217880096-efa3a30a-55e0-4b7e-acf5-b6e94a7fd98c.MP4

[참고] https://ios-development.tistory.com/963

## 📮 관련 이슈
- #129 수

