### PR TITLE
댓글 API 연동

### DIFF
--- a/PLUB/Sources/Models/Feeds/CommentContent.swift
+++ b/PLUB/Sources/Models/Feeds/CommentContent.swift
@@ -64,7 +64,7 @@ struct CommentContent: Codable {
     case postDate = "createdAt"
     case type = "commentType"
     case parentCommentID = "parentCommentId"
-    case groupID = "groupId"
+    case groupID = "commentGroupId"
   }
   
   private let identifier = UUID()

--- a/PLUB/Sources/Models/Feeds/CommentContent.swift
+++ b/PLUB/Sources/Models/Feeds/CommentContent.swift
@@ -66,4 +66,12 @@ struct CommentContent: Codable {
     case parentCommentID = "parentCommentId"
     case groupID = "groupId"
   }
+  
+  private let identifier = UUID()
+}
+
+extension CommentContent: Hashable {
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(identifier)
+  }
 }

--- a/PLUB/Sources/Models/Feeds/FeedsContent.swift
+++ b/PLUB/Sources/Models/Feeds/FeedsContent.swift
@@ -119,4 +119,12 @@ struct FeedsContent: Codable {
     case isPinned = "pin"
     case plubbingID = "plubbingId"
   }
+  
+  private let identifier = UUID()
+}
+
+extension FeedsContent: Hashable {
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(identifier)
+  }
 }

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -45,6 +45,7 @@ final class BoardDetailViewController: BaseViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     setCollectionView()
+    applyInitialSnapshots()
     collectionView.delegate = self
   }
   
@@ -130,5 +131,20 @@ private extension BoardDetailViewController {
     dataSource?.supplementaryViewProvider = .init { collectionView, elementKind, indexPath in
       return collectionView.dequeueConfiguredReusableSupplementary(using: headerRegistration, for: indexPath)
     }
+  }
+  
+  /// 초기 Snapshot을 설정합니다. DataSource가 초기화될 시 해당 메서드가 실행됩니다.
+  /// 직접 이 메서드를 실행할 필요는 없습니다.
+  private func applyInitialSnapshots() {
+    var snapshot = Snapshot()
+    
+    var sections = [-1] // 최소한 하나의 Section이라도 존재해야 함
+    sections.append(contentsOf: Array(Set(viewModel.comments.map { $0.groupID })))
+    snapshot.appendSections(sections)
+    
+    sections.forEach { sectionGroupID in
+      snapshot.appendItems(viewModel.comments.filter { $0.groupID == sectionGroupID }, toSection: sectionGroupID)
+    }
+    dataSource?.apply(snapshot)
   }
 }

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -84,3 +84,18 @@ extension BoardDetailViewController: UICollectionViewDelegateFlowLayout {
     return headerView.systemLayoutSizeFitting(CGSize(width: collectionView.frame.width, height: UIView.layoutFittingCompressedSize.height), withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel)
   }
 }
