### PR TITLE
[FEAT] Clipboard API 연동 및 버그 수정

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -176,8 +176,8 @@
 		BA94E81C297E706A00DF23CE /* IntroductionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA94E81B297E706A00DF23CE /* IntroductionViewModel.swift */; };
 		BA98B34929AC956A00307073 /* CommentContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA98B34829AC956A00307073 /* CommentContent.swift */; };
 		BAAD0AD529BB2E72007B33D9 /* ArchiveCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAD0AD429BB2E72007B33D9 /* ArchiveCollectionViewCell.swift */; };
-		BAB9DFD229BB17B90062807C /* ArchiveViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB9DFD029BB17B90062807C /* ArchiveViewModel.swift */; };
 		BAB033FA29B5C5580077C4D9 /* BoardDetailCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB033F929B5C5580077C4D9 /* BoardDetailCollectionHeaderView.swift */; };
+		BAB9DFD229BB17B90062807C /* ArchiveViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB9DFD029BB17B90062807C /* ArchiveViewModel.swift */; };
 		BABB011A297ED415004178EC /* InterestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB0119297ED415004178EC /* InterestViewController.swift */; };
 		BABB011C297ED74C004178EC /* InterestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB011B297ED74C004178EC /* InterestViewModel.swift */; };
 		BAC5EF2D298A9E4300F3955E /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC5EF2C298A9E4300F3955E /* SplashViewController.swift */; };
@@ -456,8 +456,8 @@
 		BA94E81B297E706A00DF23CE /* IntroductionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionViewModel.swift; sourceTree = "<group>"; };
 		BA98B34829AC956A00307073 /* CommentContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentContent.swift; sourceTree = "<group>"; };
 		BAAD0AD429BB2E72007B33D9 /* ArchiveCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveCollectionViewCell.swift; sourceTree = "<group>"; };
-		BAB9DFD029BB17B90062807C /* ArchiveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveViewModel.swift; sourceTree = "<group>"; };
 		BAB033F929B5C5580077C4D9 /* BoardDetailCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailCollectionHeaderView.swift; sourceTree = "<group>"; };
+		BAB9DFD029BB17B90062807C /* ArchiveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveViewModel.swift; sourceTree = "<group>"; };
 		BABB0119297ED415004178EC /* InterestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewController.swift; sourceTree = "<group>"; };
 		BABB011B297ED74C004178EC /* InterestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewModel.swift; sourceTree = "<group>"; };
 		BAC5EF2C298A9E4300F3955E /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
@@ -498,7 +498,6 @@
 		C3413E182995492D004B8DBD /* GuestQuestionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestQuestionViewController.swift; sourceTree = "<group>"; };
 		C344E53E2986B938009F73A9 /* MeetingCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCategoryViewController.swift; sourceTree = "<group>"; };
 		C344E5402986B9D7009F73A9 /* MeetingCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCategoryViewModel.swift; sourceTree = "<group>"; };
-		C346B49A29B1040A00884E4F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C34C096F29773860001AFF16 /* DateBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateBottomSheetViewController.swift; sourceTree = "<group>"; };
 		C34F07F2297DAFD900C91E90 /* AddQuestionTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddQuestionTableViewCell.swift; sourceTree = "<group>"; };
 		C34F07F4297DB1DC00C91E90 /* AddQuestionControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddQuestionControl.swift; sourceTree = "<group>"; };
@@ -742,8 +741,8 @@
 				BAE0AC7B29B5D71B00F46F3D /* Component */,
 				BAE0AC7A29B5D71300F46F3D /* Model */,
 				BAE0AC7929B5D6FB00F46F3D /* ViewModel */,
-				702876BF29A374FE00E57509 /* ClipboardViewController.swift */,
 				BAE0AC7429B5D67D00F46F3D /* BoardDetailViewController.swift */,
+				702876BF29A374FE00E57509 /* ClipboardViewController.swift */,
 			);
 			path = Clipboard;
 			sourceTree = "<group>";
@@ -1797,7 +1796,6 @@
 				70197B7B29549B6A000503F6 /* SelectedCategoryChartCollectionViewCell.swift in Sources */,
 				70A4209C2988B1DC0026E9F9 /* SortControl.swift in Sources */,
 				70A420A7298D0F140026E9F9 /* RecentSearchListCollectionViewCell.swift in Sources */,
-				705F81C829AFB1DC00830C4F /* BoardCollectionHeaderView.swift in Sources */,
 				C33952EF29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift in Sources */,
 				BA340E2429782321002BAF2C /* ParticipantListView.swift in Sources */,
 				C3EB29C829A9040600615B6B /* ScheduleTableViewCell.swift in Sources */,

