### PR TITLE
[FEAT] 검색화면과 관련된 UI 수정 및 필터타입에 따른 API 연동

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -837,38 +837,6 @@
 			path = Lottie;
 			sourceTree = "<group>";
 		};
-		BA8E2B3D297461C8009DDF32 /* Request */ = {
-			isa = PBXGroup;
-			children = (
-				BA8E2B3F297461E6009DDF32 /* SignInRequest.swift */,
-				BAC8930829755B87000D44E2 /* SignUpRequest.swift */,
-				BAE5D3342975B10F00268D44 /* ReissuanceRequest.swift */,
-				C38A5B9A297AE05100485355 /* KakaoLocationRequest.swift */,
-				C3B04E452981788800188E60 /* UploadImageRequest.swift */,
-			);
-			path = Request;
-			sourceTree = "<group>";
-		};
-		BA8E2B3E297461D5009DDF32 /* Response */ = {
-			isa = PBXGroup;
-			children = (
-				BA8E2B4729746881009DDF32 /* SignInResponse.swift */,
-				BAE5D3362975B20000268D44 /* TokenResponse.swift */,
-				C38A5B98297ADE8500485355 /* KakaoLocationResponse.swift */,
-				C3B04E472981789A00188E60 /* UploadImageResponse.swift */,
-			);
-			path = Response;
-			sourceTree = "<group>";
-		};
-		BABB0118297ED405004178EC /* Interest */ = {
-			isa = PBXGroup;
-			children = (
-				BABB0119297ED415004178EC /* InterestViewController.swift */,
-				BABB011B297ED74C004178EC /* InterestViewModel.swift */,
-			);
-			path = Interest;
-			sourceTree = "<group>";
-		};
 		BAC5EF2A2989F58900F3955E /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (

--- a/PLUB/Sources/Views/Home/Cell/Search/RecentSearchListCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Cell/Search/RecentSearchListCollectionViewCell.swift
@@ -20,6 +20,7 @@ class RecentSearchListCollectionViewCell: UICollectionViewCell {
   static let identifier = "RecentSearchListCollectionViewCell"
   private let disposeBag = DisposeBag()
   weak var delegate: RecentSearchListCollectionViewCellDelegate?
+  var searchkeyword: String?
   
   private let recentSearchLabel = UILabel().then {
     $0.numberOfLines = 1
@@ -80,5 +81,6 @@ class RecentSearchListCollectionViewCell: UICollectionViewCell {
   
   func configureUI(with model: String) {
     recentSearchLabel.text = model
+    searchkeyword = model
   }
 }

--- a/PLUB/Sources/Views/Home/Cell/Search/SearchOutputHeaderView.swift
+++ b/PLUB/Sources/Views/Home/Cell/Search/SearchOutputHeaderView.swift
@@ -18,9 +18,8 @@ protocol SearchOutputHeaderViewDelegate: AnyObject {
   func didTappedTopBar(which: IndexPath)
 }
 
-class SearchOutputHeaderView: UICollectionReusableView {
+class SearchOutputHeaderView: UIView {
   
-  static let identifier = "SearchOutputHeaderView"
   private let disposeBag = DisposeBag()
   private let tabModel = [
     "제목",

--- a/PLUB/Sources/Views/Home/Cell/Search/SearchOutputHeaderView.swift
+++ b/PLUB/Sources/Views/Home/Cell/Search/SearchOutputHeaderView.swift
@@ -82,7 +82,7 @@ class SearchOutputHeaderView: UIView {
       $0.height.equalTo(1)
       $0.leading.equalTo(topTabCollectionView.snp.leading)
       $0.bottom.equalTo(topTabCollectionView.snp.bottom)
-      $0.width.equalTo(self.frame.width / 3)
+      $0.width.equalTo((Device.width - 20) / 3)
     }
     
     interesetListGridButton.snp.makeConstraints {

--- a/PLUB/Sources/Views/Home/Cell/Search/SearchOutputHeaderView.swift
+++ b/PLUB/Sources/Views/Home/Cell/Search/SearchOutputHeaderView.swift
@@ -15,6 +15,7 @@ protocol SearchOutputHeaderViewDelegate: AnyObject {
   func didTappedInterestListChartButton()
   func didTappedInterestListGridButton()
   func didTappedSortControl()
+  func didTappedTopBar(which: IndexPath)
 }
 
 class SearchOutputHeaderView: UICollectionReusableView {
@@ -144,7 +145,6 @@ class SearchOutputHeaderView: UICollectionReusableView {
   private func setTabbar() {
     let firstIndexPath = IndexPath(item: 0, section: 0)
     topTabCollectionView.selectItem(at: firstIndexPath, animated: false, scrollPosition: .right)
-//    collectionView(topTabCollectionView, didSelectItemAt: firstIndexPath)
   }
 }
 
@@ -165,6 +165,8 @@ extension SearchOutputHeaderView: UICollectionViewDelegate, UICollectionViewData
   
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     let cell = collectionView.cellForItem(at: indexPath) as? TopTabCollectionViewCell ?? TopTabCollectionViewCell()
+    
+    delegate?.didTappedTopBar(which: indexPath)
     
     UIView.animate(withDuration: 0.3) {
       self.highlightView.snp.remakeConstraints {

--- a/PLUB/Sources/Views/Home/Cell/Search/TopTabCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Cell/Search/TopTabCollectionViewCell.swift
@@ -14,6 +14,17 @@ enum FilterType { // 모집글 검색을 위한 필터타입
   case title // 제목
   case name // 모임이름
   case mix // 제목 + 글
+  
+  var text: String {
+    switch self {
+    case .title:
+      return "title"
+    case .name:
+      return "name"
+    case .mix:
+      return "mix"
+    }
+  }
 }
 
 class TopTabCollectionViewCell: UICollectionViewCell {

--- a/PLUB/Sources/Views/Home/Cell/Search/TopTabCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Cell/Search/TopTabCollectionViewCell.swift
@@ -10,6 +10,12 @@ import UIKit
 import SnapKit
 import Then
 
+enum FilterType { // 모집글 검색을 위한 필터타입
+  case title // 제목
+  case name // 모임이름
+  case mix // 제목 + 글
+}
+
 class TopTabCollectionViewCell: UICollectionViewCell {
   
   static let identifier = "TopTabCollectionViewCell"

--- a/PLUB/Sources/Views/Home/Cell/SelectCategory/SelectedCategoryChartCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Cell/SelectCategory/SelectedCategoryChartCollectionViewCell.swift
@@ -17,12 +17,13 @@ struct SelectedCategoryCollectionViewCellModel { // 차트, 그리드일때 둘 
   let title: String
   let mainImage: String?
   let introduce: String
-  let isBookmarked: Bool
+  var isBookmarked: Bool
   let selectedCategoryInfoModel: CategoryInfoListModel
 }
 
 protocol SelectedCategoryChartCollectionViewCellDelegate: AnyObject {
   func didTappedChartBookmarkButton(plubbingID: String)
+  func updateBookmarkState(isBookmarked: Bool, cell: UICollectionViewCell)
 }
 
 final class SelectedCategoryChartCollectionViewCell: UICollectionViewCell {
@@ -111,6 +112,7 @@ final class SelectedCategoryChartCollectionViewCell: UICollectionViewCell {
       .subscribe(onNext: { owner, _ in
         guard let plubbingID = owner.plubbingID else { return }
         owner.delegate?.didTappedChartBookmarkButton(plubbingID: "\(plubbingID)")
+        owner.delegate?.updateBookmarkState(isBookmarked: true, cell: owner)
       })
       .disposed(by: disposeBag)
       
@@ -119,6 +121,7 @@ final class SelectedCategoryChartCollectionViewCell: UICollectionViewCell {
       .subscribe(onNext: { owner, _ in
         guard let plubbingID = owner.plubbingID else { return }
         owner.delegate?.didTappedChartBookmarkButton(plubbingID: "\(plubbingID)")
+        owner.delegate?.updateBookmarkState(isBookmarked: false, cell: owner)
       })
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/Cell/SelectCategory/SelectedCategoryChartCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Cell/SelectCategory/SelectedCategoryChartCollectionViewCell.swift
@@ -22,7 +22,7 @@ struct SelectedCategoryCollectionViewCellModel { // 차트, 그리드일때 둘 
 }
 
 protocol SelectedCategoryChartCollectionViewCellDelegate: AnyObject {
-  func didTappedBookmarkButton(plubbingID: String)
+  func didTappedChartBookmarkButton(plubbingID: String)
 }
 
 final class SelectedCategoryChartCollectionViewCell: UICollectionViewCell {
@@ -110,7 +110,7 @@ final class SelectedCategoryChartCollectionViewCell: UICollectionViewCell {
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
         guard let plubbingID = owner.plubbingID else { return }
-        owner.delegate?.didTappedBookmarkButton(plubbingID: "\(plubbingID)")
+        owner.delegate?.didTappedChartBookmarkButton(plubbingID: "\(plubbingID)")
       })
       .disposed(by: disposeBag)
       
@@ -118,7 +118,7 @@ final class SelectedCategoryChartCollectionViewCell: UICollectionViewCell {
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
         guard let plubbingID = owner.plubbingID else { return }
-        owner.delegate?.didTappedBookmarkButton(plubbingID: "\(plubbingID)")
+        owner.delegate?.didTappedChartBookmarkButton(plubbingID: "\(plubbingID)")
       })
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/Cell/SelectCategory/SelectedCategoryFilterHeaderView.swift
+++ b/PLUB/Sources/Views/Home/Cell/SelectCategory/SelectedCategoryFilterHeaderView.swift
@@ -18,8 +18,7 @@ protocol SelectedCategoryFilterHeaderViewDelegate: AnyObject {
   func didTappedSortControl()
 }
 
-final class SelectedCategoryFilterHeaderView: UICollectionReusableView {
-  static let identifier = "InterestListFilterHeaderView"
+class SelectedCategoryFilterHeaderView: UIView {
   
   weak var delegate: SelectedCategoryFilterHeaderViewDelegate?
   private let disposeBag = DisposeBag()

--- a/PLUB/Sources/Views/Home/Cell/SelectCategory/SelectedCategoryGridCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Cell/SelectCategory/SelectedCategoryGridCollectionViewCell.swift
@@ -9,10 +9,16 @@ import UIKit
 
 import RxSwift
 
+protocol SelectedCategoryGridCollectionViewCellDelegate: AnyObject {
+  func didTappedBookmarkButton(plubbingID: String)
+}
+
 final class SelectedCategoryGridCollectionViewCell: UICollectionViewCell {
   
   static let identifier = "SelectedCategoryGridCollectionViewCell"
   private let disposeBag = DisposeBag()
+  private var plubbingID: String?
+  weak var delegate: SelectedCategoryGridCollectionViewCellDelegate?
   
   private let titleLabel = UILabel().then {
     $0.font = .subtitle
@@ -87,14 +93,18 @@ final class SelectedCategoryGridCollectionViewCell: UICollectionViewCell {
   
   private func bind() {
     bookmarkButton.buttonTapObservable
-      .subscribe(onNext: {
-        
+      .withUnretained(self)
+      .subscribe(onNext: { owner, _ in
+        guard let plubbingID = owner.plubbingID else { return }
+        owner.delegate?.didTappedBookmarkButton(plubbingID: "\(plubbingID)")
       })
       .disposed(by: disposeBag)
-    
+      
     bookmarkButton.buttonUnTapObservable
-      .subscribe(onNext: {
-        
+      .withUnretained(self)
+      .subscribe(onNext: { owner, _ in
+        guard let plubbingID = owner.plubbingID else { return }
+        owner.delegate?.didTappedBookmarkButton(plubbingID: "\(plubbingID)")
       })
       .disposed(by: disposeBag)
   }
@@ -104,5 +114,6 @@ final class SelectedCategoryGridCollectionViewCell: UICollectionViewCell {
     titleLabel.text = model.title
     descriptionLabel.text = model.introduce
     categoryInfoListView.configureUI(with: model.selectedCategoryInfoModel)
+    plubbingID = model.plubbingID
   }
 }

--- a/PLUB/Sources/Views/Home/Cell/SelectCategory/SelectedCategoryGridCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Cell/SelectCategory/SelectedCategoryGridCollectionViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
 import RxSwift
 
 protocol SelectedCategoryGridCollectionViewCellDelegate: AnyObject {
-  func didTappedBookmarkButton(plubbingID: String)
+  func didTappedGridBookmarkButton(plubbingID: String)
 }
 
 final class SelectedCategoryGridCollectionViewCell: UICollectionViewCell {
@@ -96,7 +96,7 @@ final class SelectedCategoryGridCollectionViewCell: UICollectionViewCell {
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
         guard let plubbingID = owner.plubbingID else { return }
-        owner.delegate?.didTappedBookmarkButton(plubbingID: "\(plubbingID)")
+        owner.delegate?.didTappedGridBookmarkButton(plubbingID: "\(plubbingID)")
       })
       .disposed(by: disposeBag)
       
@@ -104,7 +104,7 @@ final class SelectedCategoryGridCollectionViewCell: UICollectionViewCell {
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
         guard let plubbingID = owner.plubbingID else { return }
-        owner.delegate?.didTappedBookmarkButton(plubbingID: "\(plubbingID)")
+        owner.delegate?.didTappedGridBookmarkButton(plubbingID: "\(plubbingID)")
       })
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/Component/SortControl.swift
+++ b/PLUB/Sources/Views/Home/Component/SortControl.swift
@@ -26,13 +26,14 @@ enum SortType {
   }
 }
 
-final class SortControl: UIControl {
+class SortControl: UIControl {
   
   private let type: SortType
   
   var sortChanged: SortType = .popular {
     didSet {
       sortLabel.text = sortChanged.text
+      sortLabel.layoutIfNeeded()
     }
   }
   

--- a/PLUB/Sources/Views/Home/Component/SortControl.swift
+++ b/PLUB/Sources/Views/Home/Component/SortControl.swift
@@ -33,7 +33,6 @@ class SortControl: UIControl {
   var sortChanged: SortType = .popular {
     didSet {
       sortLabel.text = sortChanged.text
-      sortLabel.layoutIfNeeded()
     }
   }
   

--- a/PLUB/Sources/Views/Home/HomeViewController.swift
+++ b/PLUB/Sources/Views/Home/HomeViewController.swift
@@ -335,4 +335,9 @@ extension HomeViewController: SelectedCategoryChartCollectionViewCellDelegate {
   func didTappedChartBookmarkButton(plubbingID: String) {
     viewModel.tappedBookmark.onNext(plubbingID)
   }
+  
+  func updateBookmarkState(isBookmarked: Bool, cell: UICollectionViewCell) {
+    guard let indexPath = homeCollectionView.indexPath(for: cell) else { return }
+    recommendationList[indexPath.row].isBookmarked = isBookmarked
+  }
 }

--- a/PLUB/Sources/Views/Home/HomeViewController.swift
+++ b/PLUB/Sources/Views/Home/HomeViewController.swift
@@ -102,7 +102,7 @@ class HomeViewController: BaseViewController {
         image: UIImage(named: "blackBookmark"),
         style: .done,
         target: self,
-        action: #selector(didTappedSearchButton)
+        action: #selector(didTappedBookmarkButton)
       ),
       UIBarButtonItem(
         image: UIImage(named: "search"),
@@ -152,6 +152,10 @@ class HomeViewController: BaseViewController {
     let vc = SearchInputViewController()
     vc.navigationItem.largeTitleDisplayMode = .never
     self.navigationController?.pushViewController(vc, animated: true)
+  }
+  
+  @objc private func didTappedBookmarkButton() {
+    
   }
   
   private func createCompositionalSection(homeCollectionType: HomeSectionType) -> NSCollectionLayoutSection {

--- a/PLUB/Sources/Views/Home/HomeViewController.swift
+++ b/PLUB/Sources/Views/Home/HomeViewController.swift
@@ -332,7 +332,7 @@ extension HomeViewController: InterestSelectCollectionViewCellDelegate {
 }
 
 extension HomeViewController: SelectedCategoryChartCollectionViewCellDelegate {
-  func didTappedBookmarkButton(plubbingID: String) {
+  func didTappedChartBookmarkButton(plubbingID: String) {
     viewModel.tappedBookmark.onNext(plubbingID)
   }
 }

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -247,10 +247,12 @@ extension SearchInputViewController: UICollectionViewDelegate, UICollectionViewD
         case .chart:
           let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SelectedCategoryChartCollectionViewCell.identifier, for: indexPath) as? SelectedCategoryChartCollectionViewCell ?? SelectedCategoryChartCollectionViewCell()
           cell.configureUI(with: model[indexPath.row])
+          cell.delegate = self
           return cell
         case .grid:
           let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SelectedCategoryGridCollectionViewCell.identifier, for: indexPath) as? SelectedCategoryGridCollectionViewCell ?? SelectedCategoryGridCollectionViewCell()
           cell.configureUI(with: model[indexPath.row])
+          cell.delegate = self
           return cell
         }
       }
@@ -331,3 +333,12 @@ extension SearchInputViewController: SortBottomSheetViewControllerDelegate {
   }
 }
 
+extension SearchInputViewController: SelectedCategoryChartCollectionViewCellDelegate, SelectedCategoryGridCollectionViewCellDelegate {
+  func didTappedChartBookmarkButton(plubbingID: String) {
+    viewModel.tappedBookmark.onNext(plubbingID)
+  }
+  
+  func didTappedGridBookmarkButton(plubbingID: String) {
+    viewModel.tappedBookmark.onNext(plubbingID)
+  }
+}

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -340,6 +340,11 @@ extension SearchInputViewController: SortBottomSheetViewControllerDelegate {
 }
 
 extension SearchInputViewController: SelectedCategoryChartCollectionViewCellDelegate, SelectedCategoryGridCollectionViewCellDelegate {
+  func updateBookmarkState(isBookmarked: Bool, cell: UICollectionViewCell) {
+    guard let indexPath = interestListCollectionView.indexPath(for: cell) else { return }
+    model[indexPath.row].isBookmarked = isBookmarked
+  }
+  
   func didTappedChartBookmarkButton(plubbingID: String) {
     viewModel.tappedBookmark.onNext(plubbingID)
   }

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -335,6 +335,7 @@ extension SearchInputViewController: SearchOutputHeaderViewDelegate {
 extension SearchInputViewController: SortBottomSheetViewControllerDelegate {
   func didTappedSortButton(type: SortType) {
     self.type = type
+    dismiss(animated: false)
   }
 }
 

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -321,6 +321,10 @@ extension SearchInputViewController: RecentSearchListHeaderViewDelegate {
 }
 
 extension SearchInputViewController: SearchOutputHeaderViewDelegate {
+  func didTappedTopBar(which: IndexPath) {
+    
+  }
+  
   func didTappedSortControl() {
     let vc = SortBottomSheetViewController()
     vc.modalPresentationStyle = .overFullScreen

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -32,6 +32,7 @@ final class SearchInputViewController: BaseViewController {
   
   private lazy var interestListCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout().then({
     $0.scrollDirection = .vertical
+    $0.sectionHeadersPinToVisibleBounds = true
   })).then {
     $0.backgroundColor = .background
   }.then {
@@ -224,6 +225,13 @@ extension SearchInputViewController: UICollectionViewDelegate, UICollectionViewD
       let vc = DetailRecruitmentViewController(plubbingID: model[indexPath.row].plubbingID)
       vc.navigationItem.largeTitleDisplayMode = .never
       self.navigationController?.pushViewController(vc, animated: true)
+    } else if collectionView == recentSearchListView {
+      guard let cell = collectionView.cellForItem(at: indexPath) as? RecentSearchListCollectionViewCell,
+            let keyword = cell.searchkeyword else { return }
+      self.searchBar.text = keyword
+      self.noResultSearchView.configureUI(with: keyword)
+      self.viewModel.whichKeyword.onNext(keyword)
+      self.interestListCollectionView.isHidden = false
     }
   }
   

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -143,11 +143,7 @@ final class SearchInputViewController: BaseViewController {
       .filter { $0.count != 0 }
       .withUnretained(self)
       .subscribe(onNext: { owner, text in
-        owner.noResultSearchView.configureUI(with: text)
-        owner.viewModel.whichKeyword.onNext(text)
-        owner.recentSearchListView.isHidden = true
-        owner.interestListCollectionView.isHidden = false
-        owner.searchOutputHeaderView.isHidden = false
+        owner.presentSearchOutput(keyword: text)
       })
       .disposed(by: disposeBag)
     
@@ -164,10 +160,7 @@ final class SearchInputViewController: BaseViewController {
       .filter { $0.isEmpty }
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
-        owner.recentSearchListView.isHidden = false
-        owner.interestListCollectionView.isHidden = true
-        owner.searchOutputHeaderView.isHidden = true
-        owner.noResultSearchView.isHidden = true
+        owner.dismissSearchOutput()
       })
       .disposed(by: disposeBag)
     
@@ -188,12 +181,24 @@ final class SearchInputViewController: BaseViewController {
     
   }
   
+  private func presentSearchOutput(keyword: String) {
+    noResultSearchView.configureUI(with: keyword)
+    viewModel.whichKeyword.onNext(keyword)
+    recentSearchListView.isHidden = true
+    interestListCollectionView.isHidden = false
+    searchOutputHeaderView.isHidden = false
+  }
+  
+  private func dismissSearchOutput() {
+    recentSearchListView.isHidden = false
+    interestListCollectionView.isHidden = true
+    searchOutputHeaderView.isHidden = true
+    noResultSearchView.isHidden = true
+  }
+  
   @objc private func didTappedBackButton() {
     if interestListCollectionView.isHidden == false || noResultSearchView.isHidden == false {
-      interestListCollectionView.isHidden = true
-      searchOutputHeaderView.isHidden = true
-      noResultSearchView.isHidden = true
-      recentSearchListView.isHidden = false
+      dismissSearchOutput()
     }
     else {
       self.navigationController?.popViewController(animated: true)
@@ -239,11 +244,7 @@ extension SearchInputViewController: UICollectionViewDelegate, UICollectionViewD
       guard let cell = collectionView.cellForItem(at: indexPath) as? RecentSearchListCollectionViewCell,
             let keyword = cell.searchkeyword else { return }
       self.searchBar.text = keyword
-      self.noResultSearchView.configureUI(with: keyword)
-      self.viewModel.whichKeyword.onNext(keyword)
-      self.interestListCollectionView.isHidden = false
-      self.searchOutputHeaderView.isHidden = false
-      self.recentSearchListView.isHidden = true
+      self.presentSearchOutput(keyword: keyword)
     }
   }
   

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -111,7 +111,7 @@ final class SearchInputViewController: BaseViewController {
     
     searchOutputHeaderView.snp.makeConstraints {
       $0.top.equalTo(view.safeAreaLayoutGuide)
-      $0.leading.trailing.equalToSuperview()
+      $0.leading.trailing.equalToSuperview().inset(10)
       $0.height.equalTo(64)
     }
     

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -26,7 +26,7 @@ final class SearchInputViewController: BaseViewController {
   private var type: SortType = .popular {
     didSet {
       interestListCollectionView.reloadSections([0])
-      //      viewModel.whichSortType.onNext(type)
+      viewModel.whichSortType.onNext(type)
     }
   }
   
@@ -163,6 +163,11 @@ final class SearchInputViewController: BaseViewController {
       .map { !$0 }
       .drive(noResultSearchView.rx.isHidden)
       .disposed(by: disposeBag)
+    
+    viewModel.isBookmarked.emit(onNext: { isBookmarked in
+      print("해당 모집글을 북마크 \(isBookmarked)")
+    })
+    .disposed(by: disposeBag)
     
   }
   

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -25,9 +25,9 @@ final class SearchInputViewController: BaseViewController {
   
   private var type: SortType = .popular {
     didSet {
-      interestListCollectionView.reloadData()
       viewModel.whichSortType.onNext(type)
       searchOutputHeaderView.filterChanged = type
+      interestListCollectionView.reloadData()
     }
   }
   

--- a/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
+++ b/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
@@ -217,6 +217,7 @@ extension SelectedCategoryViewController: SelectedCategoryFilterHeaderViewDelega
 extension SelectedCategoryViewController: SortBottomSheetViewControllerDelegate {
   func didTappedSortButton(type: SortType) {
     self.type = type
+    dismiss(animated: false)
   }
 }
 

--- a/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
+++ b/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
@@ -222,6 +222,11 @@ extension SelectedCategoryViewController: SortBottomSheetViewControllerDelegate 
 }
 
 extension SelectedCategoryViewController: SelectedCategoryChartCollectionViewCellDelegate, SelectedCategoryGridCollectionViewCellDelegate {
+  func updateBookmarkState(isBookmarked: Bool, cell: UICollectionViewCell) {
+    guard let indexPath = interestListCollectionView.indexPath(for: cell) else { return }
+    model[indexPath.row].isBookmarked = isBookmarked
+  }
+  
   func didTappedChartBookmarkButton(plubbingID: String) {
     viewModel.tappedBookmark.onNext(plubbingID)
   }

--- a/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
+++ b/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
@@ -220,14 +220,13 @@ extension SelectedCategoryViewController: SortBottomSheetViewControllerDelegate 
   }
 }
 
-extension SelectedCategoryViewController: SelectedCategoryChartCollectionViewCellDelegate {
+extension SelectedCategoryViewController: SelectedCategoryChartCollectionViewCellDelegate, SelectedCategoryGridCollectionViewCellDelegate {
   func didTappedChartBookmarkButton(plubbingID: String) {
     viewModel.tappedBookmark.onNext(plubbingID)
   }
-}
-
-extension SelectedCategoryViewController: SelectedCategoryGridCollectionViewCellDelegate {
+  
   func didTappedGridBookmarkButton(plubbingID: String) {
     viewModel.tappedBookmark.onNext(plubbingID)
   }
 }
+

--- a/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
+++ b/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
@@ -129,10 +129,12 @@ extension SelectedCategoryViewController: UICollectionViewDelegate, UICollection
       case .chart:
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SelectedCategoryChartCollectionViewCell.identifier, for: indexPath) as? SelectedCategoryChartCollectionViewCell ?? SelectedCategoryChartCollectionViewCell()
         cell.configureUI(with: model[indexPath.row])
+        cell.delegate = self
         return cell
       case .grid:
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SelectedCategoryGridCollectionViewCell.identifier, for: indexPath) as? SelectedCategoryGridCollectionViewCell ?? SelectedCategoryGridCollectionViewCell()
         cell.configureUI(with: model[indexPath.row])
+        
         return cell
       }
     }
@@ -210,5 +212,11 @@ extension SelectedCategoryViewController: SelectedCategoryFilterHeaderViewDelega
 extension SelectedCategoryViewController: SortBottomSheetViewControllerDelegate {
   func didTappedSortButton(type: SortType) {
     self.type = type
+  }
+}
+
+extension SelectedCategoryViewController: SelectedCategoryChartCollectionViewCellDelegate {
+  func didTappedBookmarkButton(plubbingID: String) {
+    viewModel.tappedBookmark.onNext(plubbingID)
   }
 }

--- a/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
+++ b/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
@@ -104,6 +104,11 @@ final class SelectedCategoryViewController: BaseViewController {
       .map { !$0 }
       .emit(to: noSelectedCategoryView.rx.isHidden)
       .disposed(by: disposeBag)
+    
+    viewModel.isBookmarked.emit(onNext: { isBookmarked in
+      print("해당 모집글을 북마크 \(isBookmarked)")
+    })
+    .disposed(by: disposeBag)
   }
   
   @objc private func didTappedBackButton() {

--- a/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
+++ b/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
@@ -134,7 +134,7 @@ extension SelectedCategoryViewController: UICollectionViewDelegate, UICollection
       case .grid:
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SelectedCategoryGridCollectionViewCell.identifier, for: indexPath) as? SelectedCategoryGridCollectionViewCell ?? SelectedCategoryGridCollectionViewCell()
         cell.configureUI(with: model[indexPath.row])
-        
+        cell.delegate = self
         return cell
       }
     }
@@ -216,7 +216,13 @@ extension SelectedCategoryViewController: SortBottomSheetViewControllerDelegate 
 }
 
 extension SelectedCategoryViewController: SelectedCategoryChartCollectionViewCellDelegate {
-  func didTappedBookmarkButton(plubbingID: String) {
+  func didTappedChartBookmarkButton(plubbingID: String) {
+    viewModel.tappedBookmark.onNext(plubbingID)
+  }
+}
+
+extension SelectedCategoryViewController: SelectedCategoryGridCollectionViewCellDelegate {
+  func didTappedGridBookmarkButton(plubbingID: String) {
     viewModel.tappedBookmark.onNext(plubbingID)
   }
 }

--- a/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
+++ b/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
@@ -28,9 +28,9 @@ final class SelectedCategoryViewController: BaseViewController {
   
   private var type: SortType = .popular {
     didSet {
-      interestListCollectionView.reloadData()
       viewModel.whichSortType.onNext(type)
       selectedCategoryFilterHeaderView.filterChanged = type
+      interestListCollectionView.reloadData()
     }
   }
   

--- a/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
+++ b/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
@@ -14,7 +14,6 @@ import Then
 enum SelectedCategoryType {
   case chart
   case grid
-//  case emp
 }
 
 final class SelectedCategoryViewController: BaseViewController {
@@ -38,6 +37,7 @@ final class SelectedCategoryViewController: BaseViewController {
   
   private lazy var interestListCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout().then({
     $0.scrollDirection = .vertical
+    $0.sectionHeadersPinToVisibleBounds = true
   })).then {
     $0.backgroundColor = .background
   }.then {

--- a/PLUB/Sources/Views/Home/ViewModel/ApplyQuestionViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/ApplyQuestionViewModel.swift
@@ -31,7 +31,7 @@ final class ApplyQuestionViewModel: ApplyQuestionViewModelType {
   
   init() {
     let currentPlubbing = PublishSubject<String>()
-    let questions = BehaviorSubject<[ApplyQuestionTableViewCellModel]>(value: [])
+    let questions = BehaviorRelay<[ApplyQuestionTableViewCellModel]>(value: [])
     let currentQuestion = PublishSubject<QuestionStatus>()
     let isActivating = BehaviorSubject<Bool>(value: false)
     let entireQuestionStatus = PublishSubject<[QuestionStatus]>()

--- a/PLUB/Sources/Views/Home/ViewModel/DetailRecruitmentViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/DetailRecruitmentViewModel.swift
@@ -34,7 +34,7 @@ final class DetailRecruitmentViewModel: DetailRecruitmentViewModelType {
   
   init() {
     let selectingPlubbingID = PublishSubject<String>()
-    let successFetchingDetail = PublishSubject<DetailRecruitmentResponse>()
+    let successFetchingDetail = PublishRelay<DetailRecruitmentResponse>()
     self.selectPlubbingID = selectingPlubbingID.asObserver()
     
     let fetchingDetail = selectingPlubbingID

--- a/PLUB/Sources/Views/Home/ViewModel/HomeViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/HomeViewModel.swift
@@ -92,7 +92,6 @@ final class HomeViewModel: HomeViewModelType {
       .disposed(by: disposeBag)
     
     let requestBookmark = whichBookmark
-      .debounce(.seconds(3), scheduler: ConcurrentDispatchQueueScheduler.init(qos: .default))
       .flatMapLatest(RecruitmentService.shared.requestBookmark).share()
     
     let successRequestBookmark = requestBookmark.compactMap { result -> RequestBookmarkResponse? in

--- a/PLUB/Sources/Views/Home/ViewModel/RegisterInterestViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/RegisterInterestViewModel.swift
@@ -30,7 +30,7 @@ final class RegisterInterestViewModel: RegisterInterestViewModelType {
   let isEnabledFloatingButton: Driver<Bool> // 하나의 셀이라도 눌렸는지에 대한 값 방출
   
   init() {
-    let fetchingRegisterInterest = BehaviorSubject<[RegisterInterestModel]>(value: [])
+    let fetchingRegisterInterest = BehaviorRelay<[RegisterInterestModel]>(value: [])
     let selectingDetailCellCount = BehaviorSubject<Int>(value: 0)
     let selectingDetailCell = PublishSubject<Void>()
     let deselectingDetailCell = PublishSubject<Void>()
@@ -49,7 +49,7 @@ final class RegisterInterestViewModel: RegisterInterestViewModelType {
       let models = categories.map { category in
         return RegisterInterestModel(category: category)
       }
-      fetchingRegisterInterest.onNext(models)
+      fetchingRegisterInterest.accept(models)
     })
     .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
@@ -120,7 +120,6 @@ final class SearchInputViewModel: SearchInputViewModelType {
       .disposed(by: disposeBag)
     
     let requestBookmark = whichBookmark
-    .debounce(.seconds(3), scheduler: ConcurrentDispatchQueueScheduler.init(qos: .default))
     .flatMapLatest(RecruitmentService.shared.requestBookmark).share()
     
     let successRequestBookmark = requestBookmark.compactMap { result -> RequestBookmarkResponse? in

--- a/PLUB/Sources/Views/Home/ViewModel/SelectedCategoryViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/SelectedCategoryViewModel.swift
@@ -12,10 +12,12 @@ protocol SelectedCategoryViewModelType {
   // Input
   var selectCategoryID: AnyObserver<String> { get }
   var whichSortType: AnyObserver<SortType> { get }
+  var tappedBookmark: AnyObserver<String> { get }
   
   // Output
   var updatedCellData: Driver<[SelectedCategoryCollectionViewCellModel]> { get }
   var isEmpty: Signal<Bool> { get }
+  var isBookmarked: Signal<Bool> { get }
 }
 
 final class SelectedCategoryViewModel: SelectedCategoryViewModelType {
@@ -25,21 +27,25 @@ final class SelectedCategoryViewModel: SelectedCategoryViewModelType {
   // Input
   let selectCategoryID: AnyObserver<String> // 어떤 카테고리에 대한 것인지에 대한 ID
   let whichSortType: AnyObserver<SortType> // 해당 카테고리에 대한 어떤 분류타입으로 설정하고싶은지
+  let tappedBookmark: AnyObserver<String> // 북마크버튼을 탭 했을때
   
   // Output
   let updatedCellData: Driver<[SelectedCategoryCollectionViewCellModel]> // 해당 ID와 분류타입에 대한 카테고리 데이터
   let isEmpty: Signal<Bool> // 해당 ID와 분류타입에 대한 카테고리 데이터 유무
+  let isBookmarked: Signal<Bool> // [북마크][북마크해제] 성공 유무
   
   init() {
     let selectingCategoryID = PublishSubject<String>()
     let updatingCellData = BehaviorSubject<[SelectedCategoryCollectionViewCellModel]>(value: [])
     let searchSortType = BehaviorSubject<SortType>(value: .popular)
     let dataIsEmpty = PublishSubject<Bool>()
+    let whichBookmark = PublishSubject<String>()
     
     isEmpty = dataIsEmpty.asSignal(onErrorSignalWith: .empty())
     whichSortType = searchSortType.asObserver()
     selectCategoryID = selectingCategoryID.asObserver()
     updatedCellData = updatingCellData.asDriver(onErrorDriveWith: .empty())
+    tappedBookmark = whichBookmark.asObserver()
     
     let fetchingSelectedCategory = Observable.combineLatest(
       selectingCategoryID,
@@ -62,26 +68,40 @@ final class SelectedCategoryViewModel: SelectedCategoryViewModelType {
     selectingContents
       .do(onNext: { dataIsEmpty.onNext($0.isEmpty) })
       .subscribe(onNext: { contents in
-      let model = contents.map { content in
-        return SelectedCategoryCollectionViewCellModel(
-          plubbingID: "\(content.plubbingID)",
-          name: content.name,
-          title: content.title,
-          mainImage: content.mainImage,
-          introduce: content.introduce,
-          isBookmarked: content.isBookmarked,
-          selectedCategoryInfoModel: .init(
-            placeName: content.placeName,
-            peopleCount: content.remainAccountNum,
-            dateTime: content.days
-          .map { $0.fromENGToKOR() }
-          .joined(separator: ",")
-        + " | "
-        + "(data.time)"))
-      }
-      updatingCellData.onNext(model)
-    })
-    .disposed(by: disposeBag)
+        let model = contents.map { content in
+          return SelectedCategoryCollectionViewCellModel(
+            plubbingID: "\(content.plubbingID)",
+            name: content.name,
+            title: content.title,
+            mainImage: content.mainImage,
+            introduce: content.introduce,
+            isBookmarked: content.isBookmarked,
+            selectedCategoryInfoModel: .init(
+              placeName: content.placeName,
+              peopleCount: content.remainAccountNum,
+              dateTime: content.days
+                .map { $0.fromENGToKOR() }
+                .joined(separator: ",")
+              + " | "
+              + "(data.time)"))
+        }
+        updatingCellData.onNext(model)
+      })
+        .disposed(by: disposeBag)
+        
+        let requestBookmark = whichBookmark
+        .debounce(.seconds(3), scheduler: ConcurrentDispatchQueueScheduler.init(qos: .default))
+        .flatMapLatest(RecruitmentService.shared.requestBookmark).share()
+        
+        let successRequestBookmark = requestBookmark.compactMap { result -> RequestBookmarkResponse? in
+          guard case .success(let response) = result else { return nil }
+          return response.data
+        }
+        
+        self.isBookmarked = successRequestBookmark.distinctUntilChanged()
+        .map { $0.isBookmarked }
+        .asSignal(onErrorSignalWith: .empty())
   }
-  
 }
+
+

--- a/PLUB/Sources/Views/Home/ViewModel/SelectedCategoryViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/SelectedCategoryViewModel.swift
@@ -36,7 +36,7 @@ final class SelectedCategoryViewModel: SelectedCategoryViewModelType {
   
   init() {
     let selectingCategoryID = PublishSubject<String>()
-    let updatingCellData = BehaviorSubject<[SelectedCategoryCollectionViewCellModel]>(value: [])
+    let updatingCellData = BehaviorRelay<[SelectedCategoryCollectionViewCellModel]>(value: [])
     let searchSortType = BehaviorSubject<SortType>(value: .popular)
     let dataIsEmpty = PublishSubject<Bool>()
     let whichBookmark = PublishSubject<String>()
@@ -85,7 +85,7 @@ final class SelectedCategoryViewModel: SelectedCategoryViewModelType {
               + " | "
               + "(data.time)"))
         }
-        updatingCellData.onNext(model)
+        updatingCellData.accept(model)
       })
         .disposed(by: disposeBag)
         

--- a/PLUB/Sources/Views/Home/ViewModel/SelectedCategoryViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/SelectedCategoryViewModel.swift
@@ -90,7 +90,6 @@ final class SelectedCategoryViewModel: SelectedCategoryViewModelType {
         .disposed(by: disposeBag)
         
         let requestBookmark = whichBookmark
-        .debounce(.seconds(3), scheduler: ConcurrentDispatchQueueScheduler.init(qos: .default))
         .flatMapLatest(RecruitmentService.shared.requestBookmark).share()
         
         let successRequestBookmark = requestBookmark.compactMap { result -> RequestBookmarkResponse? in


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 상단탭바를 이용한 필터타입에 따른 데이터 재연동 
- 화면상 UI를 통해 보여지는 데이터가 끊기지않기위한 코드 수정 
- sticky header를 위한 컬렉션뷰헤더 -> 단일 UI로 수정

🌱 PR 포인트
- viewModel을 이용한 필터타입연동은 하였지만 실제 상단탭과 연동하지는 않음 
- 최근 수빈님 pr인 상단탭바 적용하면 이후에 연동할 예정

## 📮 관련 이슈
- Resolved: #143 

