### PR TITLE
[FEAT] 마이페이지 > 대기중인 모임 구현

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -324,6 +324,7 @@
 		C3EB29CF29A9AB5C00615B6B /* ScheduleDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EB29CE29A9AB5C00615B6B /* ScheduleDateView.swift */; };
 		C3EC027D29D9582D0024C962 /* WaitingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EC027C29D9582D0024C962 /* WaitingViewController.swift */; };
 		C3EC027F29D958960024C962 /* WaitingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EC027E29D958960024C962 /* WaitingViewModel.swift */; };
+		C3EC028129D95FAC0024C962 /* MyApplicationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EC028029D95FAC0024C962 /* MyApplicationResponse.swift */; };
 		C3ED8FB52989B189002F689B /* CreateMeetingRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ED8FB42989B189002F689B /* CreateMeetingRequest.swift */; };
 		C3ED8FB72989B87E002F689B /* CreateMeetingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ED8FB62989B87E002F689B /* CreateMeetingResponse.swift */; };
 		C3ED8FB92989E13D002F689B /* MeetingSummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ED8FB82989E13D002F689B /* MeetingSummaryViewModel.swift */; };
@@ -638,6 +639,7 @@
 		C3EB29CE29A9AB5C00615B6B /* ScheduleDateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleDateView.swift; sourceTree = "<group>"; };
 		C3EC027C29D9582D0024C962 /* WaitingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingViewController.swift; sourceTree = "<group>"; };
 		C3EC027E29D958960024C962 /* WaitingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingViewModel.swift; sourceTree = "<group>"; };
+		C3EC028029D95FAC0024C962 /* MyApplicationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyApplicationResponse.swift; sourceTree = "<group>"; };
 		C3ED8FB42989B189002F689B /* CreateMeetingRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetingRequest.swift; sourceTree = "<group>"; };
 		C3ED8FB62989B87E002F689B /* CreateMeetingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetingResponse.swift; sourceTree = "<group>"; };
 		C3ED8FB82989E13D002F689B /* MeetingSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSummaryViewModel.swift; sourceTree = "<group>"; };
@@ -1763,6 +1765,7 @@
 				702876BA299E4DBA00E57509 /* BookmarkAllResponse.swift */,
 				70727A2829C709E9003DE956 /* ApplyForRecruitmentResponse.swift */,
 				C3E0390929C2125700C4744C /* InquireApplicantResponse.swift */,
+				C3EC028029D95FAC0024C962 /* MyApplicationResponse.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -2084,6 +2087,7 @@
 				C3B04E4229816B9C00188E60 /* ImageRouter.swift in Sources */,
 				BA8E2B4429746738009DDF32 /* AuthRouter.swift in Sources */,
 				BA94E81C297E706A00DF23CE /* IntroductionViewModel.swift in Sources */,
+				C3EC028129D95FAC0024C962 /* MyApplicationResponse.swift in Sources */,
 				702876BB299E4DBA00E57509 /* BookmarkAllResponse.swift in Sources */,
 				70A420A9298D89A40026E9F9 /* RecentSearchListHeaderView.swift in Sources */,
 				70A420BD29914B690026E9F9 /* DetailRecruitmentResponse.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -322,6 +322,8 @@
 		C3EB29CB29A91CC600615B6B /* MeetingScheduleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EB29CA29A91CC600615B6B /* MeetingScheduleViewModel.swift */; };
 		C3EB29CD29A9A4D400615B6B /* ScheduleDetailContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EB29CC29A9A4D400615B6B /* ScheduleDetailContentView.swift */; };
 		C3EB29CF29A9AB5C00615B6B /* ScheduleDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EB29CE29A9AB5C00615B6B /* ScheduleDateView.swift */; };
+		C3EC027D29D9582D0024C962 /* WaitingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EC027C29D9582D0024C962 /* WaitingViewController.swift */; };
+		C3EC027F29D958960024C962 /* WaitingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EC027E29D958960024C962 /* WaitingViewModel.swift */; };
 		C3ED8FB52989B189002F689B /* CreateMeetingRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ED8FB42989B189002F689B /* CreateMeetingRequest.swift */; };
 		C3ED8FB72989B87E002F689B /* CreateMeetingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ED8FB62989B87E002F689B /* CreateMeetingResponse.swift */; };
 		C3ED8FB92989E13D002F689B /* MeetingSummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ED8FB82989E13D002F689B /* MeetingSummaryViewModel.swift */; };
@@ -634,6 +636,8 @@
 		C3EB29CA29A91CC600615B6B /* MeetingScheduleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingScheduleViewModel.swift; sourceTree = "<group>"; };
 		C3EB29CC29A9A4D400615B6B /* ScheduleDetailContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleDetailContentView.swift; sourceTree = "<group>"; };
 		C3EB29CE29A9AB5C00615B6B /* ScheduleDateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleDateView.swift; sourceTree = "<group>"; };
+		C3EC027C29D9582D0024C962 /* WaitingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingViewController.swift; sourceTree = "<group>"; };
+		C3EC027E29D958960024C962 /* WaitingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingViewModel.swift; sourceTree = "<group>"; };
 		C3ED8FB42989B189002F689B /* CreateMeetingRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetingRequest.swift; sourceTree = "<group>"; };
 		C3ED8FB62989B87E002F689B /* CreateMeetingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetingResponse.swift; sourceTree = "<group>"; };
 		C3ED8FB82989E13D002F689B /* MeetingSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSummaryViewModel.swift; sourceTree = "<group>"; };
@@ -1362,6 +1366,7 @@
 				C3100CBD29BD94DC005FCCAD /* Cell */,
 				C3100CBA29BD8A96005FCCAD /* Component */,
 				C3E0390629C2087000C4744C /* Recruiting */,
+				C3EC027B29D958070024C962 /* Waiting */,
 			);
 			path = MyPage;
 			sourceTree = "<group>";
