### PR TITLE
[FIX] 검색화면관련 UI 오류에 따른 코드 수정 및 보완 

### DIFF
--- a/PLUB/Sources/Models/Account/Response/InquireInterestResponse.swift
+++ b/PLUB/Sources/Models/Account/Response/InquireInterestResponse.swift
@@ -19,7 +19,7 @@ struct InquireInterestResponse: Codable {
   init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     
-    self.accountID = try values.decodeIfPresent(Int.self, forKey: .accountID) ?? 0
-    self.categoryID = try values.decodeIfPresent([Int].self, forKey: .categoryID) ?? []
+    accountID = try values.decodeIfPresent(Int.self, forKey: .accountID) ?? 0
+    categoryID = try values.decodeIfPresent([Int].self, forKey: .categoryID) ?? []
   }
 }

--- a/PLUB/Sources/Models/Category/Response/AllCategoryListResponse.swift
+++ b/PLUB/Sources/Models/Category/Response/AllCategoryListResponse.swift
@@ -17,7 +17,7 @@ struct AllCategoryListResponse: Codable {
   init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     
-    self.categories = try values.decodeIfPresent([Category].self, forKey: .categories) ?? []
+    categories = try values.decodeIfPresent([Category].self, forKey: .categories) ?? []
   }
 }
 
@@ -42,10 +42,10 @@ struct SubCategory: Codable {
   init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     
-    self.id = try values.decodeIfPresent(Int.self, forKey: .id) ?? 0
-    self.name = try values.decodeIfPresent(String.self, forKey: .name) ?? ""
-    self.categoryName = try values.decodeIfPresent(String.self, forKey: .categoryName) ?? ""
-    self.parentId = try values.decodeIfPresent(String.self, forKey: .parentId) ?? ""
-    self.isSelected = try values.decodeIfPresent(Bool.self, forKey: .isSelected) ?? false
+    id = try values.decodeIfPresent(Int.self, forKey: .id) ?? 0
+    name = try values.decodeIfPresent(String.self, forKey: .name) ?? ""
+    categoryName = try values.decodeIfPresent(String.self, forKey: .categoryName) ?? ""
+    parentId = try values.decodeIfPresent(String.self, forKey: .parentId) ?? ""
+    isSelected = try values.decodeIfPresent(Bool.self, forKey: .isSelected) ?? false
   }
 }

--- a/PLUB/Sources/Models/Category/Response/MainCategoryListResponse.swift
+++ b/PLUB/Sources/Models/Category/Response/MainCategoryListResponse.swift
@@ -16,7 +16,7 @@ struct MainCategoryListResponse: Codable {
   
   init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
-    self.categories = try values.decodeIfPresent([MainCategory].self, forKey: .categories) ?? []
+    categories = try values.decodeIfPresent([MainCategory].self, forKey: .categories) ?? []
   }
 }
 

--- a/PLUB/Sources/Models/Category/Response/SubCategoryListResponse.swift
+++ b/PLUB/Sources/Models/Category/Response/SubCategoryListResponse.swift
@@ -17,6 +17,6 @@ struct SubCategoryListResponse: Codable {
   init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     
-    self.categories = try values.decodeIfPresent([SubCategory].self, forKey: .categories) ?? []
+    categories = try values.decodeIfPresent([SubCategory].self, forKey: .categories) ?? []
   }
 }

--- a/PLUB/Sources/Models/Meeting/Response/CategoryMeetingResponse.swift
+++ b/PLUB/Sources/Models/Meeting/Response/CategoryMeetingResponse.swift
@@ -20,10 +20,10 @@ struct CategoryMeetingResponse: Codable {
   init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     
-    self.totalPages = try values.decodeIfPresent(Int.self, forKey: .totalPages) ?? 0
-    self.totalElements = try values.decodeIfPresent(Int.self, forKey: .totalElements) ?? 0
-    self.last = try values.decodeIfPresent(Bool.self, forKey: .last) ?? false
-    self.content = try values.decodeIfPresent([Content].self, forKey: .content) ?? []
+    totalPages = try values.decodeIfPresent(Int.self, forKey: .totalPages) ?? 0
+    totalElements = try values.decodeIfPresent(Int.self, forKey: .totalElements) ?? 0
+    last = try values.decodeIfPresent(Bool.self, forKey: .last) ?? false
+    content = try values.decodeIfPresent([Content].self, forKey: .content) ?? []
   }
 }
 

