### PR TITLE
[FEAT] 내모임 UI 구현

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -211,6 +211,7 @@
 		C35AFD012998B0A500AB5CD3 /* EditMeetingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35AFD002998B0A500AB5CD3 /* EditMeetingViewModel.swift */; };
 		C361743129AF95E2006AEAB1 /* MyMeetingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C361743029AF95E2006AEAB1 /* MyMeetingResponse.swift */; };
 		C361743329AF9B2D006AEAB1 /* MeetingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C361743229AF9B2D006AEAB1 /* MeetingViewModel.swift */; };
+		C361743629AFB875006AEAB1 /* MeetingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C361743529AFB875006AEAB1 /* MeetingCollectionViewCell.swift */; };
 		C3622B4729A7C414005EF09C /* ScheduleListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3622B4629A7C414005EF09C /* ScheduleListResponse.swift */; };
 		C3622B4A29A7CFF0005EF09C /* AddScheduleControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3622B4929A7CFF0005EF09C /* AddScheduleControl.swift */; };
 		C3622B4C29A7D209005EF09C /* ScheduleTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3622B4B29A7D209005EF09C /* ScheduleTopView.swift */; };
@@ -463,6 +464,7 @@
 		C35AFD002998B0A500AB5CD3 /* EditMeetingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMeetingViewModel.swift; sourceTree = "<group>"; };
 		C361743029AF95E2006AEAB1 /* MyMeetingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyMeetingResponse.swift; sourceTree = "<group>"; };
 		C361743229AF9B2D006AEAB1 /* MeetingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingViewModel.swift; sourceTree = "<group>"; };
+		C361743529AFB875006AEAB1 /* MeetingCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCollectionViewCell.swift; sourceTree = "<group>"; };
 		C3622B4629A7C414005EF09C /* ScheduleListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleListResponse.swift; sourceTree = "<group>"; };
 		C3622B4929A7CFF0005EF09C /* AddScheduleControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddScheduleControl.swift; sourceTree = "<group>"; };
 		C3622B4B29A7D209005EF09C /* ScheduleTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleTopView.swift; sourceTree = "<group>"; };
@@ -891,6 +893,7 @@
 		BA42D1F028EDE08000C20061 /* Meeting */ = {
 			isa = PBXGroup;
 			children = (
+				C361743429AFB83E006AEAB1 /* Cell */,
 				BA42D1F428EDE11900C20061 /* MeetingViewController.swift */,
 				C361743229AF9B2D006AEAB1 /* MeetingViewModel.swift */,
 				C3AB743A296B1EC3003DD5E2 /* CreateMeeting */,
@@ -1171,6 +1174,14 @@
 				C383968229A29C63005998A5 /* CreateSchedule */,
 			);
 			path = Schedule;
+			sourceTree = "<group>";
+		};
+		C361743429AFB83E006AEAB1 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				C361743529AFB875006AEAB1 /* MeetingCollectionViewCell.swift */,
+			);
+			path = Cell;
 			sourceTree = "<group>";
 		};
 		C3622B4829A7CFCD005EF09C /* Component */ = {
@@ -1733,6 +1744,7 @@
 				702876C429A3752A00E57509 /* MeetingScheduleViewController.swift in Sources */,
 				70A420C229914B890026E9F9 /* InquireInterestResponse.swift in Sources */,
 				C383967C29A25A3E005998A5 /* ScheduleRouter.swift in Sources */,
+				C361743629AFB875006AEAB1 /* MeetingCollectionViewCell.swift in Sources */,
 				C359FEAA29A08B7E00B2F561 /* ScheduleTitleView.swift in Sources */,
 				BA7255C12992445600A3E8F5 /* PLUBTabBarController.swift in Sources */,
 				70A420B229914B370026E9F9 /* MainCategoryListResponse.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -209,6 +209,8 @@
 		C359FEAA29A08B7E00B2F561 /* ScheduleTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C359FEA929A08B7E00B2F561 /* ScheduleTitleView.swift */; };
 		C359FEAC29A09C5200B2F561 /* ScheduleDateSubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C359FEAB29A09C5200B2F561 /* ScheduleDateSubView.swift */; };
 		C35AFD012998B0A500AB5CD3 /* EditMeetingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35AFD002998B0A500AB5CD3 /* EditMeetingViewModel.swift */; };