@@ -1855,6 +1860,15 @@
 			path = Cell;
 			sourceTree = "<group>";
 		};
+		C3EC027B29D958070024C962 /* Waiting */ = {
+			isa = PBXGroup;
+			children = (
+				C3EC027C29D9582D0024C962 /* WaitingViewController.swift */,
+				C3EC027E29D958960024C962 /* WaitingViewModel.swift */,
+			);
+			path = Waiting;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -2099,6 +2113,7 @@
 				C38A5BA7297C549A00485355 /* LocationBaseView.swift in Sources */,
 				BA8E2B46297467A2009DDF32 /* AuthService.swift in Sources */,
 				BAC923DF29546BF500385841 /* BirthViewController.swift in Sources */,
+				C3EC027D29D9582D0024C962 /* WaitingViewController.swift in Sources */,
 				70A420B329914B370026E9F9 /* SubCategoryListResponse.swift in Sources */,
 				BA88125228E48A2F00BD832A /* HomeViewController.swift in Sources */,
 				BA340E2529782356002BAF2C /* ProfileViewController.swift in Sources */,
@@ -2120,6 +2135,7 @@
 				705F81C529AFAA5200830C4F /* TodolistViewController.swift in Sources */,
 				C3CD674E29B4DD9C0052087E /* ScheduleParticipantTopView.swift in Sources */,
 				BA340E2029782301002BAF2C /* LeftAlignedCollectionViewFlowLayout.swift in Sources */,
+				C3EC027F29D958960024C962 /* WaitingViewModel.swift in Sources */,
 				BA8AA42D2988FCC3004E9403 /* OnboardingViewController.swift in Sources */,
 				C3413E15299548FB004B8DBD /* RecruitPostViewController.swift in Sources */,
 				BA88126228E48A5800BD832A /* BaseViewController.swift in Sources */,

--- a/PLUB/Sources/Models/MyPage/Response/MyPlubbingResponse.swift
+++ b/PLUB/Sources/Models/MyPage/Response/MyPlubbingResponse.swift
@@ -16,7 +16,7 @@ enum PlubbingStatusType: String, CaseIterable {
 
 struct MyPlubbingResponse: Codable {
   let plubbingStatus: PlubbingStatusType.RawValue
-  let plubbings: [MyPagePlubbing]
+  var plubbings: [MyPagePlubbing]
   
   enum CodingKeys: String, CodingKey {
     case plubbingStatus

--- a/PLUB/Sources/Models/Recruitment/Response/MyApplicationResponse.swift
+++ b/PLUB/Sources/Models/Recruitment/Response/MyApplicationResponse.swift
@@ -1,0 +1,34 @@
+//
+//  MyApplicationResponse.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/04/02.
+//
+
+import Foundation
+
+struct MyApplicationResponse: Codable {
+  let date: String
+  let plubbingInfo: PlubbingInfo
+  let answers: [Answer]
+  enum CodingKeys: String, CodingKey {
+    case plubbingInfo, answers
+    case date = "recruitDate"
+  }
+}
+
+struct PlubbingInfo: Codable {
+  let plubbingID: Int
+  let name: String
+  let days: [String]
+  let address: String?
+  let roadAddress: String?
+  let placeName: String?
+  let goal: String
+  let time: String
+  
+  enum CodingKeys: String, CodingKey {
+    case plubbingID = "plubbingId"
+    case name, days, address, roadAddress, placeName, goal, time
+  }
+}

--- a/PLUB/Sources/Network/Routers/RecruitmentRouter.swift
+++ b/PLUB/Sources/Network/Routers/RecruitmentRouter.swift
@@ -19,17 +19,21 @@ enum RecruitmentRouter {
   case inquireApplicant(Int)
   case approvalApplicant(Int, Int)
   case refuseApplicant(Int, Int)
+  case inquireMyApplication(Int)
+  case cancelApplication(Int)
 }
 
 extension RecruitmentRouter: Router {
   var method: HTTPMethod {
     switch self {
-    case .inquireDetailRecruitment, .inquireRecruitmentQuestion, .inquireAllBookmark, .searchRecruitment, .inquireApplicant:
+    case .inquireDetailRecruitment, .inquireRecruitmentQuestion, .inquireAllBookmark, .searchRecruitment, .inquireApplicant, .inquireMyApplication:
       return .get
     case .requestBookmark, .applyForRecruitment, .approvalApplicant, .refuseApplicant:
       return .post
     case .editMeetingPost, .editMeetingQuestion:
       return .put
+    case .cancelApplication:
+      return .delete
     }
   }
   
@@ -57,12 +61,14 @@ extension RecruitmentRouter: Router {
       return "/plubbings/\(plubbingID)/recruit/applicants/\(accountID)/approval"
     case .refuseApplicant(let plubbingID, let accountID):
       return "/plubbings/\(plubbingID)/recruit/applicants/\(accountID)/refuse"
+    case .inquireMyApplication(let plubbingID), .cancelApplication(let plubbingID):
+      return "/plubbings/\(plubbingID)/recruit/applicants/me"
     }
   }
   
   var parameters: ParameterType {
     switch self {
-    case .inquireDetailRecruitment, .inquireRecruitmentQuestion, .inquireAllBookmark, .requestBookmark, .inquireApplicant, .approvalApplicant, .refuseApplicant:
+    case .inquireDetailRecruitment, .inquireRecruitmentQuestion, .inquireAllBookmark, .requestBookmark, .inquireApplicant, .approvalApplicant, .refuseApplicant, .inquireMyApplication, .cancelApplication:
       return .plain
     case .searchRecruitment(let parameter):
       return .query(parameter)
@@ -77,7 +83,7 @@ extension RecruitmentRouter: Router {
   
   var headers: HeaderType {
     switch self {
-    case .inquireDetailRecruitment, .inquireRecruitmentQuestion, .inquireAllBookmark, .searchRecruitment, .requestBookmark, .editMeetingPost, .editMeetingQuestion, .applyForRecruitment, .inquireApplicant, .approvalApplicant, .refuseApplicant:
+    case .inquireDetailRecruitment, .inquireRecruitmentQuestion, .inquireAllBookmark, .searchRecruitment, .requestBookmark, .editMeetingPost, .editMeetingQuestion, .applyForRecruitment, .inquireApplicant, .approvalApplicant, .refuseApplicant, .inquireMyApplication, .cancelApplication:
       return .withAccessToken
     }
   }

--- a/PLUB/Sources/Network/Services/RecruitmentService.swift
+++ b/PLUB/Sources/Network/Services/RecruitmentService.swift
@@ -57,4 +57,12 @@ extension RecruitmentService {
   func refuseApplicant(plubbingID: Int, accountID: Int) -> PLUBResult<EmptyModel> {
     return sendRequest(RecruitmentRouter.refuseApplicant(plubbingID, accountID))
   }
+  
+  func inquireMyApplication(plubbingID: Int) -> PLUBResult<MyApplicationResponse> {
+    return sendRequest(RecruitmentRouter.inquireMyApplication(plubbingID), type: MyApplicationResponse.self)
+  }
+  
+  func cancelApplication(plubbingID: Int) -> PLUBResult<EmptyModel> {
+    return sendRequest(RecruitmentRouter.cancelApplication(plubbingID))
+  }
 }

--- a/PLUB/Sources/Views/MyPage/MyPageViewController.swift
+++ b/PLUB/Sources/Views/MyPage/MyPageViewController.swift
@@ -152,7 +152,10 @@ extension MyPageViewController: UITableViewDelegate {
       let vc = RecruitingViewController(viewModel: RecruitingViewModel(plubbingID: plubbingID))
       vc.hidesBottomBarWhenPushed = true
       navigationController?.pushViewController(vc, animated: true)
-    case .waiting: break
+    case .waiting:
+      let vc = WaitingViewController(viewModel: WaitingViewModel(plubbingID: plubbingID))
+      vc.hidesBottomBarWhenPushed = true
+      navigationController?.pushViewController(vc, animated: true)
     case .active: break
     case .end: break
     }

--- a/PLUB/Sources/Views/MyPage/MyPageViewController.swift
+++ b/PLUB/Sources/Views/MyPage/MyPageViewController.swift
@@ -153,7 +153,11 @@ extension MyPageViewController: UITableViewDelegate {
       vc.hidesBottomBarWhenPushed = true
       navigationController?.pushViewController(vc, animated: true)
     case .waiting:
-      let vc = WaitingViewController(viewModel: WaitingViewModel(plubbingID: plubbingID))
+      let vc = WaitingViewController(
+        viewModel: WaitingViewModel(
+          plubbingID: plubbingID,
+          myInfo: viewModel.myInfo)
+      )
       vc.hidesBottomBarWhenPushed = true
       navigationController?.pushViewController(vc, animated: true)
     case .active: break

--- a/PLUB/Sources/Views/MyPage/MyPageViewController.swift
+++ b/PLUB/Sources/Views/MyPage/MyPageViewController.swift
@@ -153,11 +153,13 @@ extension MyPageViewController: UITableViewDelegate {
       vc.hidesBottomBarWhenPushed = true
       navigationController?.pushViewController(vc, animated: true)
     case .waiting:
+      guard let myInfo = viewModel.myInfoData else { return }
       let vc = WaitingViewController(
         viewModel: WaitingViewModel(
           plubbingID: plubbingID,
-          myInfo: viewModel.myInfo)
+          myInfo: myInfo)
       )
+      vc.delegate = self
       vc.hidesBottomBarWhenPushed = true
       navigationController?.pushViewController(vc, animated: true)
     case .active: break
@@ -201,5 +203,11 @@ extension MyPageViewController: MyPageSectionHeaderViewDelegate {
 extension MyPageViewController: MyPageNoneViewDelegate {
   func didTappedMoveToMeeting() {
     tabBarController?.selectedIndex = 0
+  }
+}
+
+extension MyPageViewController: MyPageCellDelegate {
+  func removeCell(plubbingID: Int) {
+    viewModel.removeCell(with: plubbingID)
   }
 }

--- a/PLUB/Sources/Views/MyPage/MyPageViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/MyPageViewModel.swift
@@ -11,7 +11,7 @@ import RxSwift
 import RxCocoa
 
 struct MyPageTableViewCellModel {
-  let section: MyPlubbingResponse
+  var section: MyPlubbingResponse
   var isFolded: Bool
 }
 
@@ -22,7 +22,7 @@ final class MyPageViewModel {
   let sectionTapped: AnyObserver<Int> // 섹션뷰 클릭 이벤트
   
   // Output
-  let myInfo: Driver<MyInfoResponse> // 내 정보 데이터
+  var myInfo: Driver<MyInfoResponse> // 내 정보 데이터
   let reloadData: Driver<Void> // 테이블 뷰 갱신
   let reloadSection: Driver<Int> // 테이블 뷰 섹션 갱신
   
@@ -33,6 +33,7 @@ final class MyPageViewModel {
   
   // Data
   private(set) var myPlubbing: [MyPageTableViewCellModel] = [] // 나의 플러빙 데이터
+  private(set) var myInfoData: MyInfoResponse? // 내정보
   
   init() {
     sectionTapped = sectionTappedSubject.asObserver()
@@ -58,6 +59,7 @@ final class MyPageViewModel {
         case .success(let model):
           print(model)
           guard let data = model.data else { return }
+          owner.myInfoData = data
           owner.myInfoSubject.onNext(data)
         default:
           break
@@ -100,5 +102,20 @@ final class MyPageViewModel {
           print("")
       })
       .disposed(by: disposeBag)
+  }
+  
+  func removeCell(with plubbingID: Int) {
+    myPlubbing.enumerated().forEach { (i, data) in
+      data.section.plubbings.enumerated().forEach { (j, plubbing) in
+        if (plubbing.plubbingID == plubbingID) {
+          myPlubbing[i].section.plubbings.remove(at: j)
+          if myPlubbing[i].section.plubbings.count == 0 {
+            myPlubbing.remove(at: i)
+          }
+          reloadDataSubject.onNext(())
+          return
+        }
+      }
+    }
   }
 }

--- a/PLUB/Sources/Views/MyPage/Recruiting/Component/RecruitingHeaderView.swift
+++ b/PLUB/Sources/Views/MyPage/Recruiting/Component/RecruitingHeaderView.swift
@@ -10,6 +10,21 @@ import UIKit
 import SnapKit
 import RxSwift
 
+extension PlubbingStatusType {
+  var subtitle: String {
+    switch self {
+    case .recruiting:
+       return "지원자 내역"
+    case .end:
+      return ""
+    case .active:
+      return ""
+    case .waiting:
+      return "나의 지원서"
+    }
+  }
+}
+
 final class RecruitingHeaderView: UIView {
   private let disposeBag = DisposeBag()
   
@@ -81,7 +96,7 @@ extension RecruitingHeaderView {
   private func setupStyles() {
   }
   
-  func setupData(with data: RecruitingModel) {
+  func setupData(with data: RecruitingModel, type: PlubbingStatusType) {
     titleLabel.text = data.title
     if data.address.isEmpty {
       locationView.isHidden = true
@@ -93,6 +108,6 @@ extension RecruitingHeaderView {
       locationView.setText(data.address, false)
     }
     scheduleView.setText(data.schedule, false)
-    subtitleLabel.text = "지원자 내역"
+    subtitleLabel.text = type.subtitle
   }
 }

--- a/PLUB/Sources/Views/MyPage/Recruiting/RecruitingViewController.swift
+++ b/PLUB/Sources/Views/MyPage/Recruiting/RecruitingViewController.swift
@@ -70,7 +70,7 @@ final class RecruitingViewController: BaseViewController {
   override func bind() {
     viewModel.meetingInfo
       .drive(with: self) { owner, myInfo in
-        owner.recruitingHeaderView.setupData(with: myInfo)
+        owner.recruitingHeaderView.setupData(with: myInfo, type: .recruiting)
       }
       .disposed(by: disposeBag)
     
@@ -156,7 +156,7 @@ extension RecruitingViewController: UITableViewDelegate {
           return UIView()
       }
       footerView.delegate = self
-      footerView.setupData(sectionIndex: section)
+      footerView.setupData(sectionIndex: section, type: .recruiting)
       return footerView
     }
   }
@@ -199,7 +199,7 @@ extension RecruitingViewController: RecruitingSectionHeaderViewDelegate {
 }
 
 extension RecruitingViewController: RecruitingSectionFooterViewDelegate {
-  func declineApplicant(sectionIndex: Int) {
+  func firstButtonTapped(sectionIndex: Int) {
     let model = viewModel.applications[sectionIndex]
     let accountID = model.data.accountID
     let alert = CustomAlertView(
@@ -220,7 +220,7 @@ extension RecruitingViewController: RecruitingSectionFooterViewDelegate {
     alert.show()
   }
   
-  func acceptApplicant(sectionIndex: Int) {
+  func secondButtonTapped(sectionIndex: Int) {
     let model = viewModel.applications[sectionIndex]
     let accountID = model.data.accountID
     let alert = CustomAlertView(

--- a/PLUB/Sources/Views/MyPage/Recruiting/RecruitingViewController.swift
+++ b/PLUB/Sources/Views/MyPage/Recruiting/RecruitingViewController.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-class RecruitingViewController: BaseViewController {
+final class RecruitingViewController: BaseViewController {
   
   let viewModel: RecruitingViewModel
   

--- a/PLUB/Sources/Views/MyPage/Waiting/WaitingViewController.swift
+++ b/PLUB/Sources/Views/MyPage/Waiting/WaitingViewController.swift
@@ -89,6 +89,13 @@ final class WaitingViewController: BaseViewController {
       }
       .disposed(by: disposeBag)
     
+    viewModel.successCanelApplication
+      .drive(with: self) { owner, _ in
+        owner.navigationController?.popViewController(animated: true)
+        // TODO: 수빈 - 지원 취소 -> 마이페이지 셀 remove 로직 추가
+      }
+      .disposed(by: disposeBag)
+    
     recruitButton
       .rx.tap
       .asDriver()
@@ -216,7 +223,5 @@ extension WaitingViewController: RecruitingSectionFooterViewDelegate {
   }
   
   func secondButtonTapped(sectionIndex: Int) {
-    let model = viewModel.applications[sectionIndex]
-
   }
 }

--- a/PLUB/Sources/Views/MyPage/Waiting/WaitingViewController.swift
+++ b/PLUB/Sources/Views/MyPage/Waiting/WaitingViewController.swift
@@ -69,7 +69,7 @@ final class WaitingViewController: BaseViewController {
   override func bind() {
     viewModel.meetingInfo
       .drive(with: self) { owner, myInfo in
-        owner.recruitingHeaderView.setupData(with: myInfo)
+        owner.recruitingHeaderView.setupData(with: myInfo, type: .waiting)
       }
       .disposed(by: disposeBag)
     
@@ -154,8 +154,9 @@ extension WaitingViewController: UITableViewDelegate {
       guard let footerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: RecruitingSectionFooterView.identifier) as? RecruitingSectionFooterView else {
           return UIView()
       }
+      let questionCount = viewModel.applications[section].data.answers.count
       footerView.delegate = self
-      footerView.setupData(sectionIndex: section)
+      footerView.setupData(sectionIndex: section, type: .waiting(questionCount: questionCount))
       return footerView
     }
   }
@@ -198,45 +199,24 @@ extension WaitingViewController: RecruitingSectionHeaderViewDelegate {
 }
 
 extension WaitingViewController: RecruitingSectionFooterViewDelegate {
-  func declineApplicant(sectionIndex: Int) {
-    let model = viewModel.applications[sectionIndex]
-    let accountID = model.data.accountID
+  func firstButtonTapped(sectionIndex: Int) {
     let alert = CustomAlertView(
       AlertModel(
-        title: "해당 지원자를\n거절하시겠어요?",
+        title: "이 모임에 참여하고 싶지\n않으신가요?",
         message: nil,
-        cancelButton: "취소",
-        confirmButton: "거절하기",
+        cancelButton: "아니요",
+        confirmButton: "네",
         height: 210
       )
     ) { [weak self] in
       guard let self = self else { return }
-//      self.viewModel.refuseApplicant.onNext((
-//        sectionIndex: sectionIndex,
-//        accountID: accountID
-//      ))
+      self.viewModel.cancelApplication.onNext(sectionIndex)
     }
     alert.show()
   }
   
-  func acceptApplicant(sectionIndex: Int) {
+  func secondButtonTapped(sectionIndex: Int) {
     let model = viewModel.applications[sectionIndex]
-    let accountID = model.data.accountID
-    let alert = CustomAlertView(
-      AlertModel(
-        title: "해당 지원자를\n받으시겠어요?",
-        message: nil,
-        cancelButton: "취소",
-        confirmButton: "받기",
-        height: 210
-      )
-    ) { [weak self] in
-      guard let self = self else { return }
-//      self.viewModel.approvalApplicant.onNext((
-//        sectionIndex: sectionIndex,
-//        accountID: accountID
-//      ))
-    }
-    alert.show()
+
   }
 }

--- a/PLUB/Sources/Views/MyPage/Waiting/WaitingViewController.swift
+++ b/PLUB/Sources/Views/MyPage/Waiting/WaitingViewController.swift
@@ -1,0 +1,11 @@
+//
+//  WaitingViewController.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/04/02.
+//
+
+import UIKit
+
+final class WaitingViewController: BaseViewController {
+}

--- a/PLUB/Sources/Views/MyPage/Waiting/WaitingViewController.swift
+++ b/PLUB/Sources/Views/MyPage/Waiting/WaitingViewController.swift
@@ -8,4 +8,235 @@
 import UIKit
 
 final class WaitingViewController: BaseViewController {
+  
+  let viewModel: WaitingViewModel
+  
+  init(viewModel: WaitingViewModel) {
+    self.viewModel = viewModel
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private lazy var recruitingHeaderView = RecruitingHeaderView()
+  
+  private lazy var tableView = UITableView(frame: .zero, style: .grouped).then {
+    $0.separatorStyle = .none
+    $0.showsVerticalScrollIndicator = false
+    $0.backgroundColor = .background
+    $0.delegate = self
+    $0.dataSource = self
+    $0.tableHeaderView = recruitingHeaderView
+    $0.tableHeaderView?.frame.size.height = 190
+    $0.register(RecruitingTableViewCell.self, forCellReuseIdentifier: RecruitingTableViewCell.identifier)
+    $0.register(RecruitingSectionHeaderView.self, forHeaderFooterViewReuseIdentifier: RecruitingSectionHeaderView.identifier)
+    $0.register(RecruitingSectionFooterView.self, forHeaderFooterViewReuseIdentifier: RecruitingSectionFooterView.identifier)
+    $0.register(MyPageSectionFooterView.self, forHeaderFooterViewReuseIdentifier: MyPageSectionFooterView.identifier)
+  }
+  
+  private let recruitButton = UIButton(configuration: .plain()).then {
+    $0.configurationUpdateHandler = $0.configuration?.plubButton(label: "모집글 바로가기")
+    $0.layer.cornerRadius = 16
+    $0.layer.masksToBounds = true
+  }
+  
+  override func setupLayouts() {
+    super.setupLayouts()
+    [tableView, recruitButton].forEach {
+      view.addSubview($0)
+    }
+  }
+  
+  override func setupConstraints() {
+    tableView.snp.makeConstraints {
+      $0.top.equalTo(view.safeAreaLayoutGuide)
+      $0.leading.trailing.bottom.equalToSuperview()
+    }
+    
+    recruitButton.snp.makeConstraints {
+      $0.height.equalTo(32)
+      $0.centerX.equalToSuperview()
+      $0.bottom.equalToSuperview().inset(24)
+    }
+  }
+  
+  override func setupStyles() {
+    setupNavigationBar()
+  }
+  
+  override func bind() {
+    viewModel.meetingInfo
+      .drive(with: self) { owner, myInfo in
+        owner.recruitingHeaderView.setupData(with: myInfo)
+      }
+      .disposed(by: disposeBag)
+    
+    viewModel.reloadData
+      .drive(with: self) { owner, _ in
+        if owner.viewModel.applications.isEmpty {
+          owner.tableView.tableFooterView = RecruitingFooterView()
+          owner.tableView.tableFooterView?.frame.size.height = 74
+        }
+        owner.tableView.reloadData()
+      }
+      .disposed(by: disposeBag)
+    
+    viewModel.reloadSection
+      .drive(with: self) { owner, index in
+        owner.tableView.reloadSections([index], with: .automatic)
+      }
+      .disposed(by: disposeBag)
+    
+    recruitButton
+      .rx.tap
+      .asDriver()
+      .drive(with: self) { owner, _ in
+        let vc = DetailRecruitmentViewController(plubbingID: owner.viewModel.plubbingID, isHost: false)
+        owner.navigationController?.pushViewController(vc, animated: true)
+      }
+      .disposed(by: disposeBag)
+  }
+  
+  private func setupNavigationBar() {
+    navigationItem.leftBarButtonItem = UIBarButtonItem(
+      image: UIImage(named: "backButton"),
+      style: .plain,
+      target: self,
+      action: #selector(didTappedBackButton)
+    )
+  }
+  
+  @objc
+  private func didTappedBackButton() {
+    navigationController?.popViewController(animated: true)
+  }
+}
+
+// MARK: - UITableViewDelegate
+
+extension WaitingViewController: UITableViewDelegate {
+  func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    return UITableView.automaticDimension
+  }
+  
+  func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    let isFolded = viewModel.applications[section].isFolded
+    return isFolded ? (16 + 40 + 8) : (16 + 40 + 8 + 8)
+  }
+  
+  func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: RecruitingSectionHeaderView.identifier) as? RecruitingSectionHeaderView else {
+        return UIView()
+    }
+    
+    let model = viewModel.applications[section]
+    headerView.setupData(with: model, sectionIndex: section)
+    headerView.delegate = self
+    
+    return headerView
+  }
+  
+  func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+    let isFolded = viewModel.applications[section].isFolded
+    return isFolded ? 18 : (14 + 46)
+  }
+  
+  func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    let isFolded = viewModel.applications[section].isFolded
+    if isFolded {
+      guard let footerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: MyPageSectionFooterView.identifier) as? MyPageSectionFooterView else {
+          return UIView()
+      }
+      return footerView
+    } else {
+      guard let footerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: RecruitingSectionFooterView.identifier) as? RecruitingSectionFooterView else {
+          return UIView()
+      }
+      footerView.delegate = self
+      footerView.setupData(sectionIndex: section)
+      return footerView
+    }
+  }
+  
+  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+
+  }
+}
+
+// MARK: - UITableViewDataSource
+
+extension WaitingViewController: UITableViewDataSource {
+  func numberOfSections(in tableView: UITableView) -> Int {
+    return viewModel.applications.count
+  }
+  
+  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    guard let cell = tableView.dequeueReusableCell(
+      withIdentifier: RecruitingTableViewCell.identifier,
+      for: indexPath
+    ) as? RecruitingTableViewCell else { return UITableViewCell() }
+    
+    let model = viewModel.applications[indexPath.section]
+    let answer = model.data.answers[indexPath.row]
+    cell.setupData(with: answer)
+    
+    return cell
+  }
+  
+  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    let model = viewModel.applications[section]
+    return model.isFolded ? 0 : model.data.answers.count
+  }
+}
+
+extension WaitingViewController: RecruitingSectionHeaderViewDelegate {
+  func foldHeaderView(sectionIndex: Int) {
+    viewModel.sectionTapped.onNext(sectionIndex)
+  }
+}
+
+extension WaitingViewController: RecruitingSectionFooterViewDelegate {
+  func declineApplicant(sectionIndex: Int) {
+    let model = viewModel.applications[sectionIndex]
+    let accountID = model.data.accountID
+    let alert = CustomAlertView(
+      AlertModel(
+        title: "해당 지원자를\n거절하시겠어요?",
+        message: nil,
+        cancelButton: "취소",
+        confirmButton: "거절하기",
+        height: 210
+      )
+    ) { [weak self] in
+      guard let self = self else { return }
+//      self.viewModel.refuseApplicant.onNext((
+//        sectionIndex: sectionIndex,
+//        accountID: accountID
+//      ))
+    }
+    alert.show()
+  }
+  
+  func acceptApplicant(sectionIndex: Int) {
+    let model = viewModel.applications[sectionIndex]
+    let accountID = model.data.accountID
+    let alert = CustomAlertView(
+      AlertModel(
+        title: "해당 지원자를\n받으시겠어요?",
+        message: nil,
+        cancelButton: "취소",
+        confirmButton: "받기",
+        height: 210
+      )
+    ) { [weak self] in
+      guard let self = self else { return }
+//      self.viewModel.approvalApplicant.onNext((
+//        sectionIndex: sectionIndex,
+//        accountID: accountID
+//      ))
+    }
+    alert.show()
+  }
 }

--- a/PLUB/Sources/Views/MyPage/Waiting/WaitingViewController.swift
+++ b/PLUB/Sources/Views/MyPage/Waiting/WaitingViewController.swift
@@ -7,9 +7,14 @@
 
 import UIKit
 
+protocol MyPageCellDelegate: AnyObject {
+  func removeCell(plubbingID: Int)
+}
+
 final class WaitingViewController: BaseViewController {
   
   let viewModel: WaitingViewModel
+  weak var delegate: MyPageCellDelegate?
   
   init(viewModel: WaitingViewModel) {
     self.viewModel = viewModel
@@ -91,8 +96,8 @@ final class WaitingViewController: BaseViewController {
     
     viewModel.successCanelApplication
       .drive(with: self) { owner, _ in
+        owner.delegate?.removeCell(plubbingID: owner.viewModel.plubbingID)
         owner.navigationController?.popViewController(animated: true)
-        // TODO: 수빈 - 지원 취소 -> 마이페이지 셀 remove 로직 추가
       }
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/MyPage/Waiting/WaitingViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/Waiting/WaitingViewModel.swift
@@ -1,0 +1,18 @@
+//
+//  WaitingViewModel.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/04/02.
+//
+
+import RxSwift
+import RxCocoa
+
+class WaitingViewModel {
+  private let disposeBag = DisposeBag()
+  private(set) var plubbingID: Int
+  
+  init(plubbingID: Int) {
+    self.plubbingID = plubbingID
+  }
+}

--- a/PLUB/Sources/Views/MyPage/Waiting/WaitingViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/Waiting/WaitingViewModel.swift
@@ -117,6 +117,7 @@ class WaitingViewModel {
   
   private func createScheduleString(days: [String], time: String) -> String {
     let dateStr = days
+      .map { $0.fromENGToKOR() }
       .joined(separator: ", ")
     
     let date = DateFormatter().then {

--- a/PLUB/Sources/Views/MyPage/Waiting/WaitingViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/Waiting/WaitingViewModel.swift
@@ -16,7 +16,7 @@ class WaitingViewModel {
   
   // Input
   let sectionTapped: AnyObserver<Int> // 섹션뷰 클릭 이벤트
-  let cancelApplication: AnyObserver<(sectionIndex: Int, accountID: Int)> // 지원 취소
+  let cancelApplication: AnyObserver<Int> // 지원 취소
   let editApplication: AnyObserver<(sectionIndex: Int, accountID: Int)> // 지원서 수정
   
   // Output
@@ -25,7 +25,7 @@ class WaitingViewModel {
   let reloadSection: Driver<Int> // 테이블 뷰 섹션 갱신
   
   private let sectionTappedSubject = PublishSubject<Int>()
-  private let cancelApplicationSubject = PublishSubject<(sectionIndex: Int, accountID: Int)>()
+  private let cancelApplicationSubject = PublishSubject<Int>()
   private let editApplicationSubject = PublishSubject<(sectionIndex: Int, accountID: Int)>()
   private let meetingInfoSubject = PublishSubject<RecruitingModel>()
   private let reloadDataSubject = PublishSubject<Void>()
@@ -57,11 +57,10 @@ class WaitingViewModel {
     
     cancelApplicationSubject
       .withUnretained(self)
-      .subscribe(onNext: { owner, data in
-//        owner.approvalApplicant(
-//          sectionIndex: data.sectionIndex,
-//          accountID: data.accountID
-//        )
+      .subscribe(onNext: { owner, sectionIndex in
+        owner.cancelApplication(
+          sectionIndex: sectionIndex
+        )
       })
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/MyPage/Waiting/WaitingViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/Waiting/WaitingViewModel.swift
@@ -5,6 +5,8 @@
 //  Created by 김수빈 on 2023/04/02.
 //
 
+import Foundation
+
 import RxSwift
 import RxCocoa
 
@@ -12,7 +14,144 @@ class WaitingViewModel {
   private let disposeBag = DisposeBag()
   private(set) var plubbingID: Int
   
+  // Input
+  let sectionTapped: AnyObserver<Int> // 섹션뷰 클릭 이벤트
+  let cancelApplication: AnyObserver<(sectionIndex: Int, accountID: Int)> // 지원 취소
+  let editApplication: AnyObserver<(sectionIndex: Int, accountID: Int)> // 지원서 수정
+  
+  // Output
+  let meetingInfo: Driver<RecruitingModel> // 내 정보 데이터
+  let reloadData: Driver<Void> // 테이블 뷰 갱신
+  let reloadSection: Driver<Int> // 테이블 뷰 섹션 갱신
+  
+  private let sectionTappedSubject = PublishSubject<Int>()
+  private let cancelApplicationSubject = PublishSubject<(sectionIndex: Int, accountID: Int)>()
+  private let editApplicationSubject = PublishSubject<(sectionIndex: Int, accountID: Int)>()
+  private let meetingInfoSubject = PublishSubject<RecruitingModel>()
+  private let reloadDataSubject = PublishSubject<Void>()
+  private let reloadSectionSubject = PublishSubject<Int>()
+  
+  // Data
+  private(set) var applications: [(data: Application, isFolded: Bool)] = []
+  
   init(plubbingID: Int) {
     self.plubbingID = plubbingID
+    
+    sectionTapped = sectionTappedSubject.asObserver()
+    cancelApplication = cancelApplicationSubject.asObserver()
+    editApplication = editApplicationSubject.asObserver()
+    
+    meetingInfo = meetingInfoSubject.asDriver(onErrorDriveWith: .empty())
+    reloadData = reloadDataSubject.asDriver(onErrorDriveWith: .empty())
+    reloadSection = reloadSectionSubject.asDriver(onErrorDriveWith: .empty())
+    
+    fetchApplicants()
+    
+    sectionTappedSubject
+      .withUnretained(self)
+      .subscribe(onNext: { owner, index in
+        owner.applications[index].isFolded.toggle()
+        owner.reloadSectionSubject.onNext(index)
+      })
+      .disposed(by: disposeBag)
+    
+    cancelApplicationSubject
+      .withUnretained(self)
+      .subscribe(onNext: { owner, data in
+//        owner.approvalApplicant(
+//          sectionIndex: data.sectionIndex,
+//          accountID: data.accountID
+//        )
+      })
+      .disposed(by: disposeBag)
+    
+    editApplicationSubject
+      .withUnretained(self)
+      .subscribe(onNext: { owner, data in
+//        owner.refuseApplicant(
+//          sectionIndex: data.sectionIndex,
+//          accountID: data.accountID
+//        )
+      })
+      .disposed(by: disposeBag)
+  }
+  
+  private func fetchApplicants() {
+    RecruitmentService.shared.inquireMyApplication(plubbingID: plubbingID)
+      .withUnretained(self)
+      .subscribe(onNext: { owner, result in
+        switch result {
+        case .success(let model):
+          print(model)
+          guard let data = model.data else { return }
+          let plubbing = data.plubbingInfo
+          owner.meetingInfoSubject.onNext(
+            RecruitingModel(
+              title: plubbing.name,
+              schedule: owner.createScheduleString(
+                days: plubbing.days,
+                time: plubbing.time
+              ),
+              address: plubbing.address ?? "")
+          )
+          
+          owner.applications.append(
+            (
+              Application(
+                accountID: 0,
+                userName: "김수빈",
+                profileImage: nil,
+                date: data.date,
+                answers: data.answers),
+              true
+            )
+          )
+          // 테이블 뷰 리로드
+          owner.reloadDataSubject.onNext(())
+        default:
+          break
+        }
+      })
+      .disposed(by: disposeBag)
+  }
+  
+  private func createScheduleString(days: [String], time: String) -> String {
+    let dateStr = days
+      .joined(separator: ", ")
+    
+    let date = DateFormatter().then {
+      $0.dateFormat = "yyyy-MM-dd HH:mm:ss"
+      $0.locale = Locale(identifier: "ko_KR")
+    }.date(from: time) ?? Date()
+
+    let timeStr = DateFormatter().then {
+      $0.dateFormat = "a h시 m분"
+      $0.locale = Locale(identifier: "ko_KR")
+    }.string(from: date)
+    
+    return (dateStr.isEmpty ? "온라인" : dateStr)  + " | " + timeStr
+  }
+  
+  private func cancelApplication(sectionIndex: Int) {
+    RecruitmentService.shared.cancelApplication(
+      plubbingID: plubbingID
+    )
+      .withUnretained(self)
+      .subscribe(onNext: { owner, result in
+        switch result {
+        case .success(let model):
+          print(model)
+//          owner.applications.remove(at: sectionIndex)
+//          // 테이블 뷰 리로드
+//          owner.reloadDataSubject.onNext(())
+        default:
+          break
+        }
+      })
+      .disposed(by: disposeBag)
+  }
+  
+  private func editApplication(sectionIndex: Int, accountID: Int) {
+    
   }
 }

--- a/PLUB/Sources/Views/MyPage/Waiting/WaitingViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/Waiting/WaitingViewModel.swift
@@ -23,6 +23,7 @@ class WaitingViewModel {
   let meetingInfo: Driver<RecruitingModel> // 내 정보 데이터
   let reloadData: Driver<Void> // 테이블 뷰 갱신
   let reloadSection: Driver<Int> // 테이블 뷰 섹션 갱신
+  let successCanelApplication: Driver<Void>
   
   private let sectionTappedSubject = PublishSubject<Int>()
   private let cancelApplicationSubject = PublishSubject<Int>()
@@ -30,6 +31,7 @@ class WaitingViewModel {
   private let meetingInfoSubject = PublishSubject<RecruitingModel>()
   private let reloadDataSubject = PublishSubject<Void>()
   private let reloadSectionSubject = PublishSubject<Int>()
+  private let successCanelApplicationSubject = PublishSubject<Void>()
   
   // Data
   private(set) var applications: [(data: Application, isFolded: Bool)] = []
@@ -44,6 +46,7 @@ class WaitingViewModel {
     meetingInfo = meetingInfoSubject.asDriver(onErrorDriveWith: .empty())
     reloadData = reloadDataSubject.asDriver(onErrorDriveWith: .empty())
     reloadSection = reloadSectionSubject.asDriver(onErrorDriveWith: .empty())
+    successCanelApplication = successCanelApplicationSubject.asDriver(onErrorDriveWith: .empty())
     
     fetchApplicants()
     
@@ -67,10 +70,7 @@ class WaitingViewModel {
     editApplicationSubject
       .withUnretained(self)
       .subscribe(onNext: { owner, data in
-//        owner.refuseApplicant(
-//          sectionIndex: data.sectionIndex,
-//          accountID: data.accountID
-//        )
+//TODO: 수빈 - 질문 답변 수정 화면 연결
       })
       .disposed(by: disposeBag)
   }
@@ -141,9 +141,8 @@ class WaitingViewModel {
         switch result {
         case .success(let model):
           print(model)
-//          owner.applications.remove(at: sectionIndex)
-//          // 테이블 뷰 리로드
-//          owner.reloadDataSubject.onNext(())
+          owner.applications.remove(at: sectionIndex)
+          owner.successCanelApplicationSubject.onNext(())
         default:
           break
         }

--- a/PLUB/Sources/Views/MyPage/Waiting/WaitingViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/Waiting/WaitingViewModel.swift
@@ -13,6 +13,7 @@ import RxCocoa
 class WaitingViewModel {
   private let disposeBag = DisposeBag()
   private(set) var plubbingID: Int
+  private(set) var myInfo: MyInfoResponse
   
   // Input
   let sectionTapped: AnyObserver<Int> // 섹션뷰 클릭 이벤트
@@ -36,8 +37,9 @@ class WaitingViewModel {
   // Data
   private(set) var applications: [(data: Application, isFolded: Bool)] = []
   
-  init(plubbingID: Int) {
+  init(plubbingID: Int, myInfo: MyInfoResponse) {
     self.plubbingID = plubbingID
+    self.myInfo = myInfo
     
     sectionTapped = sectionTappedSubject.asObserver()
     cancelApplication = cancelApplicationSubject.asObserver()
@@ -97,9 +99,9 @@ class WaitingViewModel {
           owner.applications.append(
             (
               Application(
-                accountID: 0,
-                userName: "김수빈",
-                profileImage: nil,
+                accountID: -1,
+                userName: owner.myInfo.nickname,
+                profileImage: owner.myInfo.profileImage,
                 date: data.date,
                 answers: data.answers),
               true


### PR DESCRIPTION
## 📌 PR 요약
마이페이지 > 대기중인 모임 기능을 구현하였습니다.

🌱 작업한 내용
- 대기중/모집중인 모임 UI 분기 처리
- 내 지원서 조회 API 연결
- 지원 취소 API 연결
- 지원 취소 후, 마이페이지 화면 셀 갱신 로직 추가
🙏🏻 지원서 수정 화면은 아직 구현하지 못했습니다.

## 📸 스크린샷
- 대기 중인 모임 2개 이상일때 

https://user-images.githubusercontent.com/77331348/229347263-178d0c17-7b15-411f-ac12-f480e9e9b922.MP4

- 대기 중인 모임 1개 일때 

https://user-images.githubusercontent.com/77331348/229347245-81d8015f-b574-49ed-824b-e19905f30d4f.MP4

## 📮 관련 이슈
-  #130 