--- a/PLUB/Sources/Models/Recruitment/Response/BookmarkAllResponse.swift
+++ b/PLUB/Sources/Models/Recruitment/Response/BookmarkAllResponse.swift
@@ -20,10 +20,10 @@ struct BookmarkAllResponse: Codable {
   init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     
-    self.totalPages = try values.decodeIfPresent(Int.self, forKey: .totalPages) ?? 0
-    self.totalElements = try values.decodeIfPresent(Int.self, forKey: .totalElements) ?? 0
-    self.last = try values.decodeIfPresent(Bool.self, forKey: .last) ?? false
-    self.content = try values.decodeIfPresent([BookmarkContent].self, forKey: .content) ?? []
+    totalPages = try values.decodeIfPresent(Int.self, forKey: .totalPages) ?? 0
+    totalElements = try values.decodeIfPresent(Int.self, forKey: .totalElements) ?? 0
+    last = try values.decodeIfPresent(Bool.self, forKey: .last) ?? false
+    content = try values.decodeIfPresent([BookmarkContent].self, forKey: .content) ?? []
   }
 }
 

--- a/PLUB/Sources/Models/Recruitment/Response/DetailRecruitmentResponse.swift
+++ b/PLUB/Sources/Models/Recruitment/Response/DetailRecruitmentResponse.swift
@@ -34,24 +34,24 @@ struct DetailRecruitmentResponse: Codable {
   init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     
-    self.title = try values.decodeIfPresent(String.self, forKey: .title) ?? ""
-    self.introduce = try values.decodeIfPresent(String.self, forKey: .introduce) ?? ""
-    self.categories = try values.decodeIfPresent([String].self, forKey: .categories) ?? []
-    self.name = try values.decodeIfPresent(String.self, forKey: .name) ?? ""
-    self.goal = try values.decodeIfPresent(String.self, forKey: .goal) ?? ""
-    self.mainImage = try values.decodeIfPresent(String.self, forKey: .mainImage) 
-    self.days = try values.decodeIfPresent([String].self, forKey: .days) ?? []
-    self.time = try values.decodeIfPresent(String.self, forKey: .time) ?? ""
-    self.address = try values.decodeIfPresent(String.self, forKey: .address) ?? ""
-    self.roadAddress = try values.decodeIfPresent(String.self, forKey: .roadAddress) ?? ""
-    self.placeName = try values.decodeIfPresent(String.self, forKey: .placeName) ?? ""
-    self.placePositionX = try values.decodeIfPresent(Double.self, forKey: .placePositionX) ?? 0.0
-    self.placePositionY = try values.decodeIfPresent(Double.self, forKey: .placePositionY) ?? 0.0
-    self.isBookmarked = try values.decodeIfPresent(Bool.self, forKey: .isBookmarked) ?? false
-    self.isApplied = try values.decodeIfPresent(Bool.self, forKey: .isApplied) ?? false
-    self.curAccountNum = try values.decodeIfPresent(Int.self, forKey: .curAccountNum) ?? 0
-    self.remainAccountNum = try values.decodeIfPresent(Int.self, forKey: .remainAccountNum) ?? 0
-    self.joinedAccounts = try values.decodeIfPresent([AccountInfo].self, forKey: .joinedAccounts) ?? []
+    title = try values.decodeIfPresent(String.self, forKey: .title) ?? ""
+    introduce = try values.decodeIfPresent(String.self, forKey: .introduce) ?? ""
+    categories = try values.decodeIfPresent([String].self, forKey: .categories) ?? []
+    name = try values.decodeIfPresent(String.self, forKey: .name) ?? ""
+    goal = try values.decodeIfPresent(String.self, forKey: .goal) ?? ""
+    mainImage = try values.decodeIfPresent(String.self, forKey: .mainImage)
+    days = try values.decodeIfPresent([String].self, forKey: .days) ?? []
+    time = try values.decodeIfPresent(String.self, forKey: .time) ?? ""
+    address = try values.decodeIfPresent(String.self, forKey: .address) ?? ""
+    roadAddress = try values.decodeIfPresent(String.self, forKey: .roadAddress) ?? ""
+    placeName = try values.decodeIfPresent(String.self, forKey: .placeName) ?? ""
+    placePositionX = try values.decodeIfPresent(Double.self, forKey: .placePositionX) ?? 0.0
+    placePositionY = try values.decodeIfPresent(Double.self, forKey: .placePositionY) ?? 0.0
+    isBookmarked = try values.decodeIfPresent(Bool.self, forKey: .isBookmarked) ?? false
+    isApplied = try values.decodeIfPresent(Bool.self, forKey: .isApplied) ?? false
+    curAccountNum = try values.decodeIfPresent(Int.self, forKey: .curAccountNum) ?? 0
+    remainAccountNum = try values.decodeIfPresent(Int.self, forKey: .remainAccountNum) ?? 0
+    joinedAccounts = try values.decodeIfPresent([AccountInfo].self, forKey: .joinedAccounts) ?? []
   }
 }
 

