### PR TITLE
페이징 리팩토링(+PageManager)

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		BA42D1F528EDE11900C20061 /* MeetingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA42D1F428EDE11900C20061 /* MeetingViewController.swift */; };
 		BA46CC9F28EC9B05004953B1 /* Ex+UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA46CC9D28EC9B05004953B1 /* Ex+UIColor.swift */; };
 		BA46CCA028EC9B05004953B1 /* Ex+UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA46CC9E28EC9B05004953B1 /* Ex+UIButton.swift */; };
+		BA4BD1AE29D6C4A800334C04 /* PagingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4BD1AD29D6C4A800334C04 /* PagingManager.swift */; };
 		BA4C46CA297ADB5900C914F3 /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C46C9297ADB5900C914F3 /* ProfileViewModel.swift */; };
 		BA4DADB3295747E700C7ABD7 /* PageControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4DADB2295747E700C7ABD7 /* PageControl.swift */; };
 		BA52778428EECDC50036B825 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA52777B28EECDC50036B825 /* Pretendard-Medium.otf */; };
@@ -445,6 +446,7 @@
 		BA42D1F428EDE11900C20061 /* MeetingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingViewController.swift; sourceTree = "<group>"; };
 		BA46CC9D28EC9B05004953B1 /* Ex+UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Ex+UIColor.swift"; sourceTree = "<group>"; };
 		BA46CC9E28EC9B05004953B1 /* Ex+UIButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Ex+UIButton.swift"; sourceTree = "<group>"; };
+		BA4BD1AD29D6C4A800334C04 /* PagingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingManager.swift; sourceTree = "<group>"; };
 		BA4C46C9297ADB5900C914F3 /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
 		BA4DADB2295747E700C7ABD7 /* PageControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageControl.swift; sourceTree = "<group>"; };
 		BA52777B28EECDC50036B825 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
@@ -1120,6 +1122,7 @@
 			isa = PBXGroup;
 			children = (
 				BA117A3C297440D900B37E03 /* UserManager.swift */,
+				BA4BD1AD29D6C4A800334C04 /* PagingManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -2212,6 +2215,7 @@
 				C3ED8FB72989B87E002F689B /* CreateMeetingResponse.swift in Sources */,
 				BA88125028E48A2F00BD832A /* SceneDelegate.swift in Sources */,
 				C344E5412986B9D7009F73A9 /* MeetingCategoryViewModel.swift in Sources */,