--- a/PLUB/Sources/Models/Feeds/FeedsContent.swift
+++ b/PLUB/Sources/Models/Feeds/FeedsContent.swift
@@ -25,9 +25,11 @@ enum PostType: String, Codable {
   ///   - content: 게시글의 내용
   ///   - imageLink: 게시글에 들어가있는 이미지
   init(content: String?, imageLink: String?) {
-    if let _ = content, let _ = imageLink {
+    if let content = content, let imageLink = imageLink,
+       !content.isEmpty && !imageLink.isEmpty {
       self = .photoAndText
-    } else if let _ = imageLink {
+    } else if let imageLink = imageLink,
+              !imageLink.isEmpty {
       self = .photo
     } else {
       self = .text

--- a/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
@@ -93,7 +93,15 @@ final class ClipboardViewController: BaseViewController {
         cell.configure(with: model.toBoardModel)
       }
       .disposed(by: disposeBag)
-    }
+    
+    collectionView.rx.modelSelected(FeedsContent.self)
+      .debug()
+      .subscribe(with: self) { owner, model in
+        print(model)
+        owner.navigationController?.pushViewController(BoardDetailViewController(viewModel: BoardDetailViewModel(content: model)), animated: true)
+      }
+      .disposed(by: disposeBag)
+  }
 }
 
 // MARK: - UICollectionViewDelegateFlowLayout

--- a/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
@@ -61,7 +61,6 @@ final class ClipboardViewController: BaseViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     collectionView.delegate = self
-    collectionView.dataSource = self
   }
   
   // MARK: - Configuration
@@ -94,38 +93,12 @@ final class ClipboardViewController: BaseViewController {
   
   override func bind() {
     super.bind()
-  }
-}
-
-// MARK: - UICollectionViewDataSource
-
-extension ClipboardViewController: UICollectionViewDataSource {
-  
-  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    // TODO: 승현 - Clipboard API 연동하기
-    return 10
-  }
-  
-  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoardCollectionViewCell.identifier, for: indexPath) as? BoardCollectionViewCell else {
-      fatalError()
+    viewModel.fetchClipboards
+      .drive(collectionView.rx.items(cellIdentifier: BoardCollectionViewCell.identifier, cellType: BoardCollectionViewCell.self)) { index, model, cell in
+        cell.configure(with: model.toBoardModel)
+      }
+      .disposed(by: disposeBag)
     }
-    // TODO: 승현 - Clipboard API 연동하기
-    
-    let testModel = BoardModel(
-      author: "홍승현",
-      authorProfileImageLink: "https://github.com/whitehyun.png",
-      date: Date(),
-      likeCount: 10,
-      commentCount: 24,
-      title: "테스트 제목입니다.",
-      imageLink: "https://github.com/whitehyun.png",
-      content: nil
-    )
-    
-    cell.configure(with: testModel)
-    return cell
-  }
 }
 
 // MARK: - UICollectionViewDelegateFlowLayout

--- a/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
@@ -108,9 +108,7 @@ final class ClipboardViewController: BaseViewController {
 
 extension ClipboardViewController: UICollectionViewDelegateFlowLayout {
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-    // TODO: 승현 - Clipboard API 연동해서 높이 설정
-    // 너비 양옆 inset 16을 제외, 높이 305 고정 (photo)
-    // 너비 양옆 inset 16을 제외, 높이 114 고정 (photoAndText, text)
+    // 너비 양옆 inset 16을 제외
     return .init(width: view.bounds.width - 16 * 2, height: CGFloat(viewModel.cellHeights[indexPath.item]))
   }
 }

