### PR TITLE
[FEAT] 메인페이지 게시판 UI 레이아웃 및 API 연동

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		70197B7D29549B96000503F6 /* SelectedCategoryFilterHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70197B7C29549B96000503F6 /* SelectedCategoryFilterHeaderView.swift */; };
 		70197B7F29549C56000503F6 /* SelectedCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70197B7E29549C56000503F6 /* SelectedCategoryViewModel.swift */; };
 		70197B812955A68C000503F6 /* CategoryInfoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70197B802955A68C000503F6 /* CategoryInfoListView.swift */; };
-		701A9C9C29B72656006F53C2 /* MainPageClipboardCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701A9C9B29B72656006F53C2 /* MainPageClipboardCollectionViewCell.swift */; };
+		701A9C9C29B72656006F53C2 /* MainPageClipboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701A9C9B29B72656006F53C2 /* MainPageClipboardView.swift */; };
 		701A9C9E29BB2178006F53C2 /* BoardClipboardHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701A9C9D29BB2178006F53C2 /* BoardClipboardHeaderView.swift */; };
 		702876B1299B788400E57509 /* NoticeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702876B0299B788400E57509 /* NoticeViewController.swift */; };
 		702876B3299BA8AB00E57509 /* ParticipantBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702876B2299BA8AB00E57509 /* ParticipantBottomSheetViewController.swift */; };
@@ -176,8 +176,8 @@
 		BA94E81C297E706A00DF23CE /* IntroductionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA94E81B297E706A00DF23CE /* IntroductionViewModel.swift */; };
 		BA98B34929AC956A00307073 /* CommentContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA98B34829AC956A00307073 /* CommentContent.swift */; };
 		BAAD0AD529BB2E72007B33D9 /* ArchiveCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAD0AD429BB2E72007B33D9 /* ArchiveCollectionViewCell.swift */; };
-		BAB9DFD229BB17B90062807C /* ArchiveViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB9DFD029BB17B90062807C /* ArchiveViewModel.swift */; };
 		BAB033FA29B5C5580077C4D9 /* BoardDetailCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB033F929B5C5580077C4D9 /* BoardDetailCollectionHeaderView.swift */; };
+		BAB9DFD229BB17B90062807C /* ArchiveViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB9DFD029BB17B90062807C /* ArchiveViewModel.swift */; };
 		BABB011A297ED415004178EC /* InterestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB0119297ED415004178EC /* InterestViewController.swift */; };
 		BABB011C297ED74C004178EC /* InterestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB011B297ED74C004178EC /* InterestViewModel.swift */; };
 		BAC5EF2D298A9E4300F3955E /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC5EF2C298A9E4300F3955E /* SplashViewController.swift */; };
@@ -307,7 +307,7 @@
 		70197B7C29549B96000503F6 /* SelectedCategoryFilterHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedCategoryFilterHeaderView.swift; sourceTree = "<group>"; };
 		70197B7E29549C56000503F6 /* SelectedCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedCategoryViewModel.swift; sourceTree = "<group>"; };
 		70197B802955A68C000503F6 /* CategoryInfoListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryInfoListView.swift; sourceTree = "<group>"; };
-		701A9C9B29B72656006F53C2 /* MainPageClipboardCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageClipboardCollectionViewCell.swift; sourceTree = "<group>"; };
+		701A9C9B29B72656006F53C2 /* MainPageClipboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageClipboardView.swift; sourceTree = "<group>"; };
 		701A9C9D29BB2178006F53C2 /* BoardClipboardHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardClipboardHeaderView.swift; sourceTree = "<group>"; };
 		702876B0299B788400E57509 /* NoticeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeViewController.swift; sourceTree = "<group>"; };
 		702876B2299BA8AB00E57509 /* ParticipantBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantBottomSheetViewController.swift; sourceTree = "<group>"; };
@@ -456,8 +456,8 @@
 		BA94E81B297E706A00DF23CE /* IntroductionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionViewModel.swift; sourceTree = "<group>"; };
 		BA98B34829AC956A00307073 /* CommentContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentContent.swift; sourceTree = "<group>"; };
 		BAAD0AD429BB2E72007B33D9 /* ArchiveCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveCollectionViewCell.swift; sourceTree = "<group>"; };
-		BAB9DFD029BB17B90062807C /* ArchiveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveViewModel.swift; sourceTree = "<group>"; };
 		BAB033F929B5C5580077C4D9 /* BoardDetailCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailCollectionHeaderView.swift; sourceTree = "<group>"; };
+		BAB9DFD029BB17B90062807C /* ArchiveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveViewModel.swift; sourceTree = "<group>"; };
 		BABB0119297ED415004178EC /* InterestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewController.swift; sourceTree = "<group>"; };
 		BABB011B297ED74C004178EC /* InterestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewModel.swift; sourceTree = "<group>"; };
 		BAC5EF2C298A9E4300F3955E /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
@@ -498,7 +498,6 @@
 		C3413E182995492D004B8DBD /* GuestQuestionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestQuestionViewController.swift; sourceTree = "<group>"; };
 		C344E53E2986B938009F73A9 /* MeetingCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCategoryViewController.swift; sourceTree = "<group>"; };
 		C344E5402986B9D7009F73A9 /* MeetingCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCategoryViewModel.swift; sourceTree = "<group>"; };
-		C346B49A29B1040A00884E4F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C34C096F29773860001AFF16 /* DateBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateBottomSheetViewController.swift; sourceTree = "<group>"; };
 		C34F07F2297DAFD900C91E90 /* AddQuestionTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddQuestionTableViewCell.swift; sourceTree = "<group>"; };
 		C34F07F4297DB1DC00C91E90 /* AddQuestionControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddQuestionControl.swift; sourceTree = "<group>"; };
@@ -773,7 +772,7 @@
 		705F81C629AFB1B600830C4F /* Cell */ = {
 			isa = PBXGroup;
 			children = (
-				701A9C9B29B72656006F53C2 /* MainPageClipboardCollectionViewCell.swift */,
+				701A9C9B29B72656006F53C2 /* MainPageClipboardView.swift */,
 				701A9C9D29BB2178006F53C2 /* BoardClipboardHeaderView.swift */,
 			);
 			path = Cell;
@@ -1797,7 +1796,6 @@
 				70197B7B29549B6A000503F6 /* SelectedCategoryChartCollectionViewCell.swift in Sources */,
 				70A4209C2988B1DC0026E9F9 /* SortControl.swift in Sources */,
 				70A420A7298D0F140026E9F9 /* RecentSearchListCollectionViewCell.swift in Sources */,
-				705F81C829AFB1DC00830C4F /* BoardCollectionHeaderView.swift in Sources */,
 				C33952EF29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift in Sources */,
 				BA340E2429782321002BAF2C /* ParticipantListView.swift in Sources */,
 				C3EB29C829A9040600615B6B /* ScheduleTableViewCell.swift in Sources */,
@@ -1834,7 +1832,7 @@
 				BA340E1629782207002BAF2C /* IntroduceTagCollectionViewCell.swift in Sources */,
 				70197B7D29549B96000503F6 /* SelectedCategoryFilterHeaderView.swift in Sources */,
 				C317F2BA298C1D15005703CE /* MeetingCreateSuccessViewController.swift in Sources */,
-				701A9C9C29B72656006F53C2 /* MainPageClipboardCollectionViewCell.swift in Sources */,
+				701A9C9C29B72656006F53C2 /* MainPageClipboardView.swift in Sources */,
 				70A420B429914B370026E9F9 /* AllCategoryListResponse.swift in Sources */,
 				C359FEAC29A09C5200B2F561 /* ScheduleDateSubView.swift in Sources */,
 				BA876BA4296529100029CF34 /* IntroductionViewController.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		705F820E29B1142800830C4F /* MainPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705F820D29B1142800830C4F /* MainPageHeaderView.swift */; };
 		705F821029B127DF00830C4F /* MainPageNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705F820F29B127DF00830C4F /* MainPageNavigationView.swift */; };
 		705F821229B2FCEC00830C4F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 705F821129B2FCEC00830C4F /* GoogleService-Info.plist */; };