--- a/PLUB/Sources/Models/Recruitment/Response/RecruitmentQuestionResponse.swift
+++ b/PLUB/Sources/Models/Recruitment/Response/RecruitmentQuestionResponse.swift
@@ -17,7 +17,7 @@ struct RecruitmentQuestionResponse: Codable {
   init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     
-    self.questions = try values.decodeIfPresent([Question].self, forKey: .questions) ?? []
+    questions = try values.decodeIfPresent([Question].self, forKey: .questions) ?? []
   }
 }
 

--- a/PLUB/Sources/Models/Recruitment/Response/RequestBookmarkResponse.swift
+++ b/PLUB/Sources/Models/Recruitment/Response/RequestBookmarkResponse.swift
@@ -19,8 +19,8 @@ struct RequestBookmarkResponse: Codable, Equatable {
   init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     
-    self.plubbingID = try values.decodeIfPresent(Int.self, forKey: .plubbingID) ?? -1
-    self.isBookmarked = try values.decodeIfPresent(Bool.self, forKey: .isBookmarked) ?? false
+    plubbingID = try values.decodeIfPresent(Int.self, forKey: .plubbingID) ?? -1
+    isBookmarked = try values.decodeIfPresent(Bool.self, forKey: .isBookmarked) ?? false
   }
   
   static func == (lhs: Self, rhs: Self) -> Bool {

--- a/PLUB/Sources/Models/Recruitment/Response/SearchRecruitmentResponse.swift
+++ b/PLUB/Sources/Models/Recruitment/Response/SearchRecruitmentResponse.swift
@@ -20,10 +20,10 @@ struct SearchRecruitmentResponse: Codable {
   init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     
-    self.totalPages = try values.decodeIfPresent(Int.self, forKey: .totalPages) ?? 0
-    self.totalElements = try values.decodeIfPresent(Int.self, forKey: .totalElements) ?? 0
-    self.last = try values.decodeIfPresent(Bool.self, forKey: .last) ?? false
-    self.content = try values.decodeIfPresent([SearchContent].self, forKey: .content) ?? []
+    totalPages = try values.decodeIfPresent(Int.self, forKey: .totalPages) ?? 0
+    totalElements = try values.decodeIfPresent(Int.self, forKey: .totalElements) ?? 0
+    last = try values.decodeIfPresent(Bool.self, forKey: .last) ?? false
+    content = try values.decodeIfPresent([SearchContent].self, forKey: .content) ?? []
   }
 }
 