+		C361743129AF95E2006AEAB1 /* MyMeetingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C361743029AF95E2006AEAB1 /* MyMeetingResponse.swift */; };
+		C361743329AF9B2D006AEAB1 /* MeetingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C361743229AF9B2D006AEAB1 /* MeetingViewModel.swift */; };
 		C3622B4729A7C414005EF09C /* ScheduleListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3622B4629A7C414005EF09C /* ScheduleListResponse.swift */; };
 		C3622B4A29A7CFF0005EF09C /* AddScheduleControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3622B4929A7CFF0005EF09C /* AddScheduleControl.swift */; };
 		C3622B4C29A7D209005EF09C /* ScheduleTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3622B4B29A7D209005EF09C /* ScheduleTopView.swift */; };
@@ -459,6 +461,8 @@
 		C359FEA929A08B7E00B2F561 /* ScheduleTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleTitleView.swift; sourceTree = "<group>"; };
 		C359FEAB29A09C5200B2F561 /* ScheduleDateSubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleDateSubView.swift; sourceTree = "<group>"; };
 		C35AFD002998B0A500AB5CD3 /* EditMeetingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMeetingViewModel.swift; sourceTree = "<group>"; };
+		C361743029AF95E2006AEAB1 /* MyMeetingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyMeetingResponse.swift; sourceTree = "<group>"; };
+		C361743229AF9B2D006AEAB1 /* MeetingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingViewModel.swift; sourceTree = "<group>"; };
 		C3622B4629A7C414005EF09C /* ScheduleListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleListResponse.swift; sourceTree = "<group>"; };
 		C3622B4929A7CFF0005EF09C /* AddScheduleControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddScheduleControl.swift; sourceTree = "<group>"; };
 		C3622B4B29A7D209005EF09C /* ScheduleTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleTopView.swift; sourceTree = "<group>"; };
@@ -888,6 +892,7 @@
 			isa = PBXGroup;
 			children = (
 				BA42D1F428EDE11900C20061 /* MeetingViewController.swift */,
+				C361743229AF9B2D006AEAB1 /* MeetingViewModel.swift */,
 				C3AB743A296B1EC3003DD5E2 /* CreateMeeting */,
 				C33FB0702993F81800BEB15B /* EditMeeting */,
 				C359FEA4299FDE6400B2F561 /* Schedule */,