+		70727A1F29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */; };
 		7085678628EE9A92008047DC /* HomeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678528EE9A92008047DC /* HomeCollectionViewCell.swift */; };
 		7085678828EEACFB008047DC /* InterestSelectCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678728EEACFB008047DC /* InterestSelectCollectionViewCell.swift */; };
 		7085678A28EEB73F008047DC /* InterestSelectCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678928EEB73F008047DC /* InterestSelectCollectionHeaderView.swift */; };
@@ -330,6 +331,7 @@
 		705F820D29B1142800830C4F /* MainPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageHeaderView.swift; sourceTree = "<group>"; };
 		705F820F29B127DF00830C4F /* MainPageNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageNavigationView.swift; sourceTree = "<group>"; };
 		705F821129B2FCEC00830C4F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSystemCollectionViewCell.swift; sourceTree = "<group>"; };
 		7085678528EE9A92008047DC /* HomeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCollectionViewCell.swift; sourceTree = "<group>"; };
 		7085678728EEACFB008047DC /* InterestSelectCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestSelectCollectionViewCell.swift; sourceTree = "<group>"; };
 		7085678928EEB73F008047DC /* InterestSelectCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestSelectCollectionHeaderView.swift; sourceTree = "<group>"; };
@@ -774,6 +776,7 @@
 			children = (
 				701A9C9B29B72656006F53C2 /* MainPageClipboardView.swift */,
 				701A9C9D29BB2178006F53C2 /* BoardClipboardHeaderView.swift */,
+				70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -1811,6 +1814,7 @@
 				C385D10F29894BF200EF88EC /* CreateMeetingViewModel.swift in Sources */,
 				70F1DFEF297D9E1C00F9BC83 /* DetailRecruitmentViewModel.swift in Sources */,
 				BA8AA42A29863ABC004E9403 /* Interceptor.swift in Sources */,
+				70727A1F29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift in Sources */,
 				701A9C9E29BB2178006F53C2 /* BoardClipboardHeaderView.swift in Sources */,
 				70CF333929992FA60077FF47 /* RecruitmentFilterSlider.swift in Sources */,
 				BA42D1F328EDE10F00C20061 /* LoginViewController.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		705F821029B127DF00830C4F /* MainPageNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705F820F29B127DF00830C4F /* MainPageNavigationView.swift */; };
 		705F821229B2FCEC00830C4F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 705F821129B2FCEC00830C4F /* GoogleService-Info.plist */; };
 		70727A1F29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */; };
+		70727A2129BF8F2A003DE956 /* Ex+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A2029BF8F2A003DE956 /* Ex+Date.swift */; };
 		7085678628EE9A92008047DC /* HomeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678528EE9A92008047DC /* HomeCollectionViewCell.swift */; };
 		7085678828EEACFB008047DC /* InterestSelectCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678728EEACFB008047DC /* InterestSelectCollectionViewCell.swift */; };
 		7085678A28EEB73F008047DC /* InterestSelectCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678928EEB73F008047DC /* InterestSelectCollectionHeaderView.swift */; };
@@ -332,6 +333,7 @@
 		705F820F29B127DF00830C4F /* MainPageNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageNavigationView.swift; sourceTree = "<group>"; };
 		705F821129B2FCEC00830C4F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSystemCollectionViewCell.swift; sourceTree = "<group>"; };
+		70727A2029BF8F2A003DE956 /* Ex+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+Date.swift"; sourceTree = "<group>"; };
 		7085678528EE9A92008047DC /* HomeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCollectionViewCell.swift; sourceTree = "<group>"; };
 		7085678728EEACFB008047DC /* InterestSelectCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestSelectCollectionViewCell.swift; sourceTree = "<group>"; };
 		7085678928EEB73F008047DC /* InterestSelectCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestSelectCollectionHeaderView.swift; sourceTree = "<group>"; };
@@ -1019,6 +1021,7 @@
 				C38A5BA8297C60A000485355 /* Ex+UILabel.swift */,
 				70A4207F2982ED9C0026E9F9 /* Ex+String.swift */,
 				C383968029A26480005998A5 /* Ex+UIResponder.swift */,
+				70727A2029BF8F2A003DE956 /* Ex+Date.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1931,6 +1934,7 @@
 				70CF3337299921100077FF47 /* RecruitmentFilterCollectionHeaderView.swift in Sources */,
 				7085678628EE9A92008047DC /* HomeCollectionViewCell.swift in Sources */,
 				BA780E09297133220032C178 /* Config.swift in Sources */,
+				70727A2129BF8F2A003DE956 /* Ex+Date.swift in Sources */,
 				BA88124E28E48A2F00BD832A /* AppDelegate.swift in Sources */,
 				C361743129AF95E2006AEAB1 /* MyMeetingResponse.swift in Sources */,
 				702876C429A3752A00E57509 /* MeetingScheduleViewController.swift in Sources */,

