### PR TITLE
[REFACTOR] FIgma 디자인에 맞게 Font 설정

### DIFF
--- a/PLUB/AppDelegate.swift
+++ b/PLUB/AppDelegate.swift
@@ -47,7 +47,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     appearance.titleTextAttributes = [
       NSAttributedString.Key.foregroundColor: UIColor.black, // 텍스트 색상
-      NSAttributedString.Key.font: UIFont.h4! // 폰트
+      NSAttributedString.Key.font: UIFont.h4 // 폰트
     ]
     
     // 내비바 하단 회색선 제거

--- a/PLUB/Configuration/Extensions/Ex+UIFont.swift
+++ b/PLUB/Configuration/Extensions/Ex+UIFont.swift
@@ -37,19 +37,19 @@ extension UIFont {
 }
 
 extension UIFont {
-  static let h1 = UIFont(name: Pretendard.bold.rawValue, size: 32)
-  static let h2 = UIFont(name: Pretendard.bold.rawValue, size: 28)
-  static let h3 = UIFont(name: Pretendard.semiBold.rawValue, size: 24)
-  static let h4 = UIFont(name: Pretendard.semiBold.rawValue, size: 20)
-  static let h5 = UIFont(name: Pretendard.semiBold.rawValue, size: 18)
-  static let subtitle = UIFont(name: Pretendard.semiBold.rawValue, size: 16)
-  static let body1 = UIFont(name: Pretendard.semiBold.rawValue, size: 16)
-  static let body2 = UIFont(name: Pretendard.regular.rawValue, size: 16)
-  static let body3 = UIFont(name: Pretendard.medium.rawValue, size: 16)
-  static let button = UIFont(name: Pretendard.bold.rawValue, size: 14)
-  static let caption = UIFont(name: Pretendard.medium.rawValue, size: 12)
-  static let caption2 = UIFont(name: Pretendard.bold.rawValue, size: 12)
-  static let overLine = UIFont(name: Pretendard.regular.rawValue, size: 10)
+  static let h1 = UIFont(name: Pretendard.bold.rawValue, size: 32)!
+  static let h2 = UIFont(name: Pretendard.bold.rawValue, size: 28)!
+  static let h3 = UIFont(name: Pretendard.semiBold.rawValue, size: 24)!
+  static let h4 = UIFont(name: Pretendard.semiBold.rawValue, size: 20)!
+  static let h5 = UIFont(name: Pretendard.semiBold.rawValue, size: 18)!
+  static let subtitle = UIFont(name: Pretendard.semiBold.rawValue, size: 16)!
+  static let body1 = UIFont(name: Pretendard.semiBold.rawValue, size: 16)!
+  static let body2 = UIFont(name: Pretendard.regular.rawValue, size: 16)!
+  static let body3 = UIFont(name: Pretendard.medium.rawValue, size: 16)!
+  static let button = UIFont(name: Pretendard.bold.rawValue, size: 14)!
+  static let caption = UIFont(name: Pretendard.medium.rawValue, size: 12)!
+  static let caption2 = UIFont(name: Pretendard.bold.rawValue, size: 12)!
+  static let overLine = UIFont(name: Pretendard.regular.rawValue, size: 10)!
   
   /// PLUB에서  사용되는 Font-Family를 Custom으로 설정합니다.
   /// - Parameters:

--- a/PLUB/Configuration/Extensions/Ex+UIFont.swift
+++ b/PLUB/Configuration/Extensions/Ex+UIFont.swift
@@ -47,7 +47,7 @@ extension UIFont {
   static let body2 = UIFont(name: Pretendard.regular.rawValue, size: 16)
   static let body3 = UIFont(name: Pretendard.medium.rawValue, size: 16)
   static let button = UIFont(name: Pretendard.bold.rawValue, size: 14)
-  static let caption = UIFont(name: Pretendard.regular.rawValue, size: 12)
+  static let caption = UIFont(name: Pretendard.medium.rawValue, size: 12)
   static let caption2 = UIFont(name: Pretendard.bold.rawValue, size: 12)
   static let caption3 = UIFont(name: Pretendard.medium.rawValue, size: 12)
   static let overLine = UIFont(name: Pretendard.regular.rawValue, size: 10)

--- a/PLUB/Configuration/Extensions/Ex+UIFont.swift
+++ b/PLUB/Configuration/Extensions/Ex+UIFont.swift
@@ -51,8 +51,6 @@ extension UIFont {
   static let caption2 = UIFont(name: Pretendard.bold.rawValue, size: 12)
   static let overLine = UIFont(name: Pretendard.regular.rawValue, size: 10)
   
-  static let onboarding = UIFont(name: Nanum.default.rawValue, size: 36)
-  
   /// PLUB에서  사용되는 Font-Family를 Custom으로 설정합니다.
   /// - Parameters:
   ///   - family: PLUB에서 사용하는 font-family

--- a/PLUB/Configuration/Extensions/Ex+UIFont.swift
+++ b/PLUB/Configuration/Extensions/Ex+UIFont.swift
@@ -49,7 +49,6 @@ extension UIFont {
   static let button = UIFont(name: Pretendard.bold.rawValue, size: 14)
   static let caption = UIFont(name: Pretendard.medium.rawValue, size: 12)
   static let caption2 = UIFont(name: Pretendard.bold.rawValue, size: 12)
-  static let caption3 = UIFont(name: Pretendard.medium.rawValue, size: 12)
   static let overLine = UIFont(name: Pretendard.regular.rawValue, size: 10)
   
   static let onboarding = UIFont(name: Nanum.default.rawValue, size: 36)

--- a/PLUB/Configuration/Extensions/Ex+UIFont.swift
+++ b/PLUB/Configuration/Extensions/Ex+UIFont.swift
@@ -47,7 +47,6 @@ extension UIFont {
   static let body2 = UIFont(name: Pretendard.regular.rawValue, size: 16)
   static let body3 = UIFont(name: Pretendard.medium.rawValue, size: 16)
   static let button = UIFont(name: Pretendard.bold.rawValue, size: 14)
-  static let button2 = UIFont(name: Pretendard.regular.rawValue, size: 14)
   static let caption = UIFont(name: Pretendard.regular.rawValue, size: 12)
   static let caption2 = UIFont(name: Pretendard.bold.rawValue, size: 12)
   static let caption3 = UIFont(name: Pretendard.medium.rawValue, size: 12)

--- a/PLUB/Sources/Views/Home/Cell/Search/SearchOutputHeaderView.swift
+++ b/PLUB/Sources/Views/Home/Cell/Search/SearchOutputHeaderView.swift
@@ -34,8 +34,8 @@ class SearchOutputHeaderView: UIView {
   private let segmentedControl = UnderlineSegmentedControl(
     items: [FilterType.title.toKor, FilterType.name.toKor, FilterType.mix.toKor]
   ).then {
-    $0.setTitleTextAttributes([.foregroundColor: UIColor.black, .font: UIFont.body1!], for: .normal)
-    $0.setTitleTextAttributes([.foregroundColor: UIColor.main, .font: UIFont.body1!], for: .selected)
+    $0.setTitleTextAttributes([.foregroundColor: UIColor.black, .font: UIFont.body1], for: .normal)
+    $0.setTitleTextAttributes([.foregroundColor: UIColor.main, .font: UIFont.body1], for: .selected)
     $0.selectedSegmentIndex = 0
   }
   

--- a/PLUB/Sources/Views/Home/Component/RecruitmentFilterSlider.swift
+++ b/PLUB/Sources/Views/Home/Component/RecruitmentFilterSlider.swift
@@ -98,7 +98,7 @@ class RecruitmentFilterSlider: UIView {
     
     let totalCharacters = NSAttributedString(
       string: "인원 ",
-      attributes: [.foregroundColor: UIColor.black, .font: UIFont.subtitle!]
+      attributes: [.foregroundColor: UIColor.black, .font: UIFont.subtitle]
     )
     
     peopleCountLabel.attributedText = NSMutableAttributedString(attributedString: totalCharacters).then {

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -46,8 +46,8 @@ final class MainPageViewController: BaseViewController {
   private let segmentedControl = UnderlineSegmentedControl(
     items: [MainPageFilterType.board.title, MainPageFilterType.todoList.title]
   ).then {
-    $0.setTitleTextAttributes([.foregroundColor: UIColor.mediumGray, .font: UIFont.body1!], for: .normal)
-    $0.setTitleTextAttributes([.foregroundColor: UIColor.main, .font: UIFont.body1!], for: .selected)
+    $0.setTitleTextAttributes([.foregroundColor: UIColor.mediumGray, .font: UIFont.body1], for: .normal)
+    $0.setTitleTextAttributes([.foregroundColor: UIColor.main, .font: UIFont.body1], for: .selected)
     $0.selectedSegmentIndex = 0
   }
   

--- a/PLUB/Sources/Views/Login/ViewController/LoginViewController.swift
+++ b/PLUB/Sources/Views/Login/ViewController/LoginViewController.swift
@@ -36,12 +36,12 @@ final class LoginViewController: BaseViewController {
     
     let generalAttributes: [NSAttributedString.Key: Any] = [
       .foregroundColor: UIColor.black,
-      .font: UIFont.caption!
+      .font: UIFont.caption
     ]
     let linkAttributes: [NSAttributedString.Key: Any] = [
       .underlineStyle: NSUnderlineStyle.single.rawValue,
       .foregroundColor: UIColor.main,
-      .font: UIFont.caption!
+      .font: UIFont.caption
     ]
     let mutableString = NSMutableAttributedString()
     

--- a/PLUB/Sources/Views/Login/ViewController/ProfileViewController.swift
+++ b/PLUB/Sources/Views/Login/ViewController/ProfileViewController.swift
@@ -231,7 +231,7 @@ final class ProfileViewController: BaseViewController {
     // placeholder 폰트 설정
     nicknameTextField.attributedPlaceholder = NSAttributedString(
       string: Constants.placeholder,
-      attributes: [.font: UIFont.body2!]
+      attributes: [.font: UIFont.body2]
     )
     
     nicknameTextField.layer.borderColor = UIColor.mediumGray.cgColor

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Cell/LocationTableViewCell.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Cell/LocationTableViewCell.swift
@@ -35,7 +35,7 @@ final class LocationTableViewCell: UITableViewCell {
   
   private let subTitleLabel = UILabel().then {
     $0.textColor = .mediumGray
-    $0.font = .button2
+    $0.font = .caption
   }
     
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Component/NoLocationView.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Component/NoLocationView.swift
@@ -29,7 +29,7 @@ final class NoLocationView: UIView {
       다시 검색해 보세요.
     """
     $0.textColor = .deepGray
-    $0.font = .caption3
+    $0.font = .caption
     $0.numberOfLines = 0
     $0.textAlignment = .left
     $0.addLineSpacing($0)

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Component/SearchView.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Component/SearchView.swift
@@ -20,7 +20,7 @@ final class SearchView: UIView {
       string: "장소를 검색해주세요",
       attributes: [
         .foregroundColor : UIColor.deepGray,
-        .font : UIFont.body3!
+        .font : UIFont.body3
       ]
     )
     $0.textColor = .black

--- a/PLUB/Sources/Views/Meeting/EditMeeting/EditMeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/EditMeeting/EditMeetingViewController.swift
@@ -25,8 +25,8 @@ final class EditMeetingViewController: BaseViewController {
   private let segmentedControl = UnderlineSegmentedControl(
     items: ["모집글", "모임 정보", "게스트 질문"]
   ).then {
-    $0.setTitleTextAttributes([.foregroundColor: UIColor.black, .font: UIFont.h5!], for: .normal)
-    $0.setTitleTextAttributes([.foregroundColor: UIColor.main, .font: UIFont.h5!], for: .selected)
+    $0.setTitleTextAttributes([.foregroundColor: UIColor.black, .font: UIFont.h5], for: .normal)
+    $0.setTitleTextAttributes([.foregroundColor: UIColor.main, .font: UIFont.h5], for: .selected)
     $0.selectedSegmentIndex = 0
   }
   

--- a/PLUB/Sources/Views/Meeting/Schedule/CreateSchedule/CreateScheduleViewController.swift
+++ b/PLUB/Sources/Views/Meeting/Schedule/CreateSchedule/CreateScheduleViewController.swift
@@ -50,7 +50,7 @@ final class CreateScheduleViewController: BaseViewController {
       string: Constants.titlePlaceHolder,
       attributes: [
         .foregroundColor : UIColor.mediumGray,
-        .font: UIFont.h5!
+        .font: UIFont.h5
       ]
     )
     $0.textColor = .black


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- Font 리팩토링

🌱 PR 포인트
- body1(16pt), body2(16pt)는 figma디자인(14pt)에 비해 2pt 더 크게 설정되어있습니다(작년에 디자인팀과 의견 나눌 때 iOS 쪽 body 폰트는 좀 더 키워야될 것 같다고 해서 늘렸어요).

## 📮 관련 이슈
- Resolved: #202

