### PR TITLE
[MOVE] Diffable DataSource 코드 이동

### DIFF
--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -136,7 +136,7 @@ final class BoardDetailViewController: BaseViewController {
     super.bind()
     collectionView.rx.setDelegate(self).disposed(by: disposeBag)
     
-    // 가져온 댓글을 가지고 Diffable DataSource에 전달
+    // ViewModel에게 `DiffableDataSource`처리를 해주기 위해 collectionView를 전달
     viewModel.setCollectionViewObserver.onNext(collectionView)
     
     // collectionView가 터치되면 first responder를 resign 시킴

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -18,9 +18,6 @@ final class BoardDetailViewController: BaseViewController {
   
   private let viewModel: BoardDetailViewModelType & BoardDetailDataStore
   
-  /// 게시글, 댓글에 대한 CollectionViewDiffableDataSource
-  private var dataSource: DataSource?
-  
   /// 터치 및 아래로 스와이프를 인식하기 위한 gesture recognizer
   private let panGesture = UIPanGestureRecognizer(target: BoardDetailViewController.self, action: nil)
   private let tapGesture = UITapGestureRecognizer(target: BoardDetailViewController.self, action: nil)
@@ -140,12 +137,7 @@ final class BoardDetailViewController: BaseViewController {
     collectionView.rx.setDelegate(self).disposed(by: disposeBag)
     
     // 가져온 댓글을 가지고 Diffable DataSource에 전달
-    viewModel.fetchAlertDriver
-      .drive(with: self) { owner, _ in
-        owner.setCollectionView()
-        owner.applyInitialSnapshots()
-      }
-      .disposed(by: disposeBag)
+    viewModel.setCollectionViewObserver.onNext(collectionView)
     
     // collectionView가 터치되면 first responder를 resign 시킴
     tapGesture.rx.event
@@ -196,68 +188,12 @@ extension BoardDetailViewController: UICollectionViewDelegateFlowLayout {
     // 첫 번째 section에만 게시글이 보이도록 설정
     guard section == 0 else { return .zero }
     // 동적 높이 처리
-    let headerRegistration = HeaderRegistration(elementKind: UICollectionView.elementKindSectionHeader) { [viewModel] supplementaryView, elementKind, indexPath in
+    let headerRegistration = BoardDetailViewModel.HeaderRegistration(elementKind: UICollectionView.elementKindSectionHeader) { [viewModel] supplementaryView, elementKind, indexPath in
       supplementaryView.configure(with: viewModel.content)
     }
     let indexPath = IndexPath(row: 0, section: section)
     let headerView = collectionView.dequeueConfiguredReusableSupplementary(using: headerRegistration, for: indexPath)
     return headerView.systemLayoutSizeFitting(CGSize(width: collectionView.frame.width, height: UIView.layoutFittingCompressedSize.height), withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel)
-  }
-}
-
-// MARK: - Diffable DataSource & Types
-
-private extension BoardDetailViewController {
-  
-  // MARK: Type Alias
-  
-  typealias Section = Int
-  typealias Item = CommentContent
-  typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
-  typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
-  
-  typealias CellRegistration = UICollectionView.CellRegistration<BoardDetailCollectionViewCell, CommentContent>
-  typealias HeaderRegistration = UICollectionView.SupplementaryRegistration<BoardDetailCollectionHeaderView>
-  
-  // MARK: Snapshot & DataSource Part
-  
-  /// Collection View를 세팅하며, `DiffableDataSource`를 초기화하여 해당 Collection View에 데이터를 지닌 셀을 처리합니다.
-  private func setCollectionView() {
-    
-    // 단어 그대로 `등록`처리 코드, 셀 후처리할 때 사용됨
-    let registration = CellRegistration { cell, _, item in
-      cell.configure(with: item)
-    }
-    
-    // Header View Registration, 헤더 뷰 후처리에 사용됨
-    let headerRegistration = HeaderRegistration(elementKind: UICollectionView.elementKindSectionHeader) { [viewModel] supplementaryView, elementKind, indexPath in
-      supplementaryView.configure(with: viewModel.content)
-    }
-    
-    // dataSource에 cell 등록
-    dataSource = DataSource(collectionView: collectionView) { collectionView, indexPath, item in
-      return collectionView.dequeueConfiguredReusableCell(using: registration, for: indexPath, item: item)
-    }
-    
-    // dataSource에 headerView도 등록
-    dataSource?.supplementaryViewProvider = .init { collectionView, elementKind, indexPath in
-      return collectionView.dequeueConfiguredReusableSupplementary(using: headerRegistration, for: indexPath)
-    }
-  }
-  
-  /// 초기 Snapshot을 설정합니다. DataSource가 초기화될 시 해당 메서드가 실행됩니다.
-  /// 직접 이 메서드를 실행할 필요는 없습니다.
-  private func applyInitialSnapshots() {
-    var snapshot = Snapshot()
-    
-    var sections = [-1] // 최소한 하나의 Section이라도 존재해야 함
-    sections.append(contentsOf: Array(Set(viewModel.comments.map { $0.groupID })).sorted())
-    snapshot.appendSections(sections)
-    
-    sections.forEach { sectionGroupID in
-      snapshot.appendItems(viewModel.comments.filter { $0.groupID == sectionGroupID }, toSection: sectionGroupID)
-    }
-    dataSource?.apply(snapshot)
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -12,39 +12,40 @@ import RxCocoa
 
 protocol BoardDetailViewModelType {
   // Input
-  
+  var setCollectionViewObserver: AnyObserver<UICollectionView> { get }
   // Output
-  var fetchAlertDriver: Driver<Void> { get }
 }
 
 protocol BoardDetailDataStore {
   var content: BoardModel { get }
   var comments: [CommentContent] { get }
+  /// 게시글, 댓글에 대한 CollectionViewDiffableDataSource
+  var dataSource: BoardDetailViewModel.DataSource? { get }
 }
 
 final class BoardDetailViewModel: BoardDetailViewModelType, BoardDetailDataStore {
   
-  // Output
-  let fetchAlertDriver: Driver<Void>
+  // Input
+  let setCollectionViewObserver: AnyObserver<UICollectionView>
   
   // MARK: - Properties
   
   let content: BoardModel
   var comments: [CommentContent] = []
   
-  private let requestCommentsSubject = PublishSubject<Void>()
+  private(set) var dataSource: DataSource?
   
   // MARK: - Initializations
   
   init(plubbingID: Int, content: BoardModel) {
     self.content = content
     
-    fetchAlertDriver = requestCommentsSubject.asDriver(onErrorDriveWith: .empty())
-    bind(plubbingID: plubbingID)
-  }
-  
-  private func bind(plubbingID: Int) {
-    FeedsService.shared.fetchComments(plubbingID: plubbingID, feedID: content.feedID, nextCursorID: comments.last?.commentID ?? 0)
+    let collectionViewSubject = PublishSubject<UICollectionView>()
+    
+    setCollectionViewObserver = collectionViewSubject.asObserver()
+    
+    
+    let commentsObservable = FeedsService.shared.fetchComments(plubbingID: plubbingID, feedID: content.feedID, nextCursorID: comments.last?.commentID ?? 0)
       .compactMap { result -> FeedsPaginatedDataResponse<CommentContent>? in
         // TODO: 승현 - API 통신 에러 처리
         guard case let .success(response) = result else { return nil }
@@ -52,12 +53,69 @@ final class BoardDetailViewModel: BoardDetailViewModelType, BoardDetailDataStore
       }
       .filter { [weak self] in $0.isLast == false || self?.comments.count == 0 }
       .map { $0.content }
-      .subscribe(with: self) { owner, model in
-        owner.comments.append(contentsOf: model)
-        owner.requestCommentsSubject.onNext(Void()) // content, comments가 전부 할당되었으므로 onNext로 알림
+    
+    Observable.combineLatest(collectionViewSubject.asObservable(), commentsObservable)
+      .subscribe(with: self) { owner, tuple in
+        owner.comments.append(contentsOf: tuple.1)
+        owner.setCollectionView(tuple.0)
+        owner.applyInitialSnapshots()
       }
       .disposed(by: disposeBag)
   }
   
   private let disposeBag = DisposeBag()
+}
+
+extension BoardDetailViewModel {
+  
+  // MARK: Type Alias
+  
+  typealias Section = Int
+  typealias Item = CommentContent
+  typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
+  typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
+  
+  typealias CellRegistration = UICollectionView.CellRegistration<BoardDetailCollectionViewCell, CommentContent>
+  typealias HeaderRegistration = UICollectionView.SupplementaryRegistration<BoardDetailCollectionHeaderView>
+  
+  // MARK: Snapshot & DataSource Part
+  
+  /// Collection View를 세팅하며, `DiffableDataSource`를 초기화하여 해당 Collection View에 데이터를 지닌 셀을 처리합니다.
+  private func setCollectionView(_ collectionView: UICollectionView) {
+    
+    // 단어 그대로 `등록`처리 코드, 셀 후처리할 때 사용됨
+    let registration = CellRegistration { cell, _, item in
+      cell.configure(with: item)
+    }
+    
+    // Header View Registration, 헤더 뷰 후처리에 사용됨
+    let headerRegistration = HeaderRegistration(elementKind: UICollectionView.elementKindSectionHeader) { [content] supplementaryView, elementKind, indexPath in
+      supplementaryView.configure(with: content)
+    }
+    
+    // dataSource에 cell 등록
+    dataSource = DataSource(collectionView: collectionView) { collectionView, indexPath, item in
+      return collectionView.dequeueConfiguredReusableCell(using: registration, for: indexPath, item: item)
+    }
+    
+    // dataSource에 headerView도 등록
+    dataSource?.supplementaryViewProvider = .init { collectionView, elementKind, indexPath in
+      return collectionView.dequeueConfiguredReusableSupplementary(using: headerRegistration, for: indexPath)
+    }
+  }
+  
+  /// 초기 Snapshot을 설정합니다. DataSource가 초기화될 시 해당 메서드가 실행됩니다.
+  /// 직접 이 메서드를 실행할 필요는 없습니다.
+  private func applyInitialSnapshots() {
+    var snapshot = Snapshot()
+    
+    var sections = [-1] // 최소한 하나의 Section이라도 존재해야 함
+    sections.append(contentsOf: Array(Set(comments.map { $0.groupID })).sorted())
+    snapshot.appendSections(sections)
+    
+    sections.forEach { sectionGroupID in
+      snapshot.appendItems(comments.filter { $0.groupID == sectionGroupID }, toSection: sectionGroupID)
+    }
+    dataSource?.apply(snapshot)
+  }
 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용

- Diffable DataSource 코드를 ViewController에서 관리했으나, API 연동 이후 로직을 작업하는 것에서 역할분리를 진행하기가 어려워 ViewModel로 코드를 이동했습니다.

## 📮 관련 이슈
- #211

