### PR TITLE
댓글 페이징 구현

### DIFF
--- a/PLUB/Sources/Models/Feeds/CommentContent.swift
+++ b/PLUB/Sources/Models/Feeds/CommentContent.swift
@@ -87,3 +87,5 @@ extension CommentContent: Hashable {
     hasher.combine(identifier)
   }
 }
+
+extension CommentContent: Equatable { }

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -139,6 +139,14 @@ final class BoardDetailViewController: BaseViewController {
     // ViewModel에게 `DiffableDataSource`처리를 해주기 위해 collectionView를 전달
     viewModel.setCollectionViewObserver.onNext(collectionView)
     
+    // 페이징 처리 - 현재 보이는 셀들 중 마지막 셀의 IndexPath를 전달
+    collectionView.rx.contentOffset
+      .compactMap { [weak self] offset in
+        return self?.collectionView.indexPathsForVisibleItems.max()
+      }
+      .bind(to: viewModel.bottomCellObserver)
+      .disposed(by: disposeBag)
+    
     // collectionView가 터치되면 first responder를 resign 시킴
     tapGesture.rx.event
       .asDriver()

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -81,14 +81,17 @@ final class BoardDetailViewModel: BoardDetailViewModelType, BoardDetailDataStore
       }
     
     // 첫 세팅 작업
-    Observable.combineLatest(collectionViewSubject.asObservable(), commentsObservable)
-      .subscribe(with: self) { owner, tuple in
-        owner.isLast = tuple.1.isLast
-        owner.comments.append(contentsOf: tuple.1.content)
-        owner.setCollectionView(tuple.0)
-        owner.applyInitialSnapshots()
-      }
-      .disposed(by: disposeBag)
+    Observable.combineLatest(collectionViewSubject.asObservable(), commentsObservable) {
+      return (collectionView: $0, commentsData: $1)
+    }
+    .take(1)  // 첫 세팅 작업이니만큼 한 번만 실행되어야 합니다.
+    .subscribe(with: self) { owner, tuple in
+      owner.isLast = tuple.commentsData.isLast
+      owner.comments.append(contentsOf: tuple.commentsData.content)
+      owner.setCollectionView(tuple.collectionView)
+      owner.applyInitialSnapshots()
+    }
+    .disposed(by: disposeBag)
     
     // == create comments part ==
     commentInputSubject

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -23,9 +23,6 @@ protocol BoardDetailViewModelType {
 protocol BoardDetailDataStore {
   var content: BoardModel { get }
   var comments: [CommentContent] { get }
-  
-  /// 게시글, 댓글에 대한 CollectionViewDiffableDataSource
-  var dataSource: BoardDetailViewModel.DataSource? { get }
 }
 
 final class BoardDetailViewModel: BoardDetailViewModelType, BoardDetailDataStore {
@@ -39,7 +36,8 @@ final class BoardDetailViewModel: BoardDetailViewModelType, BoardDetailDataStore
   let content: BoardModel
   var comments: [CommentContent] = []
   
-  private(set) var dataSource: DataSource?
+  /// 게시글, 댓글에 대한 CollectionViewDiffableDataSource
+  private var dataSource: DataSource?
   
   /// 현재 마지막 커서(페이지)인지 판단할 때 사용합니다.
   private var isLast = false

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -47,6 +47,9 @@ final class BoardDetailViewModel: BoardDetailViewModelType, BoardDetailDataStore
   /// 현재 마지막 커서(페이지)인지 판단할 때 사용합니다.
   private var isLast = false
   
+  /// API를 요청하는 중인지 확인합니다.
+  private var isFetching = false
+  
   // MARK: - Initializations
   
   init(plubbingID: Int, content: BoardModel) {

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -79,7 +79,6 @@ final class BoardDetailViewModel: BoardDetailViewModelType, BoardDetailDataStore
         guard case let .success(response) = result else { return nil }
         return response.data
       }
-      .filter { [weak self] in $0.isLast == false || self?.comments.count == 0 }
     
     // 첫 세팅 작업
     Observable.combineLatest(collectionViewSubject.asObservable(), commentsObservable)

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -13,8 +13,12 @@ import RxCocoa
 protocol BoardDetailViewModelType {
   
   // Input
+  
   /// ViewController 단에서 initialized된 collectionView를 받습니다.
   var setCollectionViewObserver: AnyObserver<UICollectionView> { get }
+  
+  /// 보여지는 댓글 Cell 중 제일 밑의 셀의 IndexPath를 받습니다.
+  var bottomCellObserver: AnyObserver<IndexPath> { get }
   
   /// 사용자의 댓글을 입력합니다.
   var commentsInput: AnyObserver<(comment: String, parentID: Int?)> { get }
@@ -30,6 +34,7 @@ final class BoardDetailViewModel: BoardDetailViewModelType, BoardDetailDataStore
   // Input
   let setCollectionViewObserver: AnyObserver<UICollectionView>
   let commentsInput: AnyObserver<(comment: String, parentID: Int?)>
+  let bottomCellObserver: AnyObserver<IndexPath>
   
   // MARK: - Properties
   
@@ -49,9 +54,11 @@ final class BoardDetailViewModel: BoardDetailViewModelType, BoardDetailDataStore
     
     let collectionViewSubject = PublishSubject<UICollectionView>()
     let commentInputSubject   = PublishSubject<(comment: String, parentID: Int?)>()
+    let bottomCellSubject     = PublishSubject<IndexPath>()
     
     setCollectionViewObserver = collectionViewSubject.asObserver()
     commentsInput = commentInputSubject.asObserver()
+    bottomCellObserver = bottomCellSubject.asObserver()
     
     // == fetching comments part ==
     let commentsObservable = FeedsService.shared.fetchComments(plubbingID: plubbingID, feedID: content.feedID, nextCursorID: comments.last?.commentID ?? 0)


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용

- 페이징 작업 중 snapshot 수정 메서드가 중복으로 만들어지는 모습이 보였고, 이를 `updateSnapshots()`라는 메서드로 통일
   - `updateSnapshots()`을 적용하기 위해 comments가 수정될 때마다 `didSet`을 이용하여 자동으로 호출되도록 변경(기존에는 comments도 수정하고, snapshot 수정 코드가 들어간 함수를 호출하는 방식이었음)
   - `updateSnapshots()`에서는 snapshot에 들어가있지 않은 Model을 판별해야 하기에, CommentContent가 Equatable을 준수하도록 설정했습니다.
```diff

// codes..
      .subscribe(with: self) { owner, comment in
        // 일반 댓글은 단순 append
        if comment.type == .normal {
          owner.comments.append(comment)
        } else {
          // 작성된 답글은 마지막 답글 뒤에 insert
          let index = owner.comments.map { $0.groupID }.lastIndex(of: comment.groupID)!
          owner.comments.insert(comment, at: index + 1)
        }
-        owner.addCommentToGroup(comment)
      }
      .disposed(by: disposeBag)
```

🌱 PR 포인트

- 댓글 페이징 작업은 아래 다이어그램의 플로우와 동일하게 구현되었습니다.

## 📸 스크린샷

### 페이징 작업 다이어그램

![image](https://user-images.githubusercontent.com/57972338/228882358-f8dfd5c6-6a5a-452e-9f6e-2150651cc41f.png)

### 시연 영상

https://user-images.githubusercontent.com/57972338/228869075-a7867889-9226-4466-b9f3-2ac0d90b4369.MP4

## 📮 관련 이슈

- #211

## P.S.

init 내부 코드가 너무 길어져서 PR이 성공적으로 closed되면, 리팩토링하여 PR 올리도록 하겠습니다.