@@ -1404,6 +1409,7 @@
 			children = (
 				70A420B529914B4F0026E9F9 /* CategoryMeetingResponse.swift */,
 				C3ED8FB62989B87E002F689B /* CreateMeetingResponse.swift */,
+				C361743029AF95E2006AEAB1 /* MyMeetingResponse.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1602,6 +1608,7 @@
 				C38A5B9B297AE05100485355 /* KakaoLocationRequest.swift in Sources */,
 				70197B722953698F000503F6 /* SelectedCategoryViewController.swift in Sources */,
 				BA876BA1296514DA0029CF34 /* PaddingTextField.swift in Sources */,
+				C361743329AF9B2D006AEAB1 /* MeetingViewModel.swift in Sources */,
 				C38D6566298852F80052013F /* PaddingLabel.swift in Sources */,
 				70197B7B29549B6A000503F6 /* SelectedCategoryChartCollectionViewCell.swift in Sources */,
 				70A4209C2988B1DC0026E9F9 /* SortControl.swift in Sources */,
@@ -1722,6 +1729,7 @@
 				7085678628EE9A92008047DC /* HomeCollectionViewCell.swift in Sources */,
 				BA780E09297133220032C178 /* Config.swift in Sources */,
 				BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */,
+				C361743129AF95E2006AEAB1 /* MyMeetingResponse.swift in Sources */,
 				702876C429A3752A00E57509 /* MeetingScheduleViewController.swift in Sources */,
 				70A420C229914B890026E9F9 /* InquireInterestResponse.swift in Sources */,
 				C383967C29A25A3E005998A5 /* ScheduleRouter.swift in Sources */,

--- a/PLUB/Sources/Models/Meeting/Response/MyMeetingResponse.swift
+++ b/PLUB/Sources/Models/Meeting/Response/MyMeetingResponse.swift
@@ -1,0 +1,29 @@
+//
+//  MyMeetingResponse.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/03/01.
+//
+
+import Foundation
+
+struct MyMeetingResponse: Codable {
+  let myPlubbing: [MyPlubbing]
+  
+  enum CodingKeys: String, CodingKey {
+    case myPlubbing = "plubbings"
+  }
+}
+
+struct MyPlubbing: Codable {
+  let plubbingID: Int
+  let name: String
+  let goal: String
+  let mainImage: String?
+  let days: [String]
+  
+  enum CodingKeys: String, CodingKey {
+    case plubbingID = "plubbingId"
+    case name, goal, mainImage, days
+  }
+}

--- a/PLUB/Sources/Models/Schedule/Request/CreateScheduleRequest.swift
+++ b/PLUB/Sources/Models/Schedule/Request/CreateScheduleRequest.swift
@@ -62,7 +62,7 @@ struct CreateScheduleRequest: Codable {
 extension CreateScheduleRequest {
   enum CodingKeys: String, CodingKey {
     case title, memo, startTime, endTime, isAllDay, address, roadAddress, placeName, alarmType
-    case startDay = "staredAt"
+    case startDay = "startedAt"
     case endDay = "endedAt"
   }
 }

--- a/PLUB/Sources/Models/Schedule/Request/CreateScheduleRequest.swift
+++ b/PLUB/Sources/Models/Schedule/Request/CreateScheduleRequest.swift
@@ -38,6 +38,9 @@ struct CreateScheduleRequest: Codable {
   /// 장소 이름
   var placeName: String
   
+  /// 알람
+  var alarmType: String
+  
   /// 알림
   //TODO: 수빈 - 알림 정보 추가
   
@@ -52,12 +55,13 @@ struct CreateScheduleRequest: Codable {
     address = ""
     roadAddress = ""
     placeName = ""
+    alarmType = ""
   }
 }
 
 extension CreateScheduleRequest {
   enum CodingKeys: String, CodingKey {
-    case title, memo, startTime, endTime, isAllDay, address, roadAddress, placeName
+    case title, memo, startTime, endTime, isAllDay, address, roadAddress, placeName, alarmType
     case startDay = "staredAt"
     case endDay = "endedAt"
   }

--- a/PLUB/Sources/Network/Routers/MeetingRouter.swift
+++ b/PLUB/Sources/Network/Routers/MeetingRouter.swift
@@ -12,6 +12,7 @@ enum MeetingRouter {
   case editMeetingInfo(String, EditMeetingInfoRequest)
   case inquireCategoryMeeting(String, Int, String, CategoryMeetingRequest?)
   case inquireRecommendationMeeting(Int)
+  case inquireMyMeeting(Bool)
 }
 
 extension MeetingRouter: Router {
@@ -21,7 +22,7 @@ extension MeetingRouter: Router {
       return .post
     case .editMeetingInfo:
       return .put
-    case .inquireRecommendationMeeting:
+    case .inquireRecommendationMeeting, .inquireMyMeeting:
       return .get
     }
   }
@@ -36,6 +37,8 @@ extension MeetingRouter: Router {
       return "/plubbings/categories/\(categoryID)"
     case .inquireRecommendationMeeting:
       return "/plubbings/recommendation"
+    case .inquireMyMeeting:
+      return "/plubbings/my"
     }
   }
   
@@ -50,12 +53,14 @@ extension MeetingRouter: Router {
       return .queryBody(["page": "\(page)", "sort": sort], model)
     case .inquireRecommendationMeeting(let page):
       return .query(["page": page])
+    case .inquireMyMeeting(let isHost):
+      return .query(["isHost": isHost])
     }
   }
   
   var headers: HeaderType {
     switch self {
-    case .createMeeting, .editMeetingInfo, .inquireCategoryMeeting, .inquireRecommendationMeeting:
+    case .createMeeting, .editMeetingInfo, .inquireCategoryMeeting, .inquireRecommendationMeeting, .inquireMyMeeting:
       return .withAccessToken
     }
   }

--- a/PLUB/Sources/Network/Services/MeetingService.swift
+++ b/PLUB/Sources/Network/Services/MeetingService.swift
@@ -36,4 +36,8 @@ extension MeetingService {
   func inquireRecommendationMeeting(page: Int) -> PLUBResult<CategoryMeetingResponse> {
     return sendRequest(MeetingRouter.inquireRecommendationMeeting(page), type: CategoryMeetingResponse.self)
   }
+  
+  func inquireMyMeeting(isHost: Bool) -> PLUBResult<MyMeetingResponse> {
+    return sendRequest(MeetingRouter.inquireMyMeeting(isHost), type: MyMeetingResponse.self)
+  }
 }

--- a/PLUB/Sources/Views/Meeting/Cell/MeetingCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Meeting/Cell/MeetingCollectionViewCell.swift
@@ -1,0 +1,55 @@
+//
+//  MeetingCollectionViewCell.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/03/02.
+//
+
+import UIKit
+
+final class MeetingCollectionViewCell: UICollectionViewCell {
+  static let identifier = "MeetingCollectionViewCell"
+  
+  private var label = UILabel().then {
+    $0.font = .h3
+    $0.textColor = .deepGray
+    $0.textAlignment = .center
+  }
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupLayouts()
+    setupConstraints()
+    setupStyles()
+  }
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
+    
+  private func setupLayouts() {
+    addSubview(label)
+  }
+    
+  private func setupConstraints() {
+    label.snp.makeConstraints {
+      $0.center.equalToSuperview()
+    }
+  }
+  
+  private func setupStyles() {
+    backgroundColor = .clear
+    
+    layer.cornerRadius = 8
+    layer.borderWidth = 1
+    layer.borderColor = UIColor.deepGray.cgColor
+  }
+  
+  func setupData(with data: MyPlubbing) {
+    label.text = data.name
+  }
+  
+  func setupCreateCell() {
+    label.text = "+"
+  }
+}

