### PR TITLE
[FIX] Alamofire retry 내부 로직 수정

### DIFF
--- a/PLUB/Sources/Network/Foundation/Interceptor.swift
+++ b/PLUB/Sources/Network/Foundation/Interceptor.swift
@@ -15,7 +15,15 @@ final class Interceptor: RequestInterceptor {
   private let disposeBag = DisposeBag()
   
   func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
-    guard request.response?.statusCode == 401 else {
+    // 200 성공대인 경우 retry 무시
+    guard let statusCode = request.response?.statusCode,
+          !(200..<300).contains(statusCode)
+    else {
+      completion(.doNotRetry)
+      return
+    }
+    
+    guard statusCode == 401 else {
       // 401이 아닌 다른 에러가 발생한 경우, retry하지 않고 Error를 뱉음 (토큰 만료 에러가 아니기 때문)
       completion(.doNotRetryWithError(error))
       return


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 정상적으로 API 호출되었음에도 휴대폰의 내부 네트워크 오류로 인해 retry가 실행되는 현상 발생
   - retry 내부에 statusCode가 200인 경우가 생겨버림

위 문제를 수정하기 위해 200단으로 응답값을 받았을 경우 빠른 종료 처리