--- a/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
@@ -42,12 +42,12 @@ final class ClipboardViewController: BaseViewController {
   
   // MARK: - Properties
   
-  private let viewModel: ClipboardViewModelType
+  private let viewModel: ClipboardViewModelType & ClipboardCellDataStore
   
   
   // MARK: - Initializations
   
-  init(viewModel: ClipboardViewModelType) {
+  init(viewModel: ClipboardViewModelType & ClipboardCellDataStore) {
     self.viewModel = viewModel
     super.init(nibName: nil, bundle: nil)
   }

--- a/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
@@ -108,7 +108,7 @@ extension ClipboardViewController: UICollectionViewDelegateFlowLayout {
     // TODO: 승현 - Clipboard API 연동해서 높이 설정
     // 너비 양옆 inset 16을 제외, 높이 305 고정 (photo)
     // 너비 양옆 inset 16을 제외, 높이 114 고정 (photoAndText, text)
-    return .init(width: view.bounds.width - 16 * 2, height: 305)
+    return .init(width: view.bounds.width - 16 * 2, height: CGFloat(viewModel.cellHeights[indexPath.row]))
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
@@ -56,13 +56,6 @@ final class ClipboardViewController: BaseViewController {
     fatalError("init(coder:) has not been implemented")
   }
   
-  // MARK: - Life Cycles
-  
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    collectionView.delegate = self
-  }
-  
   // MARK: - Configuration
   
   override func setupLayouts() {
@@ -93,6 +86,8 @@ final class ClipboardViewController: BaseViewController {
   
   override func bind() {
     super.bind()
+    collectionView.rx.setDelegate(self).disposed(by: disposeBag)
+    
     viewModel.fetchClipboards
       .drive(collectionView.rx.items(cellIdentifier: BoardCollectionViewCell.identifier, cellType: BoardCollectionViewCell.self)) { index, model, cell in
         cell.configure(with: model.toBoardModel)
@@ -108,7 +103,7 @@ extension ClipboardViewController: UICollectionViewDelegateFlowLayout {
     // TODO: 승현 - Clipboard API 연동해서 높이 설정
     // 너비 양옆 inset 16을 제외, 높이 305 고정 (photo)
     // 너비 양옆 inset 16을 제외, 높이 114 고정 (photoAndText, text)
-    return .init(width: view.bounds.width - 16 * 2, height: CGFloat(viewModel.cellHeights[indexPath.row]))
+    return .init(width: view.bounds.width - 16 * 2, height: CGFloat(viewModel.cellHeights[indexPath.item]))
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/Model/BoardModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Model/BoardModel.swift
@@ -38,11 +38,14 @@ struct BoardModel {
 extension BoardModel {
   /// 게시글 타입
   var type: PostType {
-    if content != nil && imageLink != nil { return .photoAndText }
-    else if imageLink != nil { return .photo }
+    if content != nil && imageLink != nil && content!.isEmpty == false && imageLink!.isEmpty == false {
+      return .photoAndText
+    }
+    else if imageLink != nil && imageLink!.isEmpty == false {
+      return .photo
+    }
     else { return .text }
   }
-  
 }
 
 // MARK: - Mapping to BoardModel

--- a/PLUB/Sources/Views/Home/Clipboard/Model/BoardModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Model/BoardModel.swift
@@ -44,3 +44,25 @@ extension BoardModel {
   }
   
 }
+
+// MARK: - Mapping to BoardModel
+
+extension FeedsContent {
+  var toBoardModel: BoardModel {
+    let dateFormatter = DateFormatter().then {
+      $0.dateFormat = "yyyy-MM-dd HH:mm:ss"
+      $0.locale = Locale(identifier: "ko_KR") // locale 설정해야 date 생성 가능
+    }
+    
+    return BoardModel(
+      author: nickname,
+      authorProfileImageLink: profileImageURL,
+      date: dateFormatter.date(from: postDate)!,
+      likeCount: likeCount,
+      commentCount: commentCount,
+      title: title,
+      imageLink: feedImageURL,
+      content: content
+    )
+  }
+}

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -22,7 +22,7 @@ final class BoardDetailViewModel: BoardDetailViewModelType {
   
   // Output
   
-  init() {
+  init(content: FeedsContent) {
     
   }
   

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/ClipboardViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/ClipboardViewModel.swift
@@ -44,6 +44,8 @@ final class ClipboardViewModel: ClipboardViewModelType, ClipboardCellDataStore {
     
     sharedClipboardsAPI
       .compactMap {
+        // 높이 305 고정 (photo)
+        // 높이 114 고정 (photoAndText, text)
         $0.map { $0.type == .photo ? 305 : 114 }
       }
       .subscribe(onNext: { [weak self] in

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/ClipboardViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/ClipboardViewModel.swift
@@ -17,13 +17,17 @@ protocol ClipboardViewModelType {
   var fetchClipboards: Driver<[FeedsContent]> { get }
 }
 
-final class ClipboardViewModel: ClipboardViewModelType {
+protocol ClipboardCellDataStore {
+  var cellHeights: [Int] { get } // IndexPath별 `ClipboardCollectionViewCell`의 높이
+}
+
+final class ClipboardViewModel: ClipboardViewModelType, ClipboardCellDataStore {
   
   // Input
   
   // Output
   let fetchClipboards: Driver<[FeedsContent]>
-  
+  private(set) var cellHeights: [Int] = []
   
   
   init(plubIdentifier: Int) {

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/ClipboardViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/ClipboardViewModel.swift
@@ -14,6 +14,7 @@ protocol ClipboardViewModelType {
   // Input
   
   // Output
+  var fetchClipboards: Driver<[FeedsContent]> { get }
 }
 
 final class ClipboardViewModel: ClipboardViewModelType {
@@ -21,9 +22,18 @@ final class ClipboardViewModel: ClipboardViewModelType {
   // Input
   
   // Output
+  let fetchClipboards: Driver<[FeedsContent]>
   
-  init() {
-    
+  
+  
+  init(plubIdentifier: Int) {
+    fetchClipboards = FeedsService.shared.fetchClipboards(plubIdentifier: plubIdentifier)
+      .compactMap { response -> [FeedsContent]? in
+        // TODO: 승현 - API failure 처리
+        guard case let .success(data) = response else { return nil }
+        return data.data?.pinnedFeedList
+      }
+      .asDriver(onErrorJustReturn: [])
   }
   
   private let disposeBag = DisposeBag()

--- a/PLUB/Sources/Views/PLUBTabBarController.swift
+++ b/PLUB/Sources/Views/PLUBTabBarController.swift
@@ -32,7 +32,7 @@ final class PLUBTabBarController: UITabBarController {
         }
       ),
       BaseNavigationController(
-        rootViewController: ClipboardViewController(viewModel: ClipboardViewModel()).then {
+        rootViewController: ClipboardViewController(viewModel: ClipboardViewModel(plubIdentifier: 59)).then {
           $0.tabBarItem = UITabBarItem(title: "알림", image: UIImage(named: "bell24"), tag: 2)
         }
       ),


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용

- 다행히(?) 섹션별로 처리해야하는 복잡한 UI가 아니어서 RxDataSources는 따로 추가하지 않았습니다.
- Clipboard API를 연동했습니다.
- API 연동 도중 백엔드 API와 맞지 않는 부분을 수정했습니다.
   - FeedsContent의 Content, contentImageURL은 값이 없을 시 `nil`로 받지 않고 빈 문자열(`""`)로 받는 것 예외처리
   - 위 버그로 인해 모든 게시글이 `PostType.photoAndText`로 고정되어있었고, 지금은 타입에 맞게 잘 들어옴
- FeedsContent에서 Cell UI를 위해 BoardModel을 파싱하는 과정을 타입 프로퍼티로 전환시켰습니다.
   ```swift
  // MARK: - Mapping to BoardModel
  
  extension FeedsContent {
    var toBoardModel: BoardModel {
      let dateFormatter = DateFormatter().then {
        $0.dateFormat = "yyyy-MM-dd HH:mm:ss"
        $0.locale = Locale(identifier: "ko_KR") // locale 설정해야 date 생성 가능
      }
      
      return BoardModel(
        author: nickname,
        authorProfileImageLink: profileImageURL,
        date: dateFormatter.date(from: postDate)!,
        likeCount: likeCount,
        commentCount: commentCount,
        title: title,
        imageLink: feedImageURL,
        content: content
      )
    }
  }
   ```

🌱 PR 포인트
- Clipboard Cell의 타입에 따라 높이를 바꿔야했고, Cell 정보를 다루는 protocol을 생성하여 viewModel이 이를 준수하도록 설정했습니다.
  ```swift
  protocol ClipboardViewModelType {
    // Input
    
    // Output
    var fetchClipboards: Driver<[FeedsContent]> { get }
  }
  
  // 새롭게 추가 ✅
  protocol ClipboardCellDataStore {
    var cellHeights: [Int] { get } // IndexPath별 `ClipboardCollectionViewCell`의 높이
  }
  
  final class ClipboardViewModel: ClipboardViewModelType, ClipboardCellDataStore {
    
    // Input
    
    // Output
    let fetchClipboards: Driver<[FeedsContent]>
    private(set) var cellHeights: [Int] = []
    //...
  ```
- 그래서 높이를 설정할 때 viewModel의 `dataStore`타입의 프로퍼티를 가져와 처리합니다.
  ```swift
  // MARK: - UICollectionViewDelegateFlowLayout
  
  extension ClipboardViewController: UICollectionViewDelegateFlowLayout {
    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
      // 너비 양옆 inset 16을 제외
      return .init(width: view.bounds.width - 16 * 2, height: CGFloat(viewModel.cellHeights[indexPath.item]))
    }
  }
  ```

## 📸 스크린샷
|스크린샷|
|:--:|
|![RPReplay_Final1678616689](https://user-images.githubusercontent.com/57972338/224538658-51915d7b-b498-4956-8dea-3c18f586b4d7.gif)|

## 📮 관련 이슈
- Resolved: #159