--- a/PLUB/Configuration/Extensions/Ex+Date.swift
+++ b/PLUB/Configuration/Extensions/Ex+Date.swift
@@ -1,0 +1,15 @@
+//
+//  Ex+Date.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/03/14.
+//
+
+import Foundation
+
+extension Date {
+  func toString() -> String {
+    let formatter = DateFormatter()
+    return formatter.string(from: self)
+  }
+}

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -36,15 +36,11 @@ final class BoardViewController: BaseViewController {
     }
   }
   
-  private var boardModel: [BoardModel] = [
-    BoardModel(feedID: 1, viewType: .system, author: "", authorProfileImageLink: "", date: .now, likeCount: 3, commentCount: 3, title: "", imageLink: "", content: ""),
-    BoardModel(feedID: 1, viewType: .system, author: "", authorProfileImageLink: "", date: .now, likeCount: 3, commentCount: 3, title: "", imageLink: "", content: ""),
-    BoardModel(feedID: 1, viewType: .system, author: "", authorProfileImageLink: "", date: .now, likeCount: 3, commentCount: 3, title: "", imageLink: "", content: "")
-  ]
-//    didSet {
-//      collectionView.reloadSections([0])
-//    }
-  
+  private var boardModel: [BoardModel] = [] {
+    didSet {
+      collectionView.reloadSections([0])
+    }
+  }
   
   private var clipboardModel: [MainPageClipboardViewModel] = [] {
     didSet {
@@ -106,12 +102,12 @@ final class BoardViewController: BaseViewController {
       }
       .disposed(by: disposeBag)
     
-//    viewModel.fetchedBoardModel
-//      .drive(with: self) { owner, model in
-//        print("모델 \(model)")
-//        owner.boardModel = model
-//      }
-//      .disposed(by: disposeBag)
+    //    viewModel.fetchedBoardModel
+    //      .drive(with: self) { owner, model in
+    //        print("모델 \(model)")
+    //        owner.boardModel = model
+    //      }
+    //      .disposed(by: disposeBag)
   }
   
   private func createCollectionViewSection() -> NSCollectionLayoutSection? {
@@ -184,10 +180,11 @@ extension BoardViewController: UICollectionViewDelegate, UICollectionViewDataSou
     switch boardModel.viewType {
     case .system:
       let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoardSystemCollectionViewCell.identifier, for: indexPath) as? BoardSystemCollectionViewCell ?? BoardSystemCollectionViewCell()
+      cell.configureUI(with: boardModel)
       return cell
     default:
       let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoardCollectionViewCell.identifier, for: indexPath) as? BoardCollectionViewCell ?? BoardCollectionViewCell()
-      cell.configure(with: BoardModel(feedID: 0, viewType: .normal, author: "개나리", authorProfileImageLink: nil, date: .now, likeCount: 3, commentCount: 5, title: "게시판 제목", imageLink: nil, content: nil))
+      cell.configure(with: boardModel)
       return cell
     }
   }

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -51,7 +51,6 @@ final class BoardViewController: BaseViewController {
   ).then {
     $0.backgroundColor = .background
     $0.register(BoardCollectionViewCell.self, forCellWithReuseIdentifier: BoardCollectionViewCell.identifier)
-    $0.register(MainPageClipboardCollectionViewCell.self, forCellWithReuseIdentifier: MainPageClipboardCollectionViewCell.identifier)
     $0.register(BoardClipboardHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: BoardClipboardHeaderView.identifier)
     $0.delegate = self
     $0.dataSource = self

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -36,11 +36,15 @@ final class BoardViewController: BaseViewController {
     }
   }
   