--- a/PLUB/Sources/Views/Meeting/Cell/MeetingCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Meeting/Cell/MeetingCollectionViewCell.swift
@@ -7,10 +7,12 @@
 
 import UIKit
 
+import SnapKit
+
 final class MeetingCollectionViewCell: UICollectionViewCell {
   static let identifier = "MeetingCollectionViewCell"
   
-  private var label = UILabel().then {
+  private let label = UILabel().then {
     $0.font = .h3
     $0.textColor = .deepGray
     $0.textAlignment = .center

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingCreateSuccessViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingCreateSuccessViewController.swift
@@ -81,5 +81,18 @@ final class MeetingCreateSuccessViewController: BaseViewController {
   
   override func bind() {
     super.bind()
+    myPostButton.rx.tap
+      .asDriver()
+      .drive(with: self) { owner, _ in
+        //TODO: 수빈 - 내가 쓴 글 보기 화면 이동 추가
+      }
+      .disposed(by: disposeBag)
+    
+    mainPageButton.rx.tap
+      .asDriver()
+      .drive(with: self) { owner, _ in
+        owner.navigationController?.popToRootViewController(animated: true)
+      }
+      .disposed(by: disposeBag)
   }
 }

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
@@ -49,6 +49,15 @@ final class MeetingQuestionViewController: BaseViewController {
     $0.register(AddQuestionTableViewCell.self, forCellReuseIdentifier: AddQuestionTableViewCell.identifier)
   }
   
+  private let tapGesture = UITapGestureRecognizer(
+    target: MeetingQuestionViewController.self,
+    action: nil
+  ).then {
+    $0.numberOfTapsRequired = 1
+    $0.cancelsTouchesInView = false
+    $0.isEnabled = true
+  }
+  
   init(
     viewModel: MeetingQuestionViewModel,
     childIndex: Int
@@ -110,6 +119,15 @@ final class MeetingQuestionViewController: BaseViewController {
         )
       })
       .disposed(by: disposeBag)
+    
+    tapGesture.rx.event
+      .asDriver()
+      .drive(with: self) { owner, _ in
+        owner.view.endEditing(true)
+      }
+      .disposed(by: disposeBag)
+    
+    tableView.addGestureRecognizer(tapGesture)
   }
 }
 