--- a/PLUB/Sources/Views/Home/Cell/Search/SearchOutputHeaderView.swift
+++ b/PLUB/Sources/Views/Home/Cell/Search/SearchOutputHeaderView.swift
@@ -16,7 +16,7 @@ protocol SearchOutputHeaderViewDelegate: AnyObject {
   func didTappedInterestListChartButton()
   func didTappedInterestListGridButton()
   func didTappedSortControl()
-  func whichTappedSegmentControl(index: Int)
+  func whichTappedSegmentControl(type: FilterType)
 }
 
 class SearchOutputHeaderView: UIView {
@@ -32,7 +32,7 @@ class SearchOutputHeaderView: UIView {
   }
   
   private let segmentedControl = UnderlineSegmentedControl(
-    items: [FilterType.title.toKor, FilterType.mix.toKor, FilterType.name.toKor]
+    items: [FilterType.title.toKor, FilterType.name.toKor, FilterType.mix.toKor]
   ).then {
     $0.setTitleTextAttributes([.foregroundColor: UIColor.black, .font: UIFont.body1!], for: .normal)
     $0.setTitleTextAttributes([.foregroundColor: UIColor.main, .font: UIFont.body1!], for: .selected)
@@ -84,7 +84,7 @@ class SearchOutputHeaderView: UIView {
     
     segmentedControl.rx.value
       .subscribe(with: self) { owner, index in
-        owner.delegate?.whichTappedSegmentControl(index: index)
+        owner.delegate?.whichTappedSegmentControl(type: FilterType.allCases[index])
       }
       .disposed(by: disposeBag)
       

--- a/PLUB/Sources/Views/Home/Cell/Search/SearchOutputHeaderView.swift
+++ b/PLUB/Sources/Views/Home/Cell/Search/SearchOutputHeaderView.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import RxSwift
+import RxCocoa
 import SnapKit
 import Then
 
@@ -15,7 +16,7 @@ protocol SearchOutputHeaderViewDelegate: AnyObject {
   func didTappedInterestListChartButton()
   func didTappedInterestListGridButton()
   func didTappedSortControl()
-  func didTappedTopBar(which: IndexPath)
+  func whichTappedSegmentControl(index: Int)
 }
 
 class SearchOutputHeaderView: UIView {
@@ -31,7 +32,7 @@ class SearchOutputHeaderView: UIView {
   }
   
   private let segmentedControl = UnderlineSegmentedControl(
-    items: ["제목", "모임이름", "제목+글"]
+    items: [FilterType.title.toKor, FilterType.mix.toKor, FilterType.name.toKor]
   ).then {
     $0.setTitleTextAttributes([.foregroundColor: UIColor.black, .font: UIFont.body1!], for: .normal)
     $0.setTitleTextAttributes([.foregroundColor: UIColor.main, .font: UIFont.body1!], for: .selected)
@@ -80,6 +81,14 @@ class SearchOutputHeaderView: UIView {
   }
   
   private func bind() {
+    
+    segmentedControl.rx.value
+      .subscribe(with: self) { owner, index in
+        owner.delegate?.whichTappedSegmentControl(index: index)
+      }
+      .disposed(by: disposeBag)
+      
+    
     sortButton.rx.tap
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in

--- a/PLUB/Sources/Views/Home/Cell/Search/SearchOutputHeaderView.swift
+++ b/PLUB/Sources/Views/Home/Cell/Search/SearchOutputHeaderView.swift
@@ -21,11 +21,6 @@ protocol SearchOutputHeaderViewDelegate: AnyObject {
 class SearchOutputHeaderView: UIView {
   
   private let disposeBag = DisposeBag()
-  private let tabModel = [
-    "제목",
-    "모임이름",
-    "제목+내용"
-  ]
   
   weak var delegate: SearchOutputHeaderViewDelegate?
   
@@ -35,21 +30,12 @@ class SearchOutputHeaderView: UIView {
     }
   }
   
-  private lazy var topTabCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout().then {
-    $0.scrollDirection = .horizontal
-    $0.minimumInteritemSpacing = 0
-    $0.minimumLineSpacing = 0
-  }).then {
-    $0.backgroundColor = .background
-    $0.isScrollEnabled = false
-    $0.register(TopTabCollectionViewCell.self, forCellWithReuseIdentifier: TopTabCollectionViewCell.identifier)
-    $0.delegate = self
-    $0.dataSource = self
-    $0.showsHorizontalScrollIndicator = false
-  }
-  
-  private let highlightView = UIView().then {
-    $0.backgroundColor = .main
+  private let segmentedControl = UnderlineSegmentedControl(
+    items: ["제목", "모임이름", "제목+글"]
+  ).then {
+    $0.setTitleTextAttributes([.foregroundColor: UIColor.black, .font: UIFont.body1!], for: .normal)
+    $0.setTitleTextAttributes([.foregroundColor: UIColor.main, .font: UIFont.body1!], for: .selected)
+    $0.selectedSegmentIndex = 0
   }
   
   private let sortButton = SortControl()
@@ -62,7 +48,6 @@ class SearchOutputHeaderView: UIView {
     super.init(frame: frame)
     configureUI()
     bind()
-    setTabbar()
   }
   
   required init?(coder: NSCoder) {
@@ -71,27 +56,20 @@ class SearchOutputHeaderView: UIView {
   
   private func configureUI() {
     interestListChartButton.isSelected = true
-    [topTabCollectionView, highlightView, sortButton, interestListChartButton, interesetListGridButton].forEach { addSubview($0) }
+    [segmentedControl, sortButton, interestListChartButton, interesetListGridButton].forEach { addSubview($0) }
     
-    topTabCollectionView.snp.makeConstraints {
+    segmentedControl.snp.makeConstraints {
       $0.top.width.equalToSuperview()
       $0.height.equalTo(32)
     }
     
-    highlightView.snp.makeConstraints {
-      $0.height.equalTo(1)
-      $0.leading.equalTo(topTabCollectionView.snp.leading)
-      $0.bottom.equalTo(topTabCollectionView.snp.bottom)
-      $0.width.equalTo((Device.width - 20) / 3)
-    }
-    
     interesetListGridButton.snp.makeConstraints {
       $0.trailing.equalToSuperview()
-      $0.top.equalTo(topTabCollectionView.snp.bottom)
+      $0.top.equalTo(segmentedControl.snp.bottom)
     }
     
     interestListChartButton.snp.makeConstraints {
-      $0.top.equalTo(topTabCollectionView.snp.bottom)
+      $0.top.equalTo(segmentedControl.snp.bottom)
       $0.trailing.equalTo(interesetListGridButton.snp.leading)
     }
     
@@ -139,49 +117,5 @@ class SearchOutputHeaderView: UIView {
         owner.interesetListGridButton.isSelected = true
       })
       .disposed(by: disposeBag)
-  }
-  
-  private func setTabbar() {
-    let firstIndexPath = IndexPath(item: 0, section: 0)
-    topTabCollectionView.selectItem(at: firstIndexPath, animated: false, scrollPosition: .right)
-  }
-}
-
-extension SearchOutputHeaderView: UICollectionViewDelegate, UICollectionViewDataSource {
-  func numberOfSections(in collectionView: UICollectionView) -> Int {
-    return 1
-  }
-  
-  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return tabModel.count
-  }
-  
-  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TopTabCollectionViewCell.identifier, for: indexPath) as? TopTabCollectionViewCell ?? TopTabCollectionViewCell()
-    cell.configureUI(with: tabModel[indexPath.row])
-    return cell
-  }
-  
-  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    let cell = collectionView.cellForItem(at: indexPath) as? TopTabCollectionViewCell ?? TopTabCollectionViewCell()
-    
-    delegate?.didTappedTopBar(which: indexPath)
-    
-    UIView.animate(withDuration: 0.3) {
-      self.highlightView.snp.remakeConstraints {
-        $0.height.equalTo(1)
-        $0.bottom.equalTo(cell.snp.bottom)
-        $0.leading.equalTo(cell.snp.leading)
-        $0.trailing.equalTo(cell.snp.trailing)
-      }
-      self.layoutIfNeeded()
-    }
-  }
-}
-
-
-extension SearchOutputHeaderView: UICollectionViewDelegateFlowLayout {
-  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-    return CGSize(width: collectionView.frame.width / 3, height: collectionView.frame.height)
   }
 }

--- a/PLUB/Sources/Views/Home/Cell/Search/TopTabCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Cell/Search/TopTabCollectionViewCell.swift
@@ -10,12 +10,12 @@ import UIKit
 import SnapKit
 import Then
 
-enum FilterType { // 모집글 검색을 위한 필터타입
+enum FilterType: CaseIterable { // 모집글 검색을 위한 필터타입
   case title // 제목
   case name // 모임이름
   case mix // 제목 + 글
   
-  var text: String {
+  var toEng: String {
     switch self {
     case .title:
       return "title"
@@ -23,6 +23,17 @@ enum FilterType { // 모집글 검색을 위한 필터타입
       return "name"
     case .mix:
       return "mix"
+    }
+  }
+  
+  var toKor: String {
+    switch self {
+    case .title:
+      return "제목"
+    case .name:
+      return "모임이름"
+    case .mix:
+      return "제목+글"
     }
   }
 }

--- a/PLUB/Sources/Views/Home/Model/Recruitment/DetailRecruitmentModel.swift
+++ b/PLUB/Sources/Views/Home/Model/Recruitment/DetailRecruitmentModel.swift
@@ -22,17 +22,17 @@ struct DetailRecruitmentModel {
   let joinedAccounts: [AccountInfo]
   
   init(response: DetailRecruitmentResponse) {
-    self.title = response.title
-    self.introduce = response.introduce
-    self.categories = response.categories
-    self.name = response.name
-    self.goal = response.goal
-    self.mainImage = response.mainImage
-    self.days = response.days
-    self.placeName = response.placeName
-    self.isBookmarked = response.isBookmarked
-    self.isApplied = response.isApplied
-    self.remainAccountNum = response.remainAccountNum
-    self.joinedAccounts = response.joinedAccounts
+    title = response.title
+    introduce = response.introduce
+    categories = response.categories
+    name = response.name
+    goal = response.goal
+    mainImage = response.mainImage
+    days = response.days
+    placeName = response.placeName
+    isBookmarked = response.isBookmarked
+    isApplied = response.isApplied
+    remainAccountNum = response.remainAccountNum
+    joinedAccounts = response.joinedAccounts
   }
 }

--- a/PLUB/Sources/Views/Home/Model/RegisterInterestModel.swift
+++ b/PLUB/Sources/Views/Home/Model/RegisterInterestModel.swift
@@ -13,7 +13,7 @@ struct RegisterInterestModel {
   
   init(category: Category) {
     self.category = category
-    self.isExpanded = false
+    isExpanded = false
   }
 }
 

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -170,6 +170,7 @@ final class SearchInputViewController: BaseViewController {
       .disposed(by: disposeBag)
     
     viewModel.searchOutputIsEmpty
+      .do(onNext: { print("앙 \($0)") })
       .map { !$0 }
       .drive(noResultSearchView.rx.isHidden)
       .disposed(by: disposeBag)

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -340,8 +340,9 @@ extension SearchInputViewController: RecentSearchListHeaderViewDelegate {
 }
 
 extension SearchInputViewController: SearchOutputHeaderViewDelegate {
-  func whichTappedSegmentControl(index: Int) {
-    print("인덱스 \(index)")
+  func whichTappedSegmentControl(type: FilterType) {
+    print("인덱스 \(type.toKor)")
+    viewModel.whichFilterType.onNext(type)
   }
   
   func didTappedSortControl() {

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -170,7 +170,6 @@ final class SearchInputViewController: BaseViewController {
       .disposed(by: disposeBag)
     
     viewModel.searchOutputIsEmpty
-      .do(onNext: { print("앙 \($0)") })
       .map { !$0 }
       .drive(noResultSearchView.rx.isHidden)
       .disposed(by: disposeBag)

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -341,7 +341,6 @@ extension SearchInputViewController: RecentSearchListHeaderViewDelegate {
 
 extension SearchInputViewController: SearchOutputHeaderViewDelegate {
   func whichTappedSegmentControl(type: FilterType) {
-    print("인덱스 \(type.toKor)")
     viewModel.whichFilterType.onNext(type)
   }
   

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -340,8 +340,8 @@ extension SearchInputViewController: RecentSearchListHeaderViewDelegate {
 }
 
 extension SearchInputViewController: SearchOutputHeaderViewDelegate {
-  func didTappedTopBar(which: IndexPath) {
-    
+  func whichTappedSegmentControl(index: Int) {
+    print("인덱스 \(index)")
   }
   
   func didTappedSortControl() {

--- a/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
@@ -81,7 +81,7 @@ final class SearchInputViewModel: SearchInputViewModelType {
       .flatMapLatest { (keyword, filterType, sortType) in
         if !isLastPage.value && !isLoading.value { // 마지막 페이지가 아니고 로딩중이 아닐때
           isLoading.accept(true)
-          return RecruitmentService.shared.searchRecruitment(searchParameter: .init(keyword: keyword, page: currentPage.value, type: filterType.text, sort: sortType.text))
+          return RecruitmentService.shared.searchRecruitment(searchParameter: .init(keyword: keyword, page: currentPage.value, type: filterType.toEng, sort: sortType.text))
         }
         return .empty()
       }
@@ -163,7 +163,7 @@ final class SearchInputViewModel: SearchInputViewModelType {
         print("페이지 \(page)")
       })
         .flatMapLatest { page in
-          return RecruitmentService.shared.searchRecruitment(searchParameter: .init(keyword: try searchKeyword.value(), page: currentPage.value, type: try searchFilterType.value().text, sort: try searchSortType.value().text))
+          return RecruitmentService.shared.searchRecruitment(searchParameter: .init(keyword: try searchKeyword.value(), page: currentPage.value, type: try searchFilterType.value().toEng, sort: try searchSortType.value().text))
         }
         .compactMap { result -> [SearchContent]? in
           print("결과 \(result)")

--- a/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
@@ -84,7 +84,7 @@ final class SearchInputViewModel: SearchInputViewModelType {
         isLastPage.accept(false)
         currentPage.accept(1)
       })
-      .flatMapLatest { (keyword, filterType, sortType) in
+      .flatMapLatest { keyword, filterType, sortType in
         isLoading.accept(true)
         return RecruitmentService.shared.searchRecruitment(
           searchParameter: .init(
@@ -193,8 +193,13 @@ final class SearchInputViewModel: SearchInputViewModelType {
       .asSignal(onErrorSignalWith: .empty())
     
     // 검색 아웃풋관련 상태값
-    keywordListIsEmpty = recentKeywordList.map { $0.isEmpty }.asDriver(onErrorJustReturn: true)
-    searchOutputIsEmpty = fetchingSearchOutput.skip(1).map { $0.isEmpty }.asDriver(onErrorJustReturn: true)
+    keywordListIsEmpty = recentKeywordList
+      .map { $0.isEmpty }
+      .asDriver(onErrorJustReturn: true)
+    
+    searchOutputIsEmpty = fetchingSearchOutput.skip(1)
+      .map { $0.isEmpty }
+      .asDriver(onErrorJustReturn: true)
   }
 }
 

--- a/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
@@ -27,7 +27,8 @@ protocol SearchInputViewModelType {
   var isBookmarked: Signal<Bool> { get }
 }
 
-// TODO: 이건준 -추후 API요청에 따른 result failure에 대한 에러 묶어서 처리하기
+// TODO: 이건준 - 추후 API요청에 따른 result failure에 대한 에러 묶어서 처리하기
+// TODO: 이건준 - 검색 Output화면 첫번째 인덱스 UI에 따라서 초기값달라져야함
 final class SearchInputViewModel: SearchInputViewModelType {
   private let disposeBag = DisposeBag()
   
@@ -50,7 +51,7 @@ final class SearchInputViewModel: SearchInputViewModelType {
   init() {
     let searchKeyword = BehaviorSubject<String>(value: "")
     let searchSortType = BehaviorSubject<SortType>(value: .popular)
-    let searchFilterType = BehaviorSubject<FilterType>(value: .mix)
+    let searchFilterType = BehaviorSubject<FilterType>(value: .title)
     let fetchingSearchOutput = BehaviorRelay<[SelectedCategoryCollectionViewCellModel]>(value: [])
     let recentKeywordList = BehaviorRelay<[String]>(value: [])
     let removeKeyword = PublishSubject<Int>()
@@ -79,6 +80,9 @@ final class SearchInputViewModel: SearchInputViewModelType {
       })
       .skip(1)
       .flatMapLatest { (keyword, filterType, sortType) in
+        print("키워드 \(keyword)")
+        print("필터 \(filterType)")
+        print("분류 \(sortType)")
         if !isLastPage.value && !isLoading.value { // 마지막 페이지가 아니고 로딩중이 아닐때
           isLoading.accept(true)
           return RecruitmentService.shared.searchRecruitment(searchParameter: .init(keyword: keyword, page: currentPage.value, type: filterType.toEng, sort: sortType.text))

--- a/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
@@ -163,13 +163,10 @@ final class SearchInputViewModel: SearchInputViewModelType {
     .disposed(by: disposeBag)
     
     searchKeyword.skip(1).subscribe(onNext: { keyword in
-      var list = recentKeywordList.value
-      if list.contains(keyword) {
-        guard let index = list.firstIndex(of: keyword) else { return }
-        list.remove(at: index)
-      }
-      list.insert(keyword, at: 0)
-      recentKeywordList.accept(list)
+      let list = recentKeywordList.value
+      var filterList = list.filter { $0 != keyword }
+      filterList.insert(keyword, at: 0)
+      recentKeywordList.accept(filterList)
     })
     .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
@@ -73,7 +73,7 @@ final class SearchInputViewModel: SearchInputViewModelType {
     fetchMoreDatas = fetchingDatas.asObserver()
     
     let searchRecruitment = Observable.combineLatest(
-      searchKeyword.distinctUntilChanged(),
+      searchKeyword,
       searchFilterType,
       searchSortType
     )

--- a/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
@@ -100,9 +100,13 @@ final class SearchInputViewModel: SearchInputViewModelType {
       .filter { _ in !isLastPage.value && !isLoading.value }
       .map { $0 + 1 }
       .do(onNext: { page in
+        print("페이지 \(page)")
+        print("마지막페이지 \(isLastPage.value)")
+        print("로딩중 \(isLoading.value)")
         currentPage.accept(page)
       })
         .flatMapLatest { page in
+          isLoading.accept(true)
           return RecruitmentService.shared.searchRecruitment(
             searchParameter: .init(
               keyword: try searchKeyword.value(),

--- a/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
@@ -79,15 +79,10 @@ final class SearchInputViewModel: SearchInputViewModelType {
         currentPage.accept(1)
       })
       .skip(1)
+      .filter { _ in !isLastPage.value && !isLoading.value } // 마지막 페이지가 아니고 로딩중이 아닐때
       .flatMapLatest { (keyword, filterType, sortType) in
-        print("키워드 \(keyword)")
-        print("필터 \(filterType)")
-        print("분류 \(sortType)")
-        if !isLastPage.value && !isLoading.value { // 마지막 페이지가 아니고 로딩중이 아닐때
-          isLoading.accept(true)
-          return RecruitmentService.shared.searchRecruitment(searchParameter: .init(keyword: keyword, page: currentPage.value, type: filterType.toEng, sort: sortType.text))
-        }
-        return .empty()
+        isLoading.accept(true)
+        return RecruitmentService.shared.searchRecruitment(searchParameter: .init(keyword: keyword, page: currentPage.value, type: filterType.toEng, sort: sortType.text))
       }
     
     let successSearch = requestSearch.compactMap { result -> [SearchContent]? in
@@ -160,47 +155,45 @@ final class SearchInputViewModel: SearchInputViewModelType {
       .asSignal(onErrorSignalWith: .empty())
     
     fetchingDatas.withLatestFrom(currentPage)
-      .filter { _ in isLastPage.value || isLoading.value }
+      .filter { _ in !isLastPage.value && !isLoading.value }
       .map { $0 + 1 }
       .do(onNext: { page in
         currentPage.accept(page)
-        print("페이지 \(page)")
       })
-        .flatMapLatest { page in
-          return RecruitmentService.shared.searchRecruitment(searchParameter: .init(keyword: try searchKeyword.value(), page: currentPage.value, type: try searchFilterType.value().toEng, sort: try searchSortType.value().text))
+      .flatMapLatest { page in
+        return RecruitmentService.shared.searchRecruitment(searchParameter: .init(keyword: try searchKeyword.value(), page: currentPage.value, type: try searchFilterType.value().toEng, sort: try searchSortType.value().text))
+      }
+      .compactMap { result -> [SearchContent]? in
+        guard case .success(let response) = result else { return nil }
+        isLastPage.accept(response.data?.last ?? false)
+        return response.data?.content
+      }
+      .map { contents in
+        contents.map { content in
+          return SelectedCategoryCollectionViewCellModel(
+            plubbingID: "\(content.plubbingID)",
+            name: content.name,
+            title: content.title,
+            mainImage: content.mainImage,
+            introduce: content.introduce,
+            isBookmarked: content.isBookmarked,
+            selectedCategoryInfoModel: .init(
+              placeName: content.placeName,
+              peopleCount: content.remainAccountNum,
+              dateTime: content.days
+                .map { $0.fromENGToKOR() }
+                .joined(separator: ",")
+              + " | "
+              + "(data.time)"))
         }
-        .compactMap { result -> [SearchContent]? in
-          print("결과 \(result)")
-          guard case .success(let response) = result else { return nil }
-          isLastPage.accept(response.data?.last ?? false)
-          return response.data?.content
-        }
-        .map { contents in
-          contents.map { content in
-            return SelectedCategoryCollectionViewCellModel(
-              plubbingID: "\(content.plubbingID)",
-              name: content.name,
-              title: content.title,
-              mainImage: content.mainImage,
-              introduce: content.introduce,
-              isBookmarked: content.isBookmarked,
-              selectedCategoryInfoModel: .init(
-                placeName: content.placeName,
-                peopleCount: content.remainAccountNum,
-                dateTime: content.days
-                  .map { $0.fromENGToKOR() }
-                  .joined(separator: ",")
-                + " | "
-                + "(data.time)"))
-          }
-        }
-        .subscribe(onNext: { model in
-          var cellData = fetchingSearchOutput.value
-          cellData.append(contentsOf: model)
-          fetchingSearchOutput.accept(cellData)
-          isLoading.accept(false)
-        })
-        .disposed(by: disposeBag)
+      }
+      .subscribe(onNext: { model in
+        var cellData = fetchingSearchOutput.value
+        cellData.append(contentsOf: model)
+        fetchingSearchOutput.accept(cellData)
+        isLoading.accept(false)
+      })
+      .disposed(by: disposeBag)
     
     keywordListIsEmpty = recentKeywordList.map { $0.isEmpty }.asDriver(onErrorJustReturn: true)
     searchOutputIsEmpty = fetchingSearchOutput.skip(1).map { $0.isEmpty }.asDriver(onErrorJustReturn: true)


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 검색 Input 첫 화면이 아닌 검색 Output에 따른 결과값 존재하지않을때 화면 나오는 오류 수정
- 페이징에 따른 데이터요청 시 무한루프도는 코드오류 수정
- API 응답값을 위한 모델코드 불필요한 self 삭제
- 키워드, 분류, 필터와 페이지 2개로 분류하여 하나의 스트림으로 연동시키기
- 상태값초기화에 따른 불요한 필터코드 수정
- 필터를 위한 헤더뷰 공통컴포넌트로 코드변경

## 📸 스크린샷
<img width="345" alt="스크린샷 2023-02-22 오후 7 29 54" src="https://user-images.githubusercontent.com/39263235/220594144-9d1a690d-b0c5-48f6-815a-89098eb047c8.png">


## 📮 관련 이슈
- Resolved: #168 