+				BA4BD1AE29D6C4A800334C04 /* PagingManager.swift in Sources */,
 				7028770929AA6B3D00E57509 /* CategoryMeetingRequest.swift in Sources */,
 				BAC5EF2F298AA23700F3955E /* SplashViewModel.swift in Sources */,
 				C38A5B95297AD5B000485355 /* KakaoLocationRouter.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -2490,8 +2490,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 7.0.0;
+				branch = master;
+				kind = branch;
 			};
 		};
 		BA117A4C297444EE00B37E03 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {

--- a/PLUB/Configuration/Manager/PagingManager.swift
+++ b/PLUB/Configuration/Manager/PagingManager.swift
@@ -17,7 +17,7 @@ final class PagingManager<T> {
   private var isFetching = false
   
   /// 이미 마지막 페이지에 도달했는지 여부를 판단합니다.
-  private var isLast = false
+  private(set) var isLast = false
   
   /// 임계값입니다. 마지막 셀로부터 `threshold`번째 앞인 셀이 보이는 경우 Fetch 조건에 해당하게 됩니다.
   private var threshold: Int

--- a/PLUB/Configuration/Manager/PagingManager.swift
+++ b/PLUB/Configuration/Manager/PagingManager.swift
@@ -1,0 +1,58 @@
+//
+//  PagingManager.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/03/31.
+//
+
+import UIKit
+
+import RxSwift
+import RxCocoa
+
+/// 페이징 처리를 위한 관리자 클래스 입니다.
+final class PagingManager<T> {
+  
+  /// API 호출 중인지 판단합니다.
+  private var isFetching = false
+  
+  /// 이미 마지막 페이지에 도달했는지 여부를 판단합니다.
+  private var isLast = false
+  
+  /// 임계값입니다. 마지막 셀로부터 `threshold`번째 앞인 셀이 보이는 경우 Fetch 조건에 해당하게 됩니다.
+  private var threshold: Int
+  
+  /// 다음 요청할 커서의 `Identifier`입니다.
+  private var nextCursorID = 0
+  
+  init(threshold: Int) {
+    self.threshold = threshold
+  }
+  
+  /// 다음 페이지를 가져올지 여부를 결정합니다.
+  ///
+  /// - Parameters:
+  ///   - currentIndex: 현재 아이템의 인덱스입니다.
+  ///   - totalItems: 전체 아이템 개수입니다.
+  /// - Returns: 다음 페이지를 가져올지 여부를 반환합니다.
+  func shouldFetchNextPage(currentIndex: Int, totalItems: Int) -> Bool {
+    return !isFetching && !isLast && totalItems - currentIndex <= threshold
+  }
+  
+  /// 다음 페이지를 가져옵니다.
+  ///
+  /// - Parameter fetch: 다음 페이지를 가져오는 함수입니다. 커서 ID를 입력으로 받고, 컨텐츠, 다음 커서 ID, 마지막 페이지 여부를 반환합니다.
+  /// - Returns: 다음 페이지의 컨텐츠를 반환하는 `Observable`입니다.
+  func fetchNextPage(fetch: @escaping (Int) -> Observable<(content: [T], nextCursorID: Int, isLast: Bool)>) -> Observable<[T]> {
+    guard !isFetching else { return .empty() }
+    isFetching = true
+    
+    return fetch(nextCursorID)
+      .do(onNext: { [weak self] items, nextCursorID, isLast in
+        self?.isFetching = false
+        self?.isLast = isLast
+        self?.nextCursorID = nextCursorID
+      })
+      .map { $0.content }
+  }
+}

--- a/PLUB/Configuration/Manager/PagingManager.swift
+++ b/PLUB/Configuration/Manager/PagingManager.swift
@@ -32,11 +32,11 @@ final class PagingManager<T> {
   /// 다음 페이지를 가져올지 여부를 결정합니다.
   ///
   /// - Parameters:
-  ///   - currentIndex: 현재 아이템의 인덱스입니다.
-  ///   - totalItems: 전체 아이템 개수입니다.
+  ///   - totalHeight: collectionView(tableView)의 전체 높이
+  ///   - offsetHeight: 보여지고 있는 컨텐츠의 y 위치
   /// - Returns: 다음 페이지를 가져올지 여부를 반환합니다.
-  func shouldFetchNextPage(currentIndex: Int, totalItems: Int) -> Bool {
-    return !isFetching && !isLast && totalItems - currentIndex <= threshold
+  func shouldFetchNextPage(totalHeight: CGFloat, offset: CGFloat) -> Bool {
+    return !isFetching && !isLast && totalHeight - offset <= CGFloat(threshold)
   }
   
   /// 다음 페이지를 가져옵니다.

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -139,7 +139,7 @@ final class BoardDetailViewController: BaseViewController {
     // ViewModel에게 `DiffableDataSource`처리를 해주기 위해 collectionView를 전달
     viewModel.setCollectionViewObserver.onNext(collectionView)
     
-    // 페이징 처리 - 현재 보이는 셀들 중 마지막 셀의 IndexPath를 전달
+    // 페이징 처리 - 현재 사용자가 바로보고있는 Offset의 y값과 실제 CollectionView의 높이값을 전달
     collectionView.rx.contentOffset
       .compactMap { [weak self] offset in
         guard let self else { return nil }

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -142,9 +142,10 @@ final class BoardDetailViewController: BaseViewController {
     // 페이징 처리 - 현재 보이는 셀들 중 마지막 셀의 IndexPath를 전달
     collectionView.rx.contentOffset
       .compactMap { [weak self] offset in
-        return self?.collectionView.indexPathsForVisibleItems.max()
+        guard let self else { return nil }
+        return (self.collectionView.contentSize.height, offset.y)
       }
-      .bind(to: viewModel.bottomCellObserver)
+      .bind(to: viewModel.offsetObserver)
       .disposed(by: disposeBag)
     
     // collectionView가 터치되면 first responder를 resign 시킴

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -59,6 +59,9 @@ final class BoardDetailViewModel: BoardDetailViewModelType, BoardDetailDataStore
   /// API를 요청하는 중인지 확인합니다.
   private var isFetching = false
   
+  /// 페이징 관리 객체
+  private let pagingManager = PagingManager<CommentContent>(threshold: 5)
+  
   // MARK: - Initializations
   
   init(plubbingID: Int, content: BoardModel) {

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -94,7 +94,8 @@ extension BoardDetailViewModel {
         .compactMap { result -> (content: [CommentContent], nextCursorID: Int, isLast: Bool)? in
           // TODO: 승현 - API 통신 에러 처리
           guard case let .success(response) = result else { return nil }
-          return (content: response.data!.content, nextCursorID: response.data!.content.last!.commentID, isLast: response.data!.isLast)
+          guard let data = response.data else { return nil }
+          return (content: data.content, nextCursorID: data.content.last?.commentID ?? 0, isLast: data.isLast)
         }
     }
     
@@ -161,7 +162,9 @@ extension BoardDetailViewModel {
           FeedsService.shared.fetchComments(plubbingID: plubbingID, feedID: content.feedID, nextCursorID: cursorID)
             .compactMap { result -> (content: [CommentContent], nextCursorID: Int, isLast: Bool)? in
               guard case let .success(response) = result else { return nil }
-              return (content: response.data!.content, nextCursorID: response.data!.content.last!.commentID, isLast: response.data!.isLast)
+              guard let data = response.data else { return nil }
+              // 페이징 작업시 발생하는 데이터의 마지막 요소(last)는 항상 값이 존재하므로 force-unwrapping을 사용.
+              return (content: data.content, nextCursorID: data.content.last!.commentID, isLast: data.isLast)
             }
         }
       }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 페이징 작업을 담당 및 관장하는 `PagingManager`를 구현
   - ViewModel의 책임에서 분리함으로써 코드 재사용성이 높아졌습니다.
- IndexPath 기반 Paging 코드를 Offset 기반 Paging 코드로 변경하면서 성능 향상을 기대할 수 있게 되었습니다.
   - O(N) -> O(1)

🌱 PR 포인트
- `PagingManager`는 Paging만을 목적으로 구현하게 되어서 나중에 `Pull To Refresh`작업을 하게 된다면 좀 더 고도화를 해야할 것 같습니다. 이 부분은 인지하시고 사용해 주시면 됩니다. :)

### PagingManager 톺아보기

PagingManager는 initializer로 Int 타입을 받습니다.

```swift
let pagingManager = PagingManager<CommentContent>(threshold: 700)
```

threshold는 사용자가 스크롤한 양을 판단하기 위한 값입니다. 스크롤뷰의 높이를 기준으로 사용자가 스크롤한 값의 차이가 threshold 값 이하일 때, PagingManager는 추가적인 데이터를 가져오기 위한 조건을 `true`로 설정하게 됩니다.

> threshold를 설정하게 된 계기는, 사용자 경험을 위해서였습니다. 스크롤을 전부 내려야 비로소 API를 요청하여 가져오는 것 보다, 어느 정도의 위치에 도달했을 때 미리 API를 요청하여 셀을 update해주는 것이 더 좋다고 판단했습니다.

#### shouldFetchNextPage(totalHeight:offset:)

페이징 처리 시도를 요청합니다. 현재 처리를 해도 된다면 `true`를 리턴하고, 아닐 경우 `false`를 리턴합니다.

####  fetchNextPage(fetch:)

페이징 처리를 시도합니다.



### PagingManager를 이용하여 페이징 처리하는 방법

PagingManager의 사용법은 3단계로 구성되어 있습니다. 

1. ScrollView의 실제 높이 값과 사용자가 보는 Offset.y 값을 전달
2. ViewModel에서 PagingManager에게 Paging 가능 여부를 요청
3. 가능하면 요청을 시도하고 새로운 모델값을 처리

---

1. ScrollView(CollectionView 또는 TableView를 통칭)의 실제 높이 값과, 사용자가 보고있는 Offset.y값을 전달(horizontal scroll을 지원한다면, 가로값과 offset.x값을 사용).
```swift
// ViewController Part

// 페이징 처리 - 현재 사용자가 바로보고있는 Offset의 y값과 실제 CollectionView의 높이값을 전달
collectionView.rx.contentOffset
  .compactMap { [weak self] offset in
    guard let self else { return nil }
    return (self.collectionView.contentSize.height, offset.y)
  }
  .bind(to: viewModel.offsetObserver)
  .disposed(by: disposeBag)
```

2. ViewModel에서 PagingManager에게 Paging가능 여부를 요청.

```swift
offsetObservable
  .filter { [weak self] in // pagingManager에게 fetching 가능한지 요청
    guard let self else { return false }
    return self.pagingManager.shouldFetchNextPage(totalHeight: $0, offset: $1)
  }
```

3. 가능하면 요청을 시도하고 새로운 모델값을 처리(여기서 T는 페이징 작업을 하기 위한 제네릭 모델).

> **Note**: 요청 시도에 성공했다면, `(content:nextCursorID:isLast)`타입의 튜플 값을 반환해주어야 합니다.

```swift
// 위 코드와 이어집니다.
  .flatMap { [weak self] _ -> Observable<[T]> in
    guard let self else { return .empty() }
    return self.pagingManager.fetchNextPage { cursorID in // pagingManager에서 cursorID를 내려줌
      FeedsService.shared.fetchComments(plubbingID: plubbingID, feedID: content.feedID, nextCursorID: cursorID)
        .compactMap { result -> (content: [T], nextCursorID: Int, isLast: Bool)? in
          guard case let .success(response) = result else { return nil }
          guard let data = response.data else { return nil }
          return (content: data.content, nextCursorID: data.content.last?.commentID ?? 0, isLast: data.isLast)
        }
    }
  }
```

guard case let 대신에 switch문을 쓰게 된다면 다음과 같이 작성.
```swift
// 위 코드와 이어집니다.
  .flatMap { [weak self] _ -> Observable<[T]> in
    guard let self else { return .empty() }
    return self.pagingManager.fetchNextPage { cursorID in
      FeedsService.shared.fetchComments(plubbingID: plubbingID, feedID: content.feedID, nextCursorID: cursorID)
        .compactMap { result in
          switch result {
          case .success(let response):
            guard let data = response.data else { return nil }
            return (content: data.content, nextCursorID: data.content.last?.commentID ?? 0, isLast: data.isLast)
          default:
            return nil
          }
        }
    }
  }
```

4. 페이징으로 받은 새로운 모델값을 처리합니다.

```swift
  // 위 코드와 이어집니다.
  .subscribe(with: self) { owner, content in
    // codes..
  }
  .disposed(by: disposeBag)
```

## 📸 스크린샷

- #242 와 동일

## 📮 관련 이슈

- #211

## P.S.

설명을 너무 어렵게 적어놓은 것 같네요.. 직접 적용한 코드는 아래에 적어두었습니다. 살펴보시면 좋을 것 같아요. 😅
https://github.com/PLUB2022/PLUB-iOS/blob/f318748a6fa6dfef869e93c7fe4024d083d7a5c6/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift#L154-L174

