### PR TITLE
[FEAT] 메인페이지 게시글 생성 화면 

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		705F821229B2FCEC00830C4F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 705F821129B2FCEC00830C4F /* GoogleService-Info.plist */; };
 		70727A1F29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */; };
 		70727A2129BF8F2A003DE956 /* Ex+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A2029BF8F2A003DE956 /* Ex+Date.swift */; };
+		70727A2329C4A9E4003DE956 /* CreateBoardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A2229C4A9E4003DE956 /* CreateBoardViewController.swift */; };
 		7085678628EE9A92008047DC /* HomeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678528EE9A92008047DC /* HomeCollectionViewCell.swift */; };
 		7085678828EEACFB008047DC /* InterestSelectCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678728EEACFB008047DC /* InterestSelectCollectionViewCell.swift */; };
 		7085678A28EEB73F008047DC /* InterestSelectCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678928EEB73F008047DC /* InterestSelectCollectionHeaderView.swift */; };
@@ -345,6 +346,7 @@
 		705F821129B2FCEC00830C4F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSystemCollectionViewCell.swift; sourceTree = "<group>"; };
 		70727A2029BF8F2A003DE956 /* Ex+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+Date.swift"; sourceTree = "<group>"; };
+		70727A2229C4A9E4003DE956 /* CreateBoardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBoardViewController.swift; sourceTree = "<group>"; };
 		7085678528EE9A92008047DC /* HomeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCollectionViewCell.swift; sourceTree = "<group>"; };
 		7085678728EEACFB008047DC /* InterestSelectCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestSelectCollectionViewCell.swift; sourceTree = "<group>"; };
 		7085678928EEB73F008047DC /* InterestSelectCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestSelectCollectionHeaderView.swift; sourceTree = "<group>"; };
@@ -791,6 +793,7 @@
 				705F81BE29AF35B700830C4F /* MainPageViewController.swift */,
 				705F81C229AFAA3B00830C4F /* BoardViewController.swift */,
 				705F81C429AFAA5200830C4F /* TodolistViewController.swift */,
+				70727A2229C4A9E4003DE956 /* CreateBoardViewController.swift */,
 			);
 			path = MainPage;
 			sourceTree = "<group>";
@@ -2054,6 +2057,7 @@
 				7028770729A8C9A100E57509 /* RecruitmentFilterViewModel.swift in Sources */,
 				C3413E1729954910004B8DBD /* MeetingInfoViewController.swift in Sources */,
 				BA1FC12929A5FD3C00AB3F91 /* FeedsPaginatedDataResponse.swift in Sources */,
+				70727A2329C4A9E4003DE956 /* CreateBoardViewController.swift in Sources */,
 				C3100CBC29BD8ABB005FCCAD /* MyProfileView.swift in Sources */,
 				70C42454296C86A400DECA0D /* HomeMainCollectionHeaderView.swift in Sources */,
 				BAC5EF31298B6F2D00F3955E /* CongratulationViewController.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		70727A1F29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */; };
 		70727A2129BF8F2A003DE956 /* Ex+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A2029BF8F2A003DE956 /* Ex+Date.swift */; };
 		70727A2329C4A9E4003DE956 /* CreateBoardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A2229C4A9E4003DE956 /* CreateBoardViewController.swift */; };
+		70727A2529C4C21A003DE956 /* CreateBoardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A2429C4C21A003DE956 /* CreateBoardViewModel.swift */; };
 		7085678628EE9A92008047DC /* HomeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678528EE9A92008047DC /* HomeCollectionViewCell.swift */; };
 		7085678828EEACFB008047DC /* InterestSelectCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678728EEACFB008047DC /* InterestSelectCollectionViewCell.swift */; };
 		7085678A28EEB73F008047DC /* InterestSelectCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678928EEB73F008047DC /* InterestSelectCollectionHeaderView.swift */; };