+
+// MARK: - Diffable DataSource & Types
+
+private extension BoardDetailViewController {
+  
+  // MARK: Type Alias
+  
+  typealias Section = Int
+  typealias Item = CommentContent
+  typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
+  typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
+  
+  typealias CellRegistration = UICollectionView.CellRegistration<BoardDetailCollectionViewCell, CommentContent>
+  typealias HeaderRegistration = UICollectionView.SupplementaryRegistration<BoardDetailCollectionHeaderView>
+}

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -16,7 +16,7 @@ final class BoardDetailViewController: BaseViewController {
   
   // MARK: - Properties
   
-  private let viewModel: BoardDetailViewModelType
+  private let viewModel: BoardDetailViewModelType & BoardDetailDataStore
   
   // MARK: - UI Components
   
@@ -28,7 +28,7 @@ final class BoardDetailViewController: BaseViewController {
   
   // MARK: - Initializations
   
-  init(viewModel: BoardDetailViewModelType) {
+  init(viewModel: BoardDetailViewModelType & BoardDetailDataStore) {
     self.viewModel = viewModel
     super.init(nibName: nil, bundle: nil)
   }

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -40,15 +40,6 @@ final class BoardDetailViewController: BaseViewController {
     fatalError("init(coder:) has not been implemented")
   }
   
-  // MARK: - Life Cycles
-  
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    setCollectionView()
-    applyInitialSnapshots()
-    collectionView.delegate = self
-  }
-  
   // MARK: - Configuration
   
   override func setupLayouts() {
@@ -69,6 +60,14 @@ final class BoardDetailViewController: BaseViewController {
   
   override func bind() {
     super.bind()
+    collectionView.rx.setDelegate(self).disposed(by: disposeBag)
+    
+    viewModel.fetchAlertDriver
+      .drive(with: self) { owner, _ in
+        owner.setCollectionView()
+        owner.applyInitialSnapshots()
+      }
+      .disposed(by: disposeBag)
   }
 }
 
@@ -118,7 +117,7 @@ private extension BoardDetailViewController {
   // MARK: Snapshot & DataSource Part
   
   /// Collection View를 세팅하며, `DiffableDataSource`를 초기화하여 해당 Collection View에 데이터를 지닌 셀을 처리합니다.
-  func setCollectionView() {
+  private func setCollectionView() {
     
     // 단어 그대로 `등록`처리 코드, 셀 후처리할 때 사용됨
     let registration = CellRegistration { cell, _, item in

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -77,7 +77,7 @@ final class BoardDetailViewController: BaseViewController {
 extension BoardDetailViewController: UICollectionViewDelegateFlowLayout {
   
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-    return BoardDetailCollectionViewCell.estimatedCommentCellSize(CGSize(width: view.bounds.width, height: 0), comment: "국가는 주택개발정책등을 통하여 모든 국민이 쾌적한 주거생활을 할 수 있도록 노력하여야 한다. 국가는 국민 모두의 생산 및 생활의 기반이 되는 국토의 효율적이고 균형있는 이용·개발과 보전을 위하여 법률이 정하는 바에 의하여 그에 관한 필요한 제한과 의무를 과할 수 있다. 모든 국민은 법률이 정하는 바에 의하여 공무담임권을 가진다. 모든 국민은 인간다운 생활을 할 권리를 가진다. 지방의회의 조직·권한·의원선거와 지방자치단체의 장의 선임방법 기타 지방자치단체의 조직과 운영에 관한 사항은 법률로 정한다. 이 헌법은 1988년 2월 25일부터 시행한다. 다만, 이 헌법을 시행하기 위하여 필요한 법률의 제정·개정과 이 헌법에 의한 대통령 및 국회의원의 선거 기타 이 헌법시행에 관한 준비는 이 헌법시행 전에 할 수 있다.")
+    return BoardDetailCollectionViewCell.estimatedCommentCellSize(CGSize(width: view.bounds.width, height: 0), comment: viewModel.comments[indexPath.item].content)
   }
   
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -139,7 +139,7 @@ private extension BoardDetailViewController {
     var snapshot = Snapshot()
     
     var sections = [-1] // 최소한 하나의 Section이라도 존재해야 함
-    sections.append(contentsOf: Array(Set(viewModel.comments.map { $0.groupID })))
+    sections.append(contentsOf: Array(Set(viewModel.comments.map { $0.groupID })).sorted())
     snapshot.appendSections(sections)
     
     sections.forEach { sectionGroupID in

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -101,6 +101,8 @@ extension BoardDetailViewController: UICollectionViewDelegateFlowLayout {
   }
   
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+    // 첫 번째 section에만 게시글이 보이도록 설정
+    guard section == 0 else { return .zero }
     // 동적 높이 처리
     let indexPath = IndexPath(row: 0, section: section)
     let headerView = self.collectionView(collectionView, viewForSupplementaryElementOfKind: UICollectionView.elementKindSectionHeader, at: indexPath)

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -77,7 +77,15 @@ final class BoardDetailViewController: BaseViewController {
 extension BoardDetailViewController: UICollectionViewDelegateFlowLayout {
   
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-    return BoardDetailCollectionViewCell.estimatedCommentCellSize(CGSize(width: view.bounds.width, height: 0), comment: viewModel.comments[indexPath.item].content)
+    // * section은 1부터 시작, section 순서는 groupID 순과 동일함
+    // * viewModel의 `comments`는 section, item과 상관없이 일차원 배열로 나열되어있음
+    // * 위 배열에서 section과 item의 맞는 모델을 찾아 사이즈를 구해야함
+    // * 따라서 section값에 따른 groupID를 먼저 구하고, groupID가 동일한 배열만을 빼냄
+    // * 빼낸 배열은 item을 인덱스로하여 모델을 가져오도록 구현
+    let groupID = Array(Set(viewModel.comments.map { $0.groupID })).sorted()[indexPath.section - 1]
+    let commentsModelsForSection = viewModel.comments.filter { $0.groupID == groupID }
+    let size = BoardDetailCollectionViewCell.estimatedCommentCellSize(CGSize(width: view.bounds.width, height: 0), commentContent: commentsModelsForSection[indexPath.item])
+    return size
   }
   
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -42,7 +42,6 @@ final class BoardDetailViewController: BaseViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     collectionView.delegate = self
-    collectionView.dataSource = self
   }
   
   // MARK: - Configuration
@@ -65,30 +64,6 @@ final class BoardDetailViewController: BaseViewController {
   
   override func bind() {
     super.bind()
-  }
-}
-
-// MARK: - UICollectionViewDataSource
-
-extension BoardDetailViewController: UICollectionViewDataSource {
-  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    // TODO: 승현 - Clipboard Comment API 연동하기
-    return 10
-  }
-  
-  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoardDetailCollectionViewCell.identifier, for: indexPath) as? BoardDetailCollectionViewCell else {
-      fatalError()
-    }
-    
-    return cell
-  }
-  
-  func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-    guard let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: BoardDetailCollectionHeaderView.identifier, for: indexPath) as? BoardDetailCollectionHeaderView else {
-      fatalError()
-    }
-    return headerView
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/Cell/BoardDetailCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Cell/BoardDetailCollectionViewCell.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Kingfisher
 import SnapKit
 import Then
 
@@ -173,6 +174,27 @@ final class BoardDetailCollectionViewCell: UICollectionViewCell {
   
   private func setupStyles() {
     
+  }
+  
+  func configure(with model: CommentContent) {
+    if let imageLink = model.profileImageURL {
+      profileImageView.kf.setImage(with: URL(string: imageLink)!)
+    } else {
+      profileImageView.image = UIImage(named: "userDefaultImage")
+    }
+    commentLabel.text = model.content
+    authorLabel.text = model.nickname
+    // TODO: 승현 - 날짜 처리는 정확하게 정해지지 않음, 기획안 나오면 그 때 처리할 예정
+    datetimeLabel.text = "방금 전"
+    
+    
+    // reply process
+    replyImageView.isHidden = model.type == .normal
+    repliedAuthorLabel.isHidden = model.type == .normal
+    repliedAuthorLabel.text = model.parentCommentNickname
+    
+    // author process
+    authorIndicationView.isHidden = !model.isFeedAuthor
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/Cell/BoardDetailCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Cell/BoardDetailCollectionViewCell.swift
@@ -207,9 +207,9 @@ extension BoardDetailCollectionViewCell {
   ///   - targetSize: 원하는 view의 크기,
   ///   - comment: 댓글 내용
   /// - Returns: 댓글 내용이 전부 보일 정도의 대략적인 view의 크기
-  static func estimatedCommentCellSize(_ targetSize: CGSize, comment: String) -> CGSize {
+  static func estimatedCommentCellSize(_ targetSize: CGSize, commentContent: CommentContent) -> CGSize {
     let view = BoardDetailCollectionViewCell()
-    view.commentLabel.text = comment
+    view.configure(with: commentContent)
     return view.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel)
   }
 }

--- a/PLUB/Sources/Views/Home/Clipboard/Cell/BoardDetailCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Cell/BoardDetailCollectionViewCell.swift
@@ -177,7 +177,7 @@ final class BoardDetailCollectionViewCell: UICollectionViewCell {
   }
   
   func configure(with model: CommentContent) {
-    if let imageLink = model.profileImageURL {
+    if let imageLink = model.profileImageURL, imageLink.isEmpty == false {
       profileImageView.kf.setImage(with: URL(string: imageLink)!)
     } else {
       profileImageView.image = UIImage(named: "userDefaultImage")
@@ -191,7 +191,7 @@ final class BoardDetailCollectionViewCell: UICollectionViewCell {
     // reply process
     replyImageView.isHidden = model.type == .normal
     repliedAuthorLabel.isHidden = model.type == .normal
-    repliedAuthorLabel.text = model.parentCommentNickname
+    repliedAuthorLabel.text = "\(model.parentCommentNickname ?? "") 님에게 쓴 답글"
     
     // author process
     authorIndicationView.isHidden = !model.isFeedAuthor

--- a/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
@@ -97,18 +97,9 @@ final class ClipboardViewController: BaseViewController {
     // 선택된 셀의 FeedContent와 댓글 정보를 가져오고
     // BoardDetailViewController의 ViewModel에 전달하면서 navigation push 진행
     collectionView.rx.modelSelected(FeedsContent.self)
-      .flatMap { content -> Observable<(content: FeedsContent, comments: [CommentContent])> in
-        // content를 가지고 댓글 정보 가져옴
-        return FeedsService.shared.fetchComments(plubbingID: content.plubbingID!, feedID: content.feedID)
-          .compactMap { result -> [CommentContent]? in
-            guard case let .success(response) = result else { return nil }
-            return response.data?.content
-          }
-          .map { (content, $0) } // 게시글 정보와 댓글 내역을 튜플로 감싸서 변환
-      }
       .subscribe(with: self) { owner, model in
         owner.navigationController?.pushViewController(
-          BoardDetailViewController(viewModel: BoardDetailViewModel(content: model.content, comments: model.comments)),
+          BoardDetailViewController(viewModel: BoardDetailViewModel(content: model)),
           animated: true
         )
       }

--- a/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
@@ -94,11 +94,23 @@ final class ClipboardViewController: BaseViewController {
       }
       .disposed(by: disposeBag)
     
+    // 선택된 셀의 FeedContent와 댓글 정보를 가져오고
+    // BoardDetailViewController의 ViewModel에 전달하면서 navigation push 진행
     collectionView.rx.modelSelected(FeedsContent.self)
-      .debug()
+      .flatMap { content -> Observable<(content: FeedsContent, comments: [CommentContent])> in
+        // content를 가지고 댓글 정보 가져옴
+        return FeedsService.shared.fetchComments(plubbingID: content.plubbingID!, feedID: content.feedID)
+          .compactMap { result -> [CommentContent]? in
+            guard case let .success(response) = result else { return nil }
+            return response.data?.content
+          }
+          .map { (content, $0) } // 게시글 정보와 댓글 내역을 튜플로 감싸서 변환
+      }
       .subscribe(with: self) { owner, model in
-        print(model)
-        owner.navigationController?.pushViewController(BoardDetailViewController(viewModel: BoardDetailViewModel(content: model)), animated: true)
+        owner.navigationController?.pushViewController(
+          BoardDetailViewController(viewModel: BoardDetailViewModel(content: model.content, comments: model.comments)),
+          animated: true
+        )
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/Clipboard/Component/BoardDetailCollectionHeaderView.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/BoardDetailCollectionHeaderView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Kingfisher
 import SnapKit
 import Then
 
@@ -199,10 +200,29 @@ final class BoardDetailCollectionHeaderView: UICollectionReusableView {
     
     boardsInfoStackView.setCustomSpacing(8, after: profileImageView)
     wholeStackView.setCustomSpacing(24, after: headerStackView)
-    
   }
   
   private func setupStyles() {
     backgroundColor = .white
+  }
+  
+  func configure(with model: BoardModel) {
+    if let imageLink = model.authorProfileImageLink, imageLink.isEmpty == false {
+      profileImageView.kf.setImage(with: URL(string: imageLink)!)
+    } else {
+      profileImageView.image = UIImage(named: "userDefaultImage")
+    }
+    authorLabel.text = model.author
+    dateLabel.text = DateFormatter().then { $0.dateFormat = "yyyy. MM. dd." }.string(from: model.date)
+    heartCountLabel.text = "\(model.likeCount)"
+    commentCountLabel.text = "\(model.commentCount)"
+    titleLabel.text = model.title
+    contentLabel.text = model.content
+    
+    contentImageView.isHidden = model.imageLink == nil
+    if let contentImageLink = model.imageLink, contentImageLink.isEmpty == false {
+      contentImageView.kf.setImage(with: URL(string: contentImageLink)!)
+    }
+    commentLabel.text = "달린 댓글 \(model.commentCount)"
   }
 }

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by 홍승현 on 2023/03/06.
 //
 
-import Foundation
+import UIKit
 
 import RxSwift
 import RxCocoa
@@ -14,6 +14,10 @@ protocol BoardDetailViewModelType {
   // Input
   
   // Output
+}
+
+protocol BoardDetailDataStore {
+  
 }
 
 final class BoardDetailViewModel: BoardDetailViewModelType {
@@ -27,4 +31,10 @@ final class BoardDetailViewModel: BoardDetailViewModelType {
   }
   
   private let disposeBag = DisposeBag()
+}
+
+// MARK: - Diffable Models & Types
+
+extension BoardDetailViewModel: BoardDetailDataStore {
+  
 }

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -1,4 +1,4 @@
-// 
+//
 //  BoardDetailViewModel.swift
 //  PLUB
 //
@@ -17,24 +17,23 @@ protocol BoardDetailViewModelType {
 }
 
 protocol BoardDetailDataStore {
-  
+  var content: FeedsContent { get }
+  var comments: [CommentContent] { get }
 }
 
-final class BoardDetailViewModel: BoardDetailViewModelType {
+final class BoardDetailViewModel: BoardDetailViewModelType, BoardDetailDataStore {
   
-  // Input
+  // MARK: - Properties
   
-  // Output
+  let content: FeedsContent
+  let comments: [CommentContent]
   
-  init(content: FeedsContent) {
-    
+  // MARK: - Initializations
+  
+  init(content: FeedsContent, comments: [CommentContent]) {
+    self.content = content
+    self.comments = comments
   }
   
   private let disposeBag = DisposeBag()
-}
-
-// MARK: - Diffable Models & Types
-
-extension BoardDetailViewModel: BoardDetailDataStore {
-  
 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- API로 받아온 모델로 UI 연동

🌱 PR 포인트
- `UICollectionViewDiffableDataSource`를 사용하여 구현했습니다. RxDataSource와 유사하지만, Rx를 이용한 파싱 처리보다 간결하게 쓰이는 것 같았습니다(제 머릿속으로는 이게 더 깔끔했는데 아니라면 언제든 의견 주세요.. 제가 바보라서 못하는 걸 수도 있어요).
   - `DiffableDataSource`는 #17 때 설명드렸으므로 스킵하겠습니다. 자세한 설명을 더 듣고싶다면 언제든 슬랙이나 디코로 연락주세요.

## 📸 스크린샷
|스크린샷|
|:--:|
|<img src="https://user-images.githubusercontent.com/57972338/224964302-50abdec6-9cf1-4fda-9d30-9c5f4139c3a5.gif" width="40%"/>|
|View Hierarchy|
|<img src="https://user-images.githubusercontent.com/57972338/225183538-63a44276-666b-4d90-810b-face22905f03.png" width="40%"/>|

- 각 섹션마다 하나의 댓글을 가지도록 구성했으며, 댓글이 삭제되면 하나의 섹션을 삭제하는 식으로 구현할 예정입니다.
- 두 번째 섹션부터 댓글이 보이도록 설정한 이유는 게시글이 첫 번째 섹션 헤더로 고정되어있기 때문입니다. 만약 댓글이 존재하지 않는다면, 섹션 값은 `0`이기 때문에 게시물도 보이지 않게 됩니다. 따라서, 댓글이 없어도 게시글은 보일 수 있도록 상단에 섹션 하나를 고정해두었습니다.

## 📮 관련 이슈
- #211