--- a/PLUB/Sources/Views/Meeting/MeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewController.swift
@@ -63,6 +63,11 @@ final class MeetingViewController: BaseViewController {
     super.viewDidLoad()
   }
   
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    viewModel.fetchMyMeeting()
+  }
+  
   override func setupLayouts() {
     super.setupLayouts()
     [meetingTypeStackView, pageControl, collectionView].forEach {

--- a/PLUB/Sources/Views/Meeting/MeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewController.swift
@@ -1,5 +1,10 @@
 import UIKit
 
+import RxSwift
+import RxCocoa
+import SnapKit
+import Then
+
 final class MeetingViewController: BaseViewController {
   
   private let viewModel = MeetingViewModel()
@@ -32,7 +37,7 @@ final class MeetingViewController: BaseViewController {
     $0.titleLabel?.font = .h4
   }
   
-  private lazy var pageControl = PageControl().then {
+  private let pageControl = PageControl().then {
     $0.numberOfPages = 1
     $0.isHidden = true
   }
@@ -113,7 +118,7 @@ final class MeetingViewController: BaseViewController {
     super.bind()
     
     viewModel.meetingList
-      .drive(with: self){ owner, data in
+      .drive(with: self) { owner, data in
         owner.meetingList = data
         owner.pageControl.numberOfPages = data.count
       }
@@ -121,14 +126,14 @@ final class MeetingViewController: BaseViewController {
     
     myMeetingButton.rx.tap
       .asDriver()
-      .drive(with: self){ owner, _ in
+      .drive(with: self) { owner, _ in
         //
       }
       .disposed(by: disposeBag)
     
     hostButton.rx.tap
       .asDriver()
-      .drive(with: self){ owner, _ in
+      .drive(with: self) { owner, _ in
        //
       }
       .disposed(by: disposeBag)
@@ -150,13 +155,13 @@ extension MeetingViewController: UICollectionViewDelegate, UICollectionViewDataS
     
   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     guard let cell = collectionView.dequeueReusableCell(
-      withReuseIdentifier: "MeetingCollectionViewCell",
+      withReuseIdentifier: MeetingCollectionViewCell.identifier,
       for: indexPath
     ) as? MeetingCollectionViewCell else { return UICollectionViewCell() }
     
     if indexPath.row < meetingList.count {
       cell.setupData(with: meetingList[indexPath.row])
-    } else{
+    } else {
       cell.setupCreateCell()
     }
     return cell

--- a/PLUB/Sources/Views/Meeting/MeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewController.swift
@@ -2,14 +2,11 @@ import UIKit
 
 final class MeetingViewController: BaseViewController {
   
-  
-  // MARK: - Life Cycle
+  private let viewModel = MeetingViewModel()
   
   override func viewDidLoad() {
     super.viewDidLoad()
   }
-  
-  // MARK: - Configuration
   
   override func setupLayouts() {
     super.setupLayouts()

--- a/PLUB/Sources/Views/Meeting/MeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewController.swift
@@ -4,24 +4,170 @@ final class MeetingViewController: BaseViewController {
   
   private let viewModel = MeetingViewModel()
   
+  private var meetingList: [MyPlubbing] = [] {
+    didSet {
+      self.collectionView.reloadData()
+    }
+  }
+  
+  private let meetingTypeStackView = UIStackView().then {
+    $0.axis = .horizontal
+    $0.spacing = 16
+    $0.alignment = .center
+  }
+  
+  private let lineView = UIView().then {
+    $0.backgroundColor = .black
+  }
+  
+  private let myMeetingButton = UIButton().then {
+    $0.setTitle("내 모임", for: .normal)
+    $0.setTitleColor(.mediumGray, for: .normal)
+    $0.titleLabel?.font = .h4
+  }
+  
+  private let hostButton = UIButton().then {
+    $0.setTitle("호스트", for: .normal)
+    $0.setTitleColor(.black, for: .normal)
+    $0.titleLabel?.font = .h4
+  }
+  
+  private lazy var pageControl = PageControl().then {
+    $0.numberOfPages = 1
+    $0.isHidden = true
+  }
+  
+  private let collectionViewLayout = UICollectionViewFlowLayout().then {
+    $0.minimumInteritemSpacing = 16
+    $0.itemSize = CGSize(
+      width: Device.width - 30 * 2,
+      height: Device.height
+      - (Device.topInset + Device.bottomInset)
+      - (111 + 25 + 100)
+    )
+    $0.scrollDirection = .horizontal
+  }
+  
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: collectionViewLayout
+  ).then {
+    $0.backgroundColor = .background
+    $0.showsHorizontalScrollIndicator = false
+    $0.delegate = self
+    $0.dataSource = self
+    $0.register(MeetingCollectionViewCell.self, forCellWithReuseIdentifier: "MeetingCollectionViewCell")
+  }
+  
   override func viewDidLoad() {
     super.viewDidLoad()
   }
   
   override func setupLayouts() {
     super.setupLayouts()
+    [meetingTypeStackView, pageControl, collectionView].forEach {
+      view.addSubview($0)
+    }
+    
+    [myMeetingButton, lineView, hostButton].forEach {
+      meetingTypeStackView.addArrangedSubview($0)
+    }
   }
   
   override func setupConstraints() {
     super.setupConstraints()
+    meetingTypeStackView.snp.makeConstraints {
+      $0.top.equalTo(view.safeAreaLayoutGuide).inset(51)
+      $0.height.equalTo(24)
+      $0.centerX.equalToSuperview()
+    }
+    
+    lineView.snp.makeConstraints {
+      $0.width.equalTo(1)
+      $0.height.equalTo(20)
+    }
+    
+    pageControl.snp.makeConstraints {
+      $0.top.equalTo(meetingTypeStackView.snp.bottom).offset(24)
+      $0.centerX.equalToSuperview()
+    }
+    
+    collectionView.snp.makeConstraints {
+      $0.top.equalTo(meetingTypeStackView.snp.bottom).offset(36)
+      $0.leading.trailing.equalToSuperview()
+      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(25)
+    }
   }
   
   override func setupStyles() {
     super.setupStyles()
-    view.backgroundColor = .systemBackground
+    setupNavigationBar()
   }
   
   override func bind() {
     super.bind()
+    
+    viewModel.meetingList
+      .drive(with: self){ owner, data in
+        owner.meetingList = data
+        owner.pageControl.numberOfPages = data.count
+      }
+      .disposed(by: disposeBag)
+    
+    myMeetingButton.rx.tap
+      .asDriver()
+      .drive(with: self){ owner, _ in
+        //
+      }
+      .disposed(by: disposeBag)
+    
+    hostButton.rx.tap
+      .asDriver()
+      .drive(with: self){ owner, _ in
+       //
+      }
+      .disposed(by: disposeBag)
+  }
+  
+  private func setupNavigationBar() {
+    let logoImageView = UIImageView().then {
+      $0.image = UIImage(named: "plubIcon522x147")
+      $0.contentMode = .scaleAspectFill
+    }
+    
+    self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: logoImageView)
+  }
+}
+extension MeetingViewController: UICollectionViewDelegate, UICollectionViewDataSource {
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return meetingList.count + 1
+  }
+    
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(
+      withReuseIdentifier: "MeetingCollectionViewCell",
+      for: indexPath
+    ) as? MeetingCollectionViewCell else { return UICollectionViewCell() }
+    
+    if indexPath.row < meetingList.count {
+      cell.setupData(with: meetingList[indexPath.row])
+    } else{
+      cell.setupCreateCell()
+    }
+    return cell
+  }
+    
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    if indexPath.row < meetingList.count {
+      // 플러빙 메인
+      let vc = DetailRecruitmentViewController(plubbingID: "\(meetingList[indexPath.row].plubbingID)")
+      vc.hidesBottomBarWhenPushed = true
+      self.navigationController?.pushViewController(vc, animated: true)
+    } else {
+      // 모임 생성
+      let vc = CreateMeetingViewController()
+      vc.hidesBottomBarWhenPushed = true
+      self.navigationController?.pushViewController(vc, animated: true)
+    }
   }
 }

--- a/PLUB/Sources/Views/Meeting/MeetingViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewModel.swift
@@ -13,12 +13,13 @@ import RxCocoa
 final class MeetingViewModel {
   private let disposeBag = DisposeBag()
 
-  // Input
-
-  
   // Output
+  let meetingList: Driver<[MyPlubbing]>
+
+  private let meetingListRelay = BehaviorRelay<[MyPlubbing]>(value: [])
   
   init() {
+    meetingList = meetingListRelay.asDriver()
     fetchMyMeeting()
   }
   
@@ -32,7 +33,7 @@ final class MeetingViewModel {
         switch result {
         case .success(let model):
           guard let data = model.data else { return }
-          print(data)
+          owner.meetingListRelay.accept(data.myPlubbing)
         default: break// TODO: 수빈 - PLUB 에러 Alert 띄우기
         }
       })

--- a/PLUB/Sources/Views/Meeting/MeetingViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewModel.swift
@@ -1,0 +1,41 @@
+//
+//  MeetingViewModel.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/03/01.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+final class MeetingViewModel {
+  private let disposeBag = DisposeBag()
+
+  // Input
+
+  
+  // Output
+  
+  init() {
+    fetchMyMeeting()
+  }
+  
+  private func fetchMyMeeting() {
+    MeetingService.shared
+      .inquireMyMeeting(
+        isHost: true
+      )
+      .withUnretained(self)
+      .subscribe(onNext: { owner, result in
+        switch result {
+        case .success(let model):
+          guard let data = model.data else { return }
+          print(data)
+        default: break// TODO: 수빈 - PLUB 에러 Alert 띄우기
+        }
+      })
+      .disposed(by: disposeBag)
+  }
+}

--- a/PLUB/Sources/Views/Meeting/MeetingViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewModel.swift
@@ -20,10 +20,9 @@ final class MeetingViewModel {
   
   init() {
     meetingList = meetingListRelay.asDriver()
-    fetchMyMeeting()
   }
   
-  private func fetchMyMeeting() {
+  func fetchMyMeeting() {
     MeetingService.shared
       .inquireMyMeeting(
         isHost: true

--- a/PLUB/Sources/Views/Meeting/Schedule/CreateSchedule/Component/ScheduleAlarmView.swift
+++ b/PLUB/Sources/Views/Meeting/Schedule/CreateSchedule/Component/ScheduleAlarmView.swift
@@ -24,17 +24,17 @@ enum ScheduleAlarmType: String, CaseIterable {
     case .none:
       return "NONE"
     case .before5Minute:
-      return "5MIN"
+      return "FIVE_MINUTES"
     case .before15Minute:
-      return "10MIN"
+      return "TEN_MINUTES"
     case .before30Minute:
-      return "30MIN"
+      return "THIRTY_MINUTES"
     case .before1Hour:
-      return "1HOUR"
+      return "ONE_HOUR"
     case .before1Day:
-      return "1DAY"
+      return "ONE_DAY"
     case .before1Week:
-      return "1WEEK"
+      return "ONE_WEEK"
     }
   }
 }

--- a/PLUB/Sources/Views/Meeting/Schedule/CreateSchedule/CreateScheduleViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/Schedule/CreateSchedule/CreateScheduleViewModel.swift
@@ -120,8 +120,9 @@ final class CreateScheduleViewModel {
     alarmSubject
       .withUnretained(self)
       .map { owner, alarm in
-        owner.scheduleRelay.value
-          //TODO: 수빈 alarm 데이터 추가(alarm.value)
+        owner.scheduleRelay.value.with {
+          $0.alarmType = alarm.value
+        }
       }
       .bind(to: scheduleRelay)
       .disposed(by: disposeBag)


### PR DESCRIPTION
## 📌 PR 요약
오프라인 회의 시연용으로 내모임 UI를 간단하게 구현해봤습니다.

🌱 작업한 내용
- 내 모임 조회 API 연동
- 모임 상세 페이지 연결(플러빙 메인 페이지 임시로 대체)
- 모임 생성 페이지 연결

## 📸 스크린샷

https://user-images.githubusercontent.com/77331348/222484084-8f245abd-fd7a-4c34-a2a0-6935af5ef05c.MP4

## 📮 관련 이슈
- Resolved:  #185 