@@ -347,6 +348,7 @@
 		70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSystemCollectionViewCell.swift; sourceTree = "<group>"; };
 		70727A2029BF8F2A003DE956 /* Ex+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+Date.swift"; sourceTree = "<group>"; };
 		70727A2229C4A9E4003DE956 /* CreateBoardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBoardViewController.swift; sourceTree = "<group>"; };
+		70727A2429C4C21A003DE956 /* CreateBoardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBoardViewModel.swift; sourceTree = "<group>"; };
 		7085678528EE9A92008047DC /* HomeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCollectionViewCell.swift; sourceTree = "<group>"; };
 		7085678728EEACFB008047DC /* InterestSelectCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestSelectCollectionViewCell.swift; sourceTree = "<group>"; };
 		7085678928EEB73F008047DC /* InterestSelectCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestSelectCollectionHeaderView.swift; sourceTree = "<group>"; };
@@ -813,6 +815,7 @@
 			children = (
 				705F81C029AF8E7300830C4F /* MainPageViewModel.swift */,
 				705F820829B0EE6600830C4F /* BoardViewModel.swift */,
+				70727A2429C4C21A003DE956 /* CreateBoardViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1896,6 +1899,7 @@
 				C3B3435D29BE4A3000935B73 /* MyPlubbingParameter.swift in Sources */,
 				BA72BCF029BB03FF007165E5 /* BaseNavigationController.swift in Sources */,
 				70197B722953698F000503F6 /* SelectedCategoryViewController.swift in Sources */,
+				70727A2529C4C21A003DE956 /* CreateBoardViewModel.swift in Sources */,
 				C3C24CD3298FBA6D00056313 /* PeopleNumberToolTip.swift in Sources */,
 				BA814A3429890AB1003570D3 /* OnboardingViewModel.swift in Sources */,
 				C3B3435B29BE3E5100935B73 /* MyPlubbingResponse.swift in Sources */,

--- a/PLUB/SceneDelegate.swift
+++ b/PLUB/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     window = UIWindow(windowScene: windowScene)
     window?.rootViewController = UINavigationController(rootViewController: SplashViewController())
-//    window?.rootViewController = UINavigationController(rootViewController: MainPageViewController())
+    window?.rootViewController = UINavigationController(rootViewController: MainPageViewController(plubbingID: 1))
     window?.makeKeyAndVisible()
   }
   

--- a/PLUB/SceneDelegate.swift
+++ b/PLUB/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     window = UIWindow(windowScene: windowScene)
     window?.rootViewController = UINavigationController(rootViewController: SplashViewController())
-    window?.rootViewController = UINavigationController(rootViewController: MainPageViewController(plubbingID: 1))
+//    window?.rootViewController = UINavigationController(rootViewController: MainPageViewController(plubbingID: 1))
     window?.makeKeyAndVisible()
   }
   

--- a/PLUB/SceneDelegate.swift
+++ b/PLUB/SceneDelegate.swift
@@ -19,7 +19,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     window = UIWindow(windowScene: windowScene)
     window?.rootViewController = UINavigationController(rootViewController: SplashViewController())