-  private var boardModel: [BoardModel] = [] {
-    didSet {
-      collectionView.reloadSections([0])
-    }
-  }
+  private var boardModel: [BoardModel] = [
+    BoardModel(feedID: 1, viewType: .system, author: "", authorProfileImageLink: "", date: .now, likeCount: 3, commentCount: 3, title: "", imageLink: "", content: ""),
+    BoardModel(feedID: 1, viewType: .system, author: "", authorProfileImageLink: "", date: .now, likeCount: 3, commentCount: 3, title: "", imageLink: "", content: ""),
+    BoardModel(feedID: 1, viewType: .system, author: "", authorProfileImageLink: "", date: .now, likeCount: 3, commentCount: 3, title: "", imageLink: "", content: "")
+  ]
+//    didSet {
+//      collectionView.reloadSections([0])
+//    }
+  
   
   private var clipboardModel: [MainPageClipboardViewModel] = [] {
     didSet {
@@ -101,12 +105,12 @@ final class BoardViewController: BaseViewController {
       }
       .disposed(by: disposeBag)
     
-    viewModel.fetchedBoardModel
-      .drive(with: self) { owner, model in
-        print("모델 \(model)")
-        owner.boardModel = model
-      }
-      .disposed(by: disposeBag)
+//    viewModel.fetchedBoardModel
+//      .drive(with: self) { owner, model in
+//        print("모델 \(model)")
+//        owner.boardModel = model
+//      }
+//      .disposed(by: disposeBag)
   }
   
   private func createCollectionViewSection() -> NSCollectionLayoutSection? {

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -93,6 +93,12 @@ final class BoardViewController: BaseViewController {
         owner.headerType = isEmpty ? .noClipboard : .clipboard
       }
       .disposed(by: disposeBag)
+    
+    viewModel.fetchedBoardModel
+      .drive(onNext: { model in
+        print("모델 \(model)")
+      })
+      .disposed(by: disposeBag)
   }
   
   private func createCollectionViewSection() -> NSCollectionLayoutSection? {

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -176,7 +176,7 @@ extension BoardViewController: UICollectionViewDelegate, UICollectionViewDataSou
 
 extension BoardViewController: BoardClipboardHeaderViewDelegate {
   func didTappedClipboardButton() {
-    let vc = ClipboardViewController(viewModel: ClipboardViewModel())
+    let vc = ClipboardViewController(viewModel: ClipboardViewModel(plubbingID: 0))
     vc.navigationItem.largeTitleDisplayMode = .never
     self.navigationController?.pushViewController(vc, animated: true)
   }

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -30,6 +30,8 @@ final class BoardViewController: BaseViewController {
   private let max: CGFloat = 292
   
   /// 아래 타입의 ClipboardType에 따라 다른 UI를 구성
+  private let plubbingID: Int
+  
   private var headerType: BoardHeaderViewType = .clipboard {
     didSet {
       collectionView.reloadSections([0])
@@ -67,6 +69,7 @@ final class BoardViewController: BaseViewController {
   
   init(viewModel: BoardViewModelType = BoardViewModel(), plubbingID: Int) {
     self.viewModel = viewModel
+    self.plubbingID = plubbingID
     super.init(nibName: nil, bundle: nil)
     bind(plubbingID: plubbingID)
   }
@@ -102,12 +105,9 @@ final class BoardViewController: BaseViewController {
       }
       .disposed(by: disposeBag)
     
-    //    viewModel.fetchedBoardModel
-    //      .drive(with: self) { owner, model in
-    //        print("모델 \(model)")
-    //        owner.boardModel = model
-    //      }
-    //      .disposed(by: disposeBag)
+    viewModel.fetchedBoardModel
+      .drive(rx.boardModel)
+      .disposed(by: disposeBag)
   }
   
   private func createCollectionViewSection() -> NSCollectionLayoutSection? {
@@ -190,6 +190,7 @@ extension BoardViewController: UICollectionViewDelegate, UICollectionViewDataSou
   }
   
   func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+    guard headerType == .clipboard else { return UICollectionReusableView() }
     let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: BoardClipboardHeaderView.identifier, for: indexPath) as? BoardClipboardHeaderView ?? BoardClipboardHeaderView()
     header.configureUI(with: clipboardModel)
     header.delegate = self
@@ -199,7 +200,7 @@ extension BoardViewController: UICollectionViewDelegate, UICollectionViewDataSou
 
 extension BoardViewController: BoardClipboardHeaderViewDelegate {
   func didTappedClipboardButton() {
-    let vc = ClipboardViewController(viewModel: ClipboardViewModel(plubbingID: 0))
+    let vc = ClipboardViewController(viewModel: ClipboardViewModel(plubbingID: plubbingID))
     vc.navigationItem.largeTitleDisplayMode = .never
     self.navigationController?.pushViewController(vc, animated: true)
   }

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -162,6 +162,9 @@ extension BoardViewController: UICollectionViewDelegate, UICollectionViewDataSou
   
   func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
     let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: BoardClipboardHeaderView.identifier, for: indexPath) as? BoardClipboardHeaderView ?? BoardClipboardHeaderView()
+    header.configureUI(with: [
+      MainPageClipboardViewModel(type: .text, contentImageString: "https://plub.s3.ap-northeast-2.amazonaws.com/plubbing/mainImage/sports1.png", contentText: "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요ㅇ"),
+    ])
     return header
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -164,6 +164,8 @@ extension BoardViewController: UICollectionViewDelegate, UICollectionViewDataSou
     let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: BoardClipboardHeaderView.identifier, for: indexPath) as? BoardClipboardHeaderView ?? BoardClipboardHeaderView()
     header.configureUI(with: [
       MainPageClipboardViewModel(type: .text, contentImageString: "https://plub.s3.ap-northeast-2.amazonaws.com/plubbing/mainImage/sports1.png", contentText: "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요ㅇ"),
+      MainPageClipboardViewModel(type: .photo, contentImageString: "https://plub.s3.ap-northeast-2.amazonaws.com/plubbing/mainImage/sports1.png", contentText: "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요ㅇ"),
+      MainPageClipboardViewModel(type: .photo, contentImageString: "https://plub.s3.ap-northeast-2.amazonaws.com/plubbing/mainImage/sports1.png", contentText: "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요ㅇ"),
     ])
     return header
   }

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -69,9 +69,10 @@ final class BoardViewController: BaseViewController {
     $0.contentInset = .init(top: 16, left: .zero, bottom: .zero, right: .zero)
   }
   
-  init(viewModel: BoardViewModelType = BoardViewModel()) {
+  init(viewModel: BoardViewModelType = BoardViewModel(), plubbingID: Int) {
     self.viewModel = viewModel
     super.init(nibName: nil, bundle: nil)
+    bind(plubbingID: plubbingID)
   }
   
   required init?(coder: NSCoder) {
@@ -90,10 +91,10 @@ final class BoardViewController: BaseViewController {
     }
   }
   
-  override func bind() {
+  func bind(plubbingID: Int) {
     super.bind()
     
-    viewModel.selectPlubbingID.onNext(1)
+    viewModel.selectPlubbingID.onNext(plubbingID)
     
     viewModel.fetchedMainpageClipboardViewModel
       .drive(rx.clipboardModel)

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
@@ -11,10 +11,15 @@ import RxSwift
 import SnapKit
 import Then
 
+protocol BoardClipboardHeaderViewDelegate: AnyObject {
+  func didTappedClipboardButton()
+}
+
 final class BoardClipboardHeaderView: UICollectionReusableView {
   
   static let identifier = "BoardClipboardHeaderView"
   private let disposeBag = DisposeBag()
+  weak var delegate: BoardClipboardHeaderViewDelegate?
   
   private let horizontalStackView = UIStackView().then {
     $0.axis = .horizontal
@@ -96,10 +101,12 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
   }
   
   public func configureUI(with model: [MainPageClipboardViewModel]) {
-    let mainpageClipboardType = MainPageClipboardType.getMainPageClipboardType(with: model) 
-    var model = model
+    guard !model.isEmpty else { return }
+    let mainpageClipboardType = MainPageClipboardType.getMainPageClipboardType(with: model)
+    
     switch mainpageClipboardType {
     case .moreThanThree:
+      var model = Array(model[0..<3])
       guard let firstModel = model.first else { return }
       model.remove(at: 0)
       let mainPageClipboardView = MainPageClipboardView()
@@ -114,9 +121,9 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
   
   private func bind() {
     clipboardButton.rx.tap
-      .subscribe(onNext: {
-        
-      })
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.didTappedClipboardButton()
+      }
       .disposed(by: disposeBag)
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
@@ -44,6 +44,12 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
     $0.layoutMargins = .init(top: 2, left: 13, bottom: 21, right: 13)
   }
   
+  private lazy var verticalStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 9
+    $0.distribution = .fillEqually
+  }
+  
   override init(frame: CGRect) {
     super.init(frame: frame)
     configureUI()
@@ -81,18 +87,28 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
     }
   }
   
+  private func addElement(which element: [MainPageClipboardViewModel], where at: UIStackView) {
+    element.forEach {
+      let mainPageClipboardView = MainPageClipboardView()
+      mainPageClipboardView.configureUI(with: $0)
+      at.addArrangedSubview(mainPageClipboardView)
+    }
+  }
+  
   public func configureUI(with model: [MainPageClipboardViewModel]) {
     guard let mainpageClipboardType = MainPageClipboardType.allCases.filter({ $0.rawValue == model.count }).first else { return }
+    var model = model
     switch mainpageClipboardType {
-    case .one:
-      guard let model = model.first else { return }
-      let mainPageClipboardView = MainPageClipboardView()
-      mainPageClipboardView.configureUI(with: model)
-      entireStackView.addArrangedSubview(mainPageClipboardView)
-    case .two:
-      print("")
     case .moreThanThree:
-      print("")
+      guard let firstModel = model.first else { return }
+      model.remove(at: 0)
+      let mainPageClipboardView = MainPageClipboardView()
+      mainPageClipboardView.configureUI(with: firstModel)
+      
+      [mainPageClipboardView, verticalStackView].forEach { entireStackView.addArrangedSubview($0) }
+      addElement(which: model, where: verticalStackView)
+    default:
+      addElement(which: model, where: entireStackView)
     }
   }
   

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
@@ -42,7 +42,6 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
     $0.spacing = 12
     $0.isLayoutMarginsRelativeArrangement = true
     $0.layoutMargins = .init(top: 2, left: 13, bottom: 21, right: 13)
-    $0.backgroundColor = .systemPink
   }
   
   override init(frame: CGRect) {
@@ -86,7 +85,10 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
     guard let mainpageClipboardType = MainPageClipboardType.allCases.filter({ $0.rawValue == model.count }).first else { return }
     switch mainpageClipboardType {
     case .one:
-      print("")
+      guard let model = model.first else { return }
+      let mainPageClipboardView = MainPageClipboardView()
+      mainPageClipboardView.configureUI(with: model)
+      entireStackView.addArrangedSubview(mainPageClipboardView)
     case .two:
       print("")
     case .moreThanThree:

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
@@ -82,9 +82,17 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
     }
   }
   
-//  public func configureUI() {
-//    
-//  }
+  public func configureUI(with model: [MainPageClipboardViewModel]) {
+    guard let mainpageClipboardType = MainPageClipboardType.allCases.filter({ $0.rawValue == model.count }).first else { return }
+    switch mainpageClipboardType {
+    case .one:
+      print("")
+    case .two:
+      print("")
+    case .moreThanThree:
+      print("")
+    }
+  }
   
   private func bind() {
     clipboardButton.rx.tap

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
@@ -96,7 +96,7 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
   }
   
   public func configureUI(with model: [MainPageClipboardViewModel]) {
-    guard let mainpageClipboardType = MainPageClipboardType.allCases.filter({ $0.rawValue == model.count }).first else { return }
+    let mainpageClipboardType = MainPageClipboardType.getMainPageClipboardType(with: model) 
     var model = model
     switch mainpageClipboardType {
     case .moreThanThree:

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
@@ -70,6 +70,14 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
     entireStackView.subviews.forEach { $0.removeFromSuperview() }
   }
   
+  private func bind() {
+    clipboardButton.rx.tap
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.didTappedClipboardButton()
+      }
+      .disposed(by: disposeBag)
+  }
+  
   private func configureUI() {
     backgroundColor = .white
     layer.masksToBounds = true
@@ -122,13 +130,5 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
     default:
       addElement(which: model, where: entireStackView)
     }
-  }
-  
-  private func bind() {
-    clipboardButton.rx.tap
-      .subscribe(with: self) { owner, _ in
-        owner.delegate?.didTappedClipboardButton()
-      }
-      .disposed(by: disposeBag)
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
@@ -65,6 +65,11 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
     fatalError("init(coder:) has not been implemented")
   }
   
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    entireStackView.subviews.forEach { $0.removeFromSuperview() }
+  }
+  
   private func configureUI() {
     backgroundColor = .white
     layer.masksToBounds = true

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardSystemCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardSystemCollectionViewCell.swift
@@ -1,0 +1,15 @@
+//
+//  BoardSystemCollectionViewCell.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/03/14.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class BoardSystemCollectionViewCell: UICollectionViewCell {
+  
+}

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardSystemCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardSystemCollectionViewCell.swift
@@ -105,4 +105,12 @@ final class BoardSystemCollectionViewCell: UICollectionViewCell {
       $0.bottom.equalToSuperview().inset(13.81)
     }
   }
+  
+  public func configureUI(with model: BoardModel) {
+    titleLabel.text = model.title
+    contentLabel.text = model.content
+    heartCountLabel.text = "\(model.likeCount)"
+    commentCountLabel.text = "\(model.commentCount)"
+//    dateLabel.text = model.date.
+  }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardSystemCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardSystemCollectionViewCell.swift
@@ -21,14 +21,12 @@ final class BoardSystemCollectionViewCell: UICollectionViewCell {
   private let titleLabel = UILabel().then {
     $0.textColor = .main
     $0.font = .subtitle
-    $0.text = "8번째 멤버와 함께갑니다!"
     $0.numberOfLines = 0
   }
   
   private let contentLabel = UILabel().then {
     $0.textColor = .black
     $0.font = .caption
-    $0.text = "김밥먹고싶다 님이 요란한 한줄 에 들어왔어요\n 멤버들과 함께 환영인사를 나눠보세요!"
     $0.numberOfLines = 2
     $0.lineBreakMode = .byTruncatingTail
   }
@@ -41,7 +39,6 @@ final class BoardSystemCollectionViewCell: UICollectionViewCell {
   private let heartCountLabel = UILabel().then {
     $0.textColor = .deepGray
     $0.font = .overLine
-    $0.text = "3"
   }
   
   private let commentImageView = UIImageView().then {
@@ -52,12 +49,10 @@ final class BoardSystemCollectionViewCell: UICollectionViewCell {
   private let commentCountLabel = UILabel().then {
     $0.textColor = .deepGray
     $0.font = .overLine
-    $0.text = "3"
   }
   
   private let dateLabel = UILabel().then {
     $0.font = .overLine
-    $0.text = "2022. 08. 10."
     $0.textColor = .deepGray
   }
   
@@ -68,6 +63,15 @@ final class BoardSystemCollectionViewCell: UICollectionViewCell {
   
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    titleLabel.text = nil
+    contentLabel.text = nil
+    heartCountLabel.text = nil
+    commentCountLabel.text = nil
+    dateLabel.text = nil
   }
   
   private func configureUI() {
@@ -107,8 +111,9 @@ final class BoardSystemCollectionViewCell: UICollectionViewCell {
   }
   
   public func configureUI(with model: BoardModel) {
+    guard let content = model.content else { return }
     titleLabel.text = model.title
-    contentLabel.text = model.content
+    contentLabel.text = content + "\n 멤버들과 함께 환영인사를 나눠보세요!"
     heartCountLabel.text = "\(model.likeCount)"
     commentCountLabel.text = "\(model.commentCount)"
     dateLabel.text = model.date.toString()

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardSystemCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardSystemCollectionViewCell.swift
@@ -12,4 +12,66 @@ import Then
 
 final class BoardSystemCollectionViewCell: UICollectionViewCell {
   
+  static let identifier = "BoardSystemCollectionViewCell"
+  
+  private let likeCommentStackView = UIStackView().then {
+    $0.axis = .horizontal
+  }
+  
+  private let titleLabel = UILabel().then {
+    $0.textColor = .main
+    $0.font = .subtitle
+    $0.text = "8번째 멤버와 함께갑니다!"
+  }
+  
+  private let contentLabel = UILabel().then {
+    $0.textColor = .black
+    $0.font = .caption
+  }
+  
+  private let heartImageView = UIImageView().then {
+    $0.contentMode = .scaleAspectFill
+    $0.image = UIImage(named: "heartFilled")
+  }
+  
+  private let heartCountLabel = UILabel().then {
+    $0.textColor = .deepGray
+    $0.font = .overLine
+    $0.text = "3"
+  }
+  
+  private let commentImageView = UIImageView().then {
+    $0.contentMode = .scaleAspectFill
+    $0.image = UIImage(named: "commentDots")
+  }
+  
+  private let commentCountLabel = UILabel().then {
+    $0.textColor = .deepGray
+    $0.font = .overLine
+    $0.text = "3"
+  }
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    configureUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func configureUI() {
+    [heartImageView, heartCountLabel, commentImageView, commentCountLabel].forEach { likeCommentStackView.addArrangedSubview($0) }
+    [titleLabel, likeCommentStackView].forEach { contentView.addSubview($0) }
+    titleLabel.snp.makeConstraints {
+      $0.top.equalToSuperview().inset(12)
+      $0.leading.equalToSuperview().inset(16)
+    }
+    
+    likeCommentStackView.snp.makeConstraints {
+      $0.leading.greaterThanOrEqualTo(titleLabel.snp.trailing)
+      $0.top.equalToSuperview().inset(12)
+      $0.trailing.equalToSuperview().inset(16)
+    }
+  }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardSystemCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardSystemCollectionViewCell.swift
@@ -111,6 +111,6 @@ final class BoardSystemCollectionViewCell: UICollectionViewCell {
     contentLabel.text = model.content
     heartCountLabel.text = "\(model.likeCount)"
     commentCountLabel.text = "\(model.commentCount)"
-//    dateLabel.text = model.date.
+    dateLabel.text = model.date.toString()
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardSystemCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardSystemCollectionViewCell.swift
@@ -22,11 +22,15 @@ final class BoardSystemCollectionViewCell: UICollectionViewCell {
     $0.textColor = .main
     $0.font = .subtitle
     $0.text = "8번째 멤버와 함께갑니다!"
+    $0.numberOfLines = 0
   }
   
   private let contentLabel = UILabel().then {
     $0.textColor = .black
     $0.font = .caption
+    $0.text = "김밥먹고싶다 님이 요란한 한줄 에 들어왔어요\n 멤버들과 함께 환영인사를 나눠보세요!"
+    $0.numberOfLines = 2
+    $0.lineBreakMode = .byTruncatingTail
   }
   
   private let heartImageView = UIImageView().then {
@@ -51,6 +55,12 @@ final class BoardSystemCollectionViewCell: UICollectionViewCell {
     $0.text = "3"
   }
   
+  private let dateLabel = UILabel().then {
+    $0.font = .overLine
+    $0.text = "2022. 08. 10."
+    $0.textColor = .deepGray
+  }
+  
   override init(frame: CGRect) {
     super.init(frame: frame)
     configureUI()
@@ -61,17 +71,38 @@ final class BoardSystemCollectionViewCell: UICollectionViewCell {
   }
   
   private func configureUI() {
+    contentView.backgroundColor = .white
+    contentView.layer.masksToBounds = true
+    contentView.layer.cornerRadius = 10
+  
     [heartImageView, heartCountLabel, commentImageView, commentCountLabel].forEach { likeCommentStackView.addArrangedSubview($0) }
-    [titleLabel, likeCommentStackView].forEach { contentView.addSubview($0) }
+    [titleLabel, likeCommentStackView, contentLabel, dateLabel].forEach { contentView.addSubview($0) }
     titleLabel.snp.makeConstraints {
       $0.top.equalToSuperview().inset(12)
       $0.leading.equalToSuperview().inset(16)
+    }
+    
+    [heartImageView, commentImageView].forEach {
+      $0.snp.makeConstraints {
+        $0.size.equalTo(24)
+      }
     }
     
     likeCommentStackView.snp.makeConstraints {
       $0.leading.greaterThanOrEqualTo(titleLabel.snp.trailing)
       $0.top.equalToSuperview().inset(12)
       $0.trailing.equalToSuperview().inset(16)
+    }
+    
+    contentLabel.snp.makeConstraints {
+      $0.leading.equalTo(titleLabel)
+      $0.top.equalTo(titleLabel.snp.bottom).offset(8)
+      $0.trailing.lessThanOrEqualToSuperview().inset(16)
+    }
+    
+    dateLabel.snp.makeConstraints {
+      $0.trailing.equalTo(likeCommentStackView)
+      $0.bottom.equalToSuperview().inset(13.81)
     }
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Cell/MainPageClipboardCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/MainPageClipboardCollectionViewCell.swift
@@ -10,8 +10,8 @@ import UIKit
 import SnapKit
 import Then
 
-enum MainPageClipboardType {
-  case one // 클립보드한 내역이 하나인 경우
+enum MainPageClipboardType: Int, CaseIterable {
+  case one = 1 // 클립보드한 내역이 하나인 경우
   case two // 클립보드한 내역이 2개인 경우
   case moreThanThree // 클립보드한 내역이 3개이상인 경우
 }

--- a/PLUB/Sources/Views/Home/MainPage/Cell/MainPageClipboardCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/MainPageClipboardCollectionViewCell.swift
@@ -16,15 +16,13 @@ enum MainPageClipboardType {
   case moreThanThree // 클립보드한 내역이 3개이상인 경우
 }
 
-struct MainPageClipboardCollectionViewCellModel {
+struct MainPageClipboardViewModel {
   let type: PostType
   let contentImageString: String?
   let contentText: String?
 }
 
-final class MainPageClipboardCollectionViewCell: UICollectionViewCell {
-  
-  static let identifier = "MainPageClipboardCollectionViewCell"
+final class MainPageClipboardView: UIView {
   
   private var type: PostType? {
     didSet {
@@ -59,19 +57,19 @@ final class MainPageClipboardCollectionViewCell: UICollectionViewCell {
     guard let type = type else { return }
     switch type {
     case .text:
-      contentView.addSubview(contentLabel)
+      addSubview(contentLabel)
       contentLabel.snp.makeConstraints {
         $0.directionalEdges.equalToSuperview()
       }
     default:
-      contentView.addSubview(contentImageView)
+      addSubview(contentImageView)
       contentImageView.snp.makeConstraints {
         $0.directionalEdges.equalToSuperview()
       }
     }
   }
   
-  func configureUI(with model: MainPageClipboardCollectionViewCellModel) {
+  func configureUI(with model: MainPageClipboardViewModel) {
     self.type = model.type
     switch type {
     case .text:

--- a/PLUB/Sources/Views/Home/MainPage/Cell/MainPageClipboardView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/MainPageClipboardView.swift
@@ -22,7 +22,7 @@ enum MainPageClipboardType {
     else if model.count == 2 {
       return .two
     }
-    else { 
+    else {
       return .moreThanThree
     }
   }
@@ -44,16 +44,15 @@ final class MainPageClipboardView: UIView {
   }
   
   private lazy var contentImageView = UIImageView().then {
-    $0.contentMode = .scaleAspectFit
-    $0.image = UIImage(systemName: "heart.fill")
+    $0.contentMode = .scaleAspectFill
   }
   
   private lazy var contentLabel = UILabel().then {
     $0.font = .body2
     $0.textColor = .black
-    $0.text = "sdfsdfsafasfsdfsdafsdafasfsafsafdsadfasdfs"
     $0.numberOfLines = 3
     $0.lineBreakMode = .byTruncatingTail
+    $0.backgroundColor = .subMain
   }
   
   override init(frame: CGRect) {
@@ -81,7 +80,6 @@ final class MainPageClipboardView: UIView {
     }
     layer.masksToBounds = true
     layer.cornerRadius = 10
-    backgroundColor = .blue
   }
   
   func configureUI(with model: MainPageClipboardViewModel) {

--- a/PLUB/Sources/Views/Home/MainPage/Cell/MainPageClipboardView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/MainPageClipboardView.swift
@@ -10,10 +10,22 @@ import UIKit
 import SnapKit
 import Then
 
-enum MainPageClipboardType: Int, CaseIterable {
-  case one = 1 // 클립보드한 내역이 하나인 경우
+enum MainPageClipboardType {
+  case one // 클립보드한 내역이 하나인 경우
   case two // 클립보드한 내역이 2개인 경우
   case moreThanThree // 클립보드한 내역이 3개이상인 경우
+  
+  static func getMainPageClipboardType(with model: [MainPageClipboardViewModel]) -> Self {
+    if model.count == 1 {
+      return .one
+    }
+    else if model.count == 2 {
+      return .two
+    }
+    else { 
+      return .moreThanThree
+    }
+  }
 }
 
 struct MainPageClipboardViewModel {

--- a/PLUB/Sources/Views/Home/MainPage/Cell/MainPageClipboardView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/MainPageClipboardView.swift
@@ -67,6 +67,9 @@ final class MainPageClipboardView: UIView {
         $0.directionalEdges.equalToSuperview()
       }
     }
+    layer.masksToBounds = true
+    layer.cornerRadius = 10
+    backgroundColor = .blue
   }
   
   func configureUI(with model: MainPageClipboardViewModel) {

--- a/PLUB/Sources/Views/Home/MainPage/Cell/MainPageClipboardView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/MainPageClipboardView.swift
@@ -47,10 +47,10 @@ final class MainPageClipboardView: UIView {
     $0.contentMode = .scaleAspectFill
   }
   
-  private lazy var contentLabel = UILabel().then {
+  private lazy var contentLabel = PaddingLabel(withInsets: 10, 10, 8, 8).then {
     $0.font = .body2
     $0.textColor = .black
-    $0.numberOfLines = 3
+    $0.numberOfLines = 0
     $0.lineBreakMode = .byTruncatingTail
     $0.backgroundColor = .subMain
   }

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -27,6 +27,8 @@ enum MainPageFilterType {
 
 final class MainPageViewController: BaseViewController {
   
+  private let plubbingID: Int
+  
   var currentPage = 0 {
     didSet {
       let direction: UIPageViewController.NavigationDirection = oldValue <= currentPage ? .forward : .reverse
@@ -62,7 +64,7 @@ final class MainPageViewController: BaseViewController {
     $0.dataSource = self
   }
   
-  private lazy var boardViewController = BoardViewController().then {
+  private lazy var boardViewController = BoardViewController(plubbingID: plubbingID).then {
     $0.delegate = self
   }
   private let todolistViewController = TodolistViewController()
@@ -80,6 +82,15 @@ final class MainPageViewController: BaseViewController {
   private lazy var mainpageNavigationView = MainPageNavigationView().then {
     $0.axis = .horizontal
     $0.spacing = 4
+  }
+  
+  init(plubbingID: Int) {
+    self.plubbingID = plubbingID
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
   }
   
   override func viewWillAppear(_ animated: Bool) {

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
@@ -46,7 +46,7 @@ final class BoardViewModel: BoardViewModelType {
     
     let fetchingClipboards = selectingPlubbingID
       .flatMapLatest { plubbingID in
-        return FeedsService.shared.fetchClipboards(plubIdentifier: plubbingID)
+        return FeedsService.shared.fetchClipboards(plubbingID: plubbingID)
       }
     
     let successFetchingBoards = fetchingBoards.compactMap { result -> [FeedsContent]? in

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
@@ -13,7 +13,10 @@ protocol BoardViewModelType {
   // Intput
   var selectPlubbingID: AnyObserver<Int> { get }
   
-  func createMockData() -> Observable<[MockModel]>
+  // Output
+  var fetchedMainpageClipboardViewModel: Driver<[MainPageClipboardViewModel]> { get }
+  var clipboardListIsEmpty: Driver<Bool> { get }
+  
 }
 
 /// 게시판에 관련된 클립보드리스트가 존재하는지에 대한 여부 BoardHeaderViewType Output 필요
@@ -26,9 +29,13 @@ final class BoardViewModel: BoardViewModelType {
   let selectPlubbingID: AnyObserver<Int>
   
   // Output
+  let fetchedMainpageClipboardViewModel: Driver<[MainPageClipboardViewModel]>
+  let clipboardListIsEmpty: Driver<Bool>
   
   init() {
     let selectingPlubbingID = PublishSubject<Int>()
+    let fetchingMainpageClipboardViewModel = BehaviorRelay<[MainPageClipboardViewModel]>(value: [])
+    
     self.selectPlubbingID = selectingPlubbingID.asObserver()
     
     // Input
@@ -37,27 +44,41 @@ final class BoardViewModel: BoardViewModelType {
         return FeedsService.shared.fetchBoards(plubIdentifier: plubbingID)
       }
     
+    let fetchingClipboards = selectingPlubbingID
+      .flatMapLatest { plubbingID in
+        return FeedsService.shared.fetchClipboards(plubIdentifier: plubbingID)
+      }
+    
     let successFetchingBoards = fetchingBoards.compactMap { result -> [FeedsContent]? in
       guard case .success(let response) = result else { return nil }
       return response.data?.content
     }
     
-    successFetchingBoards.subscribe(onNext: { content in
-      print("콘텐츠 \(content)")
+    let successFetchingClipboards = fetchingClipboards.compactMap { result -> [FeedsContent]? in
+      guard case .success(let response) = result else { return nil }
+      return response.data?.pinnedFeedList
+    }
+    
+    successFetchingClipboards.subscribe(onNext: { contents in
+      let mainPageClipboardViewModel = contents.map {
+        return MainPageClipboardViewModel(
+          type: $0.type,
+          contentImageString: $0.feedImageURL,
+          contentText: $0.content
+        )
+      }
+      fetchingMainpageClipboardViewModel.accept(mainPageClipboardViewModel)
     })
     .disposed(by: disposeBag)
+    
+    // Output
+    fetchedMainpageClipboardViewModel = fetchingMainpageClipboardViewModel.asDriver(onErrorDriveWith: .empty())
+    
+    clipboardListIsEmpty = fetchingMainpageClipboardViewModel
+      .map { $0.isEmpty }
+      .asDriver(onErrorDriveWith: .empty())
   }
   
-  func createMockData() -> Observable<[MockModel]> {
-    return Observable.just([
-      MockModel(type: .photo, viewType: .pin, content: "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요ㅇ", feedImageURL: "https://plub.s3.ap-northeast-2.amazonaws.com/plubbing/mainImage/sports1.png"),
-      MockModel(type: .text, viewType: .pin, content: "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요ㅇ", feedImageURL: "https://plub.s3.ap-northeast-2.amazonaws.com/plubbing/mainImage/sports1.png"),
-      MockModel(type: .photoAndText, viewType: .pin, content: "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요ㅇ", feedImageURL: "https://plub.s3.ap-northeast-2.amazonaws.com/plubbing/mainImage/sports1.png"),
-//      MockModel(type: .photoAndText, viewType: .pin, content: "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요ㅇ", feedImageURL: "https://plub.s3.ap-northeast-2.amazonaws.com/plubbing/mainImage/sports1.png"),
-//      MockModel(type: .text, viewType: .pin, content: "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요ㅇ", feedImageURL: "https://plub.s3.ap-northeast-2.amazonaws.com/plubbing/mainImage/sports1.png"),
-//      MockModel(type: .text, viewType: .pin, content: "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요ㅇ", feedImageURL: "https://plub.s3.ap-northeast-2.amazonaws.com/plubbing/mainImage/sports1.png"),
-    ])
-  }
 }
 
 struct MockModel {

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
@@ -54,6 +54,11 @@ final class BoardViewModel: BoardViewModelType {
       return response.data?.content
     }
     
+    successFetchingBoards.subscribe(onNext: { boards in
+      print("게시판 \(boards)")
+    })
+    .disposed(by: disposeBag)
+    
     let successFetchingClipboards = fetchingClipboards.compactMap { result -> [FeedsContent]? in
       guard case .success(let response) = result else { return nil }
       return response.data?.pinnedFeedList

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
@@ -20,8 +20,6 @@ protocol BoardViewModelType {
   
 }
 
-/// 게시판에 관련된 클립보드리스트가 존재하는지에 대한 여부 BoardHeaderViewType Output 필요
-///  클립보드에 관련된 리스트가 몇개인지에 대한 ClipboardType Output 필요
 final class BoardViewModel: BoardViewModelType {
   
   private let disposeBag = DisposeBag()
@@ -53,7 +51,6 @@ final class BoardViewModel: BoardViewModelType {
       }
     
     let successFetchingBoards = fetchingBoards.compactMap { result -> [FeedsContent]? in
-      print("결과 \(result)")
       guard case .success(let response) = result else { return nil }
       return response.data?.content
     }

--- a/PLUB/Sources/Views/Meeting/MeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewController.swift
@@ -170,7 +170,7 @@ extension MeetingViewController: UICollectionViewDelegate, UICollectionViewDataS
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     if indexPath.row < meetingList.count {
       // 플러빙 메인
-      let vc = MainPageViewController()
+      let vc = MainPageViewController(plubbingID: 0)
       vc.navigationItem.largeTitleDisplayMode = .never
       self.navigationController?.pushViewController(vc, animated: true)
     } else {

--- a/PLUB/Sources/Views/Meeting/MeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewController.swift
@@ -170,8 +170,9 @@ extension MeetingViewController: UICollectionViewDelegate, UICollectionViewDataS
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     if indexPath.row < meetingList.count {
       // 플러빙 메인
-      let vc = MainPageViewController(plubbingID: 0)
+      let vc = MainPageViewController(plubbingID: meetingList[indexPath.row].plubbingID)
       vc.navigationItem.largeTitleDisplayMode = .never
+      vc.hidesBottomBarWhenPushed = true
       self.navigationController?.pushViewController(vc, animated: true)
     } else {
       // 모임 생성


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 메인페이지 게시판 ViewType SYSTEM일 경우 UI 레이아웃 추가 
- 클립보드 리스트 갯수에 따른 UI 레이아웃 추가 
- 메인페이지 게시판과 관련된 API를 이용해 연동

🌱 PR 포인트
- 얼른 힘내서 빠르게 메인페이지 전체적으로 완성시키도록 하겠습니다 
- 일단 기본적으로 메인페이지 헤더에 버튼에 클립보드화면이동시키는 코드 추가한 상태라서 승현님 확인하시면 될꺼같습니다

## 📮 관련 이슈
- Resolved: #208 