-//    window?.rootViewController = UINavigationController(rootViewController: MainPageViewController(plubbingID: 1))
     window?.makeKeyAndVisible()
   }
   

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -78,6 +78,11 @@ final class BoardViewController: BaseViewController {
     fatalError("init(coder:) has not been implemented")
   }
   
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    viewModel.selectPlubbingID.onNext(plubbingID)
+  }
+  
   override func setupLayouts() {
     super.setupLayouts()
     view.addSubview(collectionView)

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -162,7 +162,19 @@ final class CreateBoardViewController: BaseViewController {
     
     uploadButton.rx.tap
       .subscribe(with: self) { owner, _ in
-        
+        guard let title = owner.titleInputTextView.textView.text else { return }
+        let request = BoardsRequest(
+          title: title,
+          content: owner.boardContentInputTextView.textView.text,
+          feedImage: owner.addPhotoImageView.image?.jpegData(compressionQuality: 1.0)?.base64EncodedString()
+        )
+        owner.viewModel.whichUpload.onNext(request)
+      }
+      .disposed(by: disposeBag)
+    
+    viewModel.isSuccessCreateBoard
+      .emit(with: self) { owner, _ in
+        owner.navigationController?.popViewController(animated: true)
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -71,9 +71,15 @@ final class CreateBoardViewController: BaseViewController {
     $0.backgroundColor = .deepGray
     $0.layer.cornerRadius = 10
     $0.layer.masksToBounds = true
+    $0.isUserInteractionEnabled = true
   }
   
   private lazy var boardContentInputTextView = InputTextView(title: "게시할 내용", placeHolder: "내용을 입력해주세요", totalCharacterLimit: 300)
+  
+  private let tapGesture = UITapGestureRecognizer(
+      target: CreateBoardViewController.self,
+      action: nil
+  )
   
   init(viewModel: CreateBoardViewModelType = CreateBoardViewModel(), plubbingID: Int) {
     self.viewModel = viewModel
@@ -89,6 +95,7 @@ final class CreateBoardViewController: BaseViewController {
     super.setupStyles()
     
     self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "back"), style: .plain, target: self, action: #selector(didTappedBackButton))
+    addPhotoImageView.addGestureRecognizer(tapGesture)
   }
   
   override func setupLayouts() {
@@ -185,7 +192,13 @@ final class CreateBoardViewController: BaseViewController {
       .subscribe(viewModel.writeContent)
       .disposed(by: disposeBag)
     
-//    addPhotoImageView.rx.image
+    tapGesture.rx.event
+      .subscribe(onNext: { _ in
+        print("탭")
+      })
+      .disposed(by: disposeBag)
+    
+//    addPhotoImageView.rx.tap
 //      .subscribe(onNext: { image in
 //        print("이미지 \(image)")
 //      })

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -76,7 +76,7 @@ final class CreateBoardViewController: BaseViewController {
   private lazy var boardContentInputTextView = InputTextView(
     title: "게시할 내용",
     placeHolder: "내용을 입력해주세요",
-    totalCharacterLimit: 300
+    options: [.textCount]
   )
   
   private let tapGesture = UITapGestureRecognizer(

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -73,9 +73,10 @@ final class CreateBoardViewController: BaseViewController {
   
   private lazy var boardContentInputTextView = InputTextView(title: "게시할 내용", placeHolder: "내용을 입력해주세요", totalCharacterLimit: 300)
   
-  init(viewModel: CreateBoardViewModelType = CreateBoardViewModel()) {
+  init(viewModel: CreateBoardViewModelType = CreateBoardViewModel(), plubbingID: Int) {
     self.viewModel = viewModel
     super.init(nibName: nil, bundle: nil)
+    bind(plubbingID: plubbingID)
   }
   
   required init?(coder: NSCoder) {
@@ -131,7 +132,7 @@ final class CreateBoardViewController: BaseViewController {
     }
   }
   
-  override func bind() {
+  func bind(plubbingID: Int) {
     super.bind()
     photoButton.rx.tap
       .subscribe(with: self) { owner, _ in

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -97,7 +97,7 @@ final class CreateBoardViewController: BaseViewController {
   override func setupStyles() {
     super.setupStyles()
     
-    self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "back"), style: .plain, target: self, action: #selector(didTappedBackButton))
+    navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "back"), style: .plain, target: self, action: #selector(didTappedBackButton))
     addPhotoImageView.addGestureRecognizer(tapGesture)
   }
   

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -10,6 +10,40 @@ import UIKit
 import SnapKit
 import Then
 
-final class CreateBoardViewController: UIViewController {
+final class CreateBoardViewController: BaseViewController {
+  
+  private let boardTypeLabel = UILabel().then {
+    $0.textColor = .black
+  }
+  
+  private let photoButton: UIButton = UIButton(configuration: .plain()).then {
+    $0.configurationUpdateHandler = $0.configuration?.list(label: "사진 Only")
+    $0.isSelected = true
+  }
+  
+  private let textButton = UIButton(configuration: .plain()).then {
+    $0.configurationUpdateHandler = $0.configuration?.list(label: "글 Only")
+  }
+  
+  private let photoAndTextButton: UIButton = UIButton(configuration: .plain()).then {
+    $0.configurationUpdateHandler = $0.configuration?.list(label: "사진+글")
+  }
+  
+  private let titleLabel = UILabel().then {
+    $0.textColor = .black
+  }
+
+  private let photoAddLabel = UILabel().then {
+    $0.textColor = .black
+  }
+  
+  override func setupStyles() {
+    super.setupStyles()
+    self.navigationController?.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "back"), style: .plain, target: self, action: #selector(didTappedBackButton))
+  }
+  
+  @objc private func didTappedBackButton() {
+    self.navigationController?.popViewController(animated: true)
+  }
   
 }

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -80,8 +80,8 @@ final class CreateBoardViewController: BaseViewController {
   )
   
   private let tapGesture = UITapGestureRecognizer(
-      target: CreateBoardViewController.self,
-      action: nil
+    target: CreateBoardViewController.self,
+    action: nil
   )
   
   init(viewModel: CreateBoardViewModelType = CreateBoardViewModel(), plubbingID: Int) {
@@ -191,16 +191,12 @@ final class CreateBoardViewController: BaseViewController {
     
     titleInputTextView.textView.rx.text
       .orEmpty
-      .subscribe(with: self) { owner, title in
-        owner.viewModel.writeTitle.onNext(title)
-      }
+      .subscribe(viewModel.writeTitle)
       .disposed(by: disposeBag)
     
     boardContentInputTextView.textView.rx.text
       .orEmpty
-      .subscribe(with: self) { owner, content in
-        owner.viewModel.writeContent.onNext(content)
-      }
+      .subscribe(viewModel.writeContent)
       .disposed(by: disposeBag)
     
     tapGesture.rx.event

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -39,7 +39,8 @@ final class CreateBoardViewController: BaseViewController {
   
   override func setupStyles() {
     super.setupStyles()
-    self.navigationController?.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "back"), style: .plain, target: self, action: #selector(didTappedBackButton))
+
+    self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "back"), style: .plain, target: self, action: #selector(didTappedBackButton))
   }
   
   @objc private func didTappedBackButton() {

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -12,6 +12,8 @@ import Then
 
 final class CreateBoardViewController: BaseViewController {
   
+  private let viewModel: CreateBoardViewModelType
+  
   private var type: PostType = .photo {
     didSet {
       guard type != oldValue else { return }
@@ -71,9 +73,18 @@ final class CreateBoardViewController: BaseViewController {
   
   private lazy var boardContentInputTextView = InputTextView(title: "게시할 내용", placeHolder: "내용을 입력해주세요", totalCharacterLimit: 300)
   
+  init(viewModel: CreateBoardViewModelType = CreateBoardViewModel()) {
+    self.viewModel = viewModel
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
   override func setupStyles() {
     super.setupStyles()
-
+    
     self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "back"), style: .plain, target: self, action: #selector(didTappedBackButton))
   }
   
@@ -146,6 +157,12 @@ final class CreateBoardViewController: BaseViewController {
         owner.photoButton.isSelected = false
         owner.textButton.isSelected = false
         owner.photoAndTextButton.isSelected = true
+      }
+      .disposed(by: disposeBag)
+    
+    uploadButton.rx.tap
+      .subscribe(with: self) { owner, _ in
+        
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -18,6 +18,7 @@ final class CreateBoardViewController: BaseViewController {
     didSet {
       guard type != oldValue else { return }
       changedPostType(type: type)
+      checkUploadButtonActivated(type: type)
     }
   }
   
@@ -56,6 +57,7 @@ final class CreateBoardViewController: BaseViewController {
     $0.configurationUpdateHandler = $0.configuration?.plubButton(label: "글 업로드")
     $0.layer.cornerRadius = 10
     $0.layer.masksToBounds = true
+    $0.isEnabled = false
   }
   
   /// PostType에 따라 필요한 UI
@@ -173,11 +175,48 @@ final class CreateBoardViewController: BaseViewController {
       }
       .disposed(by: disposeBag)
     
+    titleInputTextView.textView.rx.text
+      .orEmpty
+      .subscribe(viewModel.writeTitle)
+      .disposed(by: disposeBag)
+    
+    boardContentInputTextView.textView.rx.text
+      .orEmpty
+      .subscribe(viewModel.writeContent)
+      .disposed(by: disposeBag)
+    
+//    addPhotoImageView.rx.image
+//      .subscribe(onNext: { image in
+//        print("이미지 \(image)")
+//      })
+//      .disposed(by: disposeBag)
+    
     viewModel.isSuccessCreateBoard
       .emit(with: self) { owner, _ in
         owner.navigationController?.popViewController(animated: true)
       }
       .disposed(by: disposeBag)
+  }
+  
+  private func checkUploadButtonActivated(type: PostType) {
+    switch type {
+    case .photo:
+      viewModel.onlyTextUploadButtonIsActivated
+        .drive(onNext: { isActivated in
+          print("뭐야1 \(isActivated)")
+        })
+        .disposed(by: disposeBag)
+    case .text:
+      viewModel.onlyTextUploadButtonIsActivated
+        .drive(uploadButton.rx.isEnabled)
+        .disposed(by: disposeBag)
+    case .photoAndText:
+      viewModel.onlyTextUploadButtonIsActivated
+        .drive(onNext: { isActivated in
+          print("뭐야3 \(isActivated)")
+        })
+        .disposed(by: disposeBag)
+    }
   }
   
   private func changedPostType(type: PostType) {

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -49,7 +49,12 @@ final class CreateBoardViewController: BaseViewController {
     $0.axis = .vertical
     $0.spacing = 8
   }
-
+  
+  private let uploadButton = UIButton(configuration: .plain()).then {
+    $0.configurationUpdateHandler = $0.configuration?.plubButton(label: "글 업로드")
+    $0.layer.cornerRadius = 10
+    $0.layer.masksToBounds = true
+  }
   
   /// PostType에 따라 필요한 UI
   private lazy var photoAddLabel = UILabel().then {
@@ -77,7 +82,7 @@ final class CreateBoardViewController: BaseViewController {
     [photoButton, textButton, photoAndTextButton].forEach { buttonStackView.addArrangedSubview($0) }
     
     [photoAddLabel, addPhotoImageView].forEach { boardTypeStackView.addArrangedSubview($0) }
-    [boardTypeLabel, buttonStackView, titleInputTextView, boardTypeStackView].forEach { view.addSubview($0) }
+    [boardTypeLabel, buttonStackView, titleInputTextView, boardTypeStackView, uploadButton].forEach { view.addSubview($0) }
   }
   
   override func setupConstraints() {
@@ -106,6 +111,12 @@ final class CreateBoardViewController: BaseViewController {
       $0.top.equalTo(titleInputTextView.snp.bottom).offset(24)
       $0.directionalHorizontalEdges.equalToSuperview().inset(16)
       $0.bottom.lessThanOrEqualToSuperview()
+    }
+    
+    uploadButton.snp.makeConstraints {
+      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(16)
+      $0.height.equalTo(46)
     }
   }
   

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -179,12 +179,28 @@ final class CreateBoardViewController: BaseViewController {
       .throttle(.seconds(1), scheduler: MainScheduler.instance)
       .subscribe(with: self) { owner, _ in
         guard let title = owner.titleInputTextView.textView.text else { return }
+        let request: BoardsRequest
+        switch owner.type {
+        case .photo:
+          request = BoardsRequest(
+            title: title,
+            content: nil,
+            feedImage: ""
+          )
+        case .text:
+          request = BoardsRequest(
+            title: title,
+            content: owner.boardContentInputTextView.textView.text,
+            feedImage: nil
+          )
+        case .photoAndText:
+          request = BoardsRequest(
+            title: title,
+            content: owner.boardContentInputTextView.textView.text,
+            feedImage: ""
+          )
+        }
         
-        let request = BoardsRequest(
-          title: title,
-          content: owner.boardContentInputTextView.textView.text,
-          feedImage: nil
-        )
         owner.viewModel.whichUpload.onNext(request)
       }
       .disposed(by: disposeBag)

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -1,0 +1,15 @@
+//
+//  CreateBoardViewController.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/03/17.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class CreateBoardViewController: UIViewController {
+  
+}

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -14,6 +14,13 @@ final class CreateBoardViewController: BaseViewController {
   
   private let boardTypeLabel = UILabel().then {
     $0.textColor = .black
+    $0.font = .subtitle
+    $0.text = "게시판 타입"
+  }
+  
+  private let buttonStackView = UIStackView().then {
+    $0.axis = .horizontal
+    $0.spacing = 8
   }
   
   private let photoButton: UIButton = UIButton(configuration: .plain()).then {
@@ -29,18 +36,66 @@ final class CreateBoardViewController: BaseViewController {
     $0.configurationUpdateHandler = $0.configuration?.list(label: "사진+글")
   }
   
-  private let titleLabel = UILabel().then {
-    $0.textColor = .black
+  private let titleInputTextView = InputTextView(title: "제목", placeHolder: "제목을 입력해주세요")
+  
+  private let boardTypeStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 8
   }
 
   private let photoAddLabel = UILabel().then {
     $0.textColor = .black
+    $0.font = .subtitle
+    $0.text = "사진 추가"
+  }
+  
+  private let addPhotoImageView = UIImageView().then {
+    $0.backgroundColor = .deepGray
+    $0.layer.cornerRadius = 10
+    $0.layer.masksToBounds = true
   }
   
   override func setupStyles() {
     super.setupStyles()
 
     self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "back"), style: .plain, target: self, action: #selector(didTappedBackButton))
+  }
+  
+  override func setupLayouts() {
+    super.setupLayouts()
+    [photoButton, textButton, photoAndTextButton].forEach { buttonStackView.addArrangedSubview($0) }
+    
+    [photoAddLabel, addPhotoImageView].forEach { boardTypeStackView.addArrangedSubview($0) }
+    [boardTypeLabel, buttonStackView, titleInputTextView, boardTypeStackView].forEach { view.addSubview($0) }
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    boardTypeLabel.snp.makeConstraints {
+      $0.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+      $0.leading.equalToSuperview().inset(16)
+    }
+    
+    buttonStackView.snp.makeConstraints {
+      $0.top.equalTo(boardTypeLabel.snp.bottom).offset(7.5)
+      $0.leading.equalTo(boardTypeLabel)
+      $0.trailing.lessThanOrEqualToSuperview()
+    }
+    
+    titleInputTextView.snp.makeConstraints {
+      $0.top.equalTo(buttonStackView.snp.bottom).offset(32.5)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(16)
+    }
+    
+    addPhotoImageView.snp.makeConstraints {
+      $0.height.equalTo(245)
+    }
+    
+    boardTypeStackView.snp.makeConstraints {
+      $0.top.equalTo(titleInputTextView.snp.bottom).offset(24)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(16)
+      $0.bottom.lessThanOrEqualToSuperview()
+    }
   }
   
   @objc private func didTappedBackButton() {

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -164,6 +164,15 @@ final class MainPageViewController: BaseViewController {
         owner.currentPage = index
       }
       .disposed(by: disposeBag)
+    
+    writeButton.rx.tap
+      .subscribe(with: self) { owner, _ in
+        let vc = CreateBoardViewController()
+        vc.navigationItem.largeTitleDisplayMode = .never
+        vc.title = "요란한 밧줄"
+        owner.navigationController?.pushViewController(vc, animated: true)
+      }
+      .disposed(by: disposeBag)
   }
   
   @objc func didTappedBackButton() {

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -167,7 +167,7 @@ final class MainPageViewController: BaseViewController {
     
     writeButton.rx.tap
       .subscribe(with: self) { owner, _ in
-        let vc = CreateBoardViewController()
+        let vc = CreateBoardViewController(plubbingID: owner.plubbingID)
         vc.navigationItem.largeTitleDisplayMode = .never
         vc.title = "요란한 밧줄"
         owner.navigationController?.pushViewController(vc, animated: true)

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/CreateBoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/CreateBoardViewModel.swift
@@ -46,6 +46,7 @@ final class CreateBoardViewModel: CreateBoardViewModelType {
     let writingTitle = BehaviorSubject<String>(value: "")
     let writingContent = BehaviorSubject<String>(value: "")
     let isSelectingImage = BehaviorSubject<Bool>(value: false)
+    let isSuccessCreatingBoard = PublishRelay<Int>()
     
     self.whichUpload = whichUploading.asObserver()
     self.selectMeeting = whichPlubbingID.asObserver()
@@ -63,14 +64,18 @@ final class CreateBoardViewModel: CreateBoardViewModelType {
       }
     
     let successCreateBoard = createBoard.compactMap { result -> BoardsResponse? in
-      print("결과 \(result)")
       guard case .success(let response) = result else { return nil }
       return response.data
     }
     
+    successCreateBoard
+      .subscribe(onNext: { data in
+        isSuccessCreatingBoard.accept(data.feedID)
+      })
+      .disposed(by: disposeBag)
+    
     // Output
-    isSuccessCreateBoard = successCreateBoard
-      .map { $0.feedID }
+    isSuccessCreateBoard = isSuccessCreatingBoard
       .asSignal(onErrorSignalWith: .empty())
     
     onlyTextUploadButtonIsActivated = Observable.combineLatest(

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/CreateBoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/CreateBoardViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  CreateBoardViewModel.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/03/18.
+//
+
+import RxSwift
+import RxCocoa
+
+final class CreateBoardViewModel {
+  
+}

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/CreateBoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/CreateBoardViewModel.swift
@@ -48,11 +48,11 @@ final class CreateBoardViewModel: CreateBoardViewModelType {
     let isSelectingImage = BehaviorSubject<Bool>(value: false)
     let isSuccessCreatingBoard = PublishRelay<Int>()
     
-    self.whichUpload = whichUploading.asObserver()
-    self.selectMeeting = whichPlubbingID.asObserver()
-    self.writeTitle = writingTitle.asObserver()
-    self.writeContent = writingContent.asObserver()
-    self.isSelectImage = isSelectingImage.asObserver()
+    whichUpload = whichUploading.asObserver()
+    selectMeeting = whichPlubbingID.asObserver()
+    writeTitle = writingTitle.asObserver()
+    writeContent = writingContent.asObserver()
+    isSelectImage = isSelectingImage.asObserver()
     
     // Input
     let createBoard = Observable.zip(

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/CreateBoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/CreateBoardViewModel.swift
@@ -8,6 +8,19 @@
 import RxSwift
 import RxCocoa
 
-final class CreateBoardViewModel {
+protocol CreateBoardViewModelType {
+  // Input
   
+  // Output
+}
+
+final class CreateBoardViewModel: CreateBoardViewModelType {
+  
+  // Input
+  
+  // Output
+  
+  init() {
+    
+  }
 }

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/CreateBoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/CreateBoardViewModel.swift
@@ -10,6 +10,7 @@ import RxCocoa
 
 protocol CreateBoardViewModelType {
   // Input
+  var uploadBoard: AnyObserver<Void> { get }
   
   // Output
 }
@@ -17,10 +18,12 @@ protocol CreateBoardViewModelType {
 final class CreateBoardViewModel: CreateBoardViewModelType {
   
   // Input
+  let uploadBoard: AnyObserver<Void>
   
   // Output
   
   init() {
-    
+    let uploadingBoard = PublishSubject<Void>()
+    self.uploadBoard = uploadingBoard.asObserver()
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/CreateBoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/CreateBoardViewModel.swift
@@ -11,6 +11,7 @@ import RxCocoa
 protocol CreateBoardViewModelType {
   // Input
   var whichUpload: AnyObserver<BoardsRequest> { get }
+  var selectMeeting: AnyObserver<Int> { get }
   
   // Output
   var isSuccessCreateBoard: Signal<Int> { get }
@@ -20,17 +21,25 @@ final class CreateBoardViewModel: CreateBoardViewModelType {
   
   // Input
   let whichUpload: AnyObserver<BoardsRequest>
+  let selectMeeting: AnyObserver<Int>
   
   // Output
   let isSuccessCreateBoard: Signal<Int>
   
   init() {
     let whichUploading = PublishSubject<BoardsRequest>()
-    self.whichUpload = whichUploading.asObserver()
+    let whichPlubbingID = PublishSubject<Int>()
     
-    let createBoard = whichUploading
-      .flatMapLatest { request in
-        return FeedsService.shared.createBoards(plubbingID: 0, model: request)
+    self.whichUpload = whichUploading.asObserver()
+    self.selectMeeting = whichPlubbingID.asObserver()
+    
+    // Input
+    let createBoard = Observable.zip(
+      whichPlubbingID,
+      whichUploading
+    )
+      .flatMapLatest { plubbingID, request in
+        return FeedsService.shared.createBoards(plubbingID: plubbingID, model: request)
       }
     
     let successCreateBoard = createBoard.compactMap { result -> BoardsResponse? in


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 메인페이지 게시글 생성 화면 UI 구현
- PostType에 따른 UI 구현
- PostType에 따른 서로 다른 업로드버튼 활성화 연동
- 업로드버튼 탭에 따른 게시글 등록
- 게시글 등록 이후 메인페이지 게시글목록 최신화
- 게시글타입에 따른 서로 다른 리퀘스트 적용

🌱 PR 포인트
- 업로드할 게시글에 대한 이미지뷰에 올린 이미지를 String으로 변환하는 코드를 어떻게 해야할지 몰라 일단 빈 문자열로 놔두었습니다, 추후에 변경하도록 하겠습니다 
- 위에 대한 이유로 텍스트가 필요없는 photo 혹은 photoAndText 타입일 경우에 content가 placeHolder가 들어가고있는데 이를 굳이 삭제안한 이유는 어차피 추후에 이미지에 대한 텍스트처리만 해준다면 업로드버튼 활성화가 될 경우는 원하는 항목을 전부 입력했을 경우이므로 고려하지않았습니다

## 📸 동작 영상
https://user-images.githubusercontent.com/39263235/226120717-2995164d-1d1c-48a2-aafe-17f89d47e52d.mp4

## 📮 관련 이슈
- Resolved: #220 

