### PR TITLE
PLUB 네트워크 로직 리팩토링

### DIFF
--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -27,6 +27,7 @@ class BaseService {
   ///
   /// 해당 메서드는 검증을 위해 사용됩니다.
   /// 요청값을 전달하고 응답받은 값을 처리하고 싶은 경우 `requestObject(_:type:)`을 사용해주세요.
+  @available(*, deprecated, renamed: "validateHTTPResponse(by:_:type:)")
   func evaluateStatus<T: Codable>(
     by statusCode: Int,
     _ data: Data,
@@ -51,6 +52,7 @@ class BaseService {
   /// - Parameters:
   ///   - target: Router를 채택한 인스턴스(instance)
   ///   - type: 응답 값에 들어오는 `data`를 파싱할 모델
+  @available(*, deprecated, renamed: "sendObservableRequest(_:)")
   func sendRequest<T: Codable>(
     _ router: Router,
     type: T.Type = EmptyModel.self

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -139,7 +139,7 @@ class BaseService {
   ///
   /// 해당 메서드로 파이프라인을 시작하게 되면, [weak self]를 통한 retain cycle를 고려하지 않아도 됩니다.
   /// 값을 파이프라인에 전달하게 되면 그 뒤 바로 종료되는 것을 보장하기 때문입니다.
-  func sendObservableRequest<T: Codable>(_ router: Router) -> Observable<GeneralResponse<T>> {
+  func sendObservableRequest<T: Codable>(_ router: Router) -> Observable<T> {
     Single.create { observer in
       
       self.session.request(router).responseData { response in
@@ -153,7 +153,8 @@ class BaseService {
           
           switch self.validateHTTPResponse(by: statusCode, data, type: T.self) {
           case .success(let decodedData):
-            observer(.success(decodedData))
+            // validateHTTPResponse에서 success인 경우 Data값을 보장함
+            observer(.success(decodedData.data!))
             
           case .failure(let error):
             observer(.failure(error))

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -98,6 +98,83 @@ class BaseService {
     }
     .asObservable()
   }
+  
+  
+  /// Network Response에 대해 검증한 결과값을 리턴합니다.
+  /// - Parameters:
+  ///   - statusCode: http 상태 코드
+  ///   - data: 응답값으로 받아온 `Data`
+  ///   - type: Data 내부를 구성하는 타입
+  /// - Returns: GeneralResponse 또는 Plub Error
+  ///
+  /// 해당 메서드는 검증을 위해 사용됩니다.
+  /// 서버로부터 값을 받아오거나 받아오지 못했을 때, 성공한 값을 리턴 또는 그에 맞는 PLUB Error를 처리합니다.
+  private func validateHTTPResponse<T: Codable>(
+    by statusCode: Int,
+    _ data: Data,
+    type: T.Type
+  ) -> Result<GeneralResponse<T>, PLUBError<GeneralResponse<T>>> {
+    guard let decodedData = try? JSONDecoder().decode(GeneralResponse<T>.self, from: data) else {
+      return .failure(.decodingError(raw: data))
+    }
+    switch statusCode {
+    case 200..<300 where decodedData.data != nil:
+      return .success(decodedData)
+    case 200..<300 where decodedData.data == nil:
+      return .failure(.decodingError(raw: data))
+    case 400..<500:
+      return .failure(.requestError(decodedData))
+    case 500..<600:
+      return .failure(.serverError)
+    default:
+      return .failure(.unknownedError)
+    }
+  }
+  
+  /// PLUB 서버에 필요한 값을 동봉하여 요청합니다.
+  /// - Parameters:
+  ///   - target: Router를 채택한 인스턴스(instance)
+  ///
+  /// 해당 메서드로 파이프라인을 시작하게 되면, [weak self]를 통한 retain cycle를 고려하지 않아도 됩니다.
+  /// 값을 파이프라인에 전달하게 되면 그 뒤 바로 종료되는 것을 보장하기 때문입니다.
+  func sendObservableRequest<T: Codable>(_ router: Router) -> Observable<GeneralResponse<T>> {
+    Single.create { observer in
+      
+      self.session.request(router).responseData { response in
+        switch response.result {
+        case .success(let data):
+          guard let statusCode = response.response?.statusCode
+          else {
+            observer(.failure(PLUBError<T>.unknownedError))
+            return
+          }
+          
+          switch self.validateHTTPResponse(by: statusCode, data, type: T.self) {
+          case .success(let decodedData):
+            observer(.success(decodedData))
+            
+          case .failure(let error):
+            observer(.failure(error))
+          }
+          
+        case .failure(let error):
+          
+          switch error {
+          case .sessionTaskFailed(let urlError as URLError) where urlError.code == .notConnectedToInternet:
+            // 네트워크 연결이 되어있지 않은 경우
+            observer(.failure(PLUBError<T>.networkError))
+            
+          default:
+            observer(.failure(PLUBError<T>.alamofireError(error))) // Alamofire Error
+            
+          }
+        }
+      }
+      
+      return Disposables.create()
+    }
+    .asObservable()
+  }
 }
 
 // MARK: - Components

--- a/PLUB/Sources/Network/Foundation/NetworkResult.swift
+++ b/PLUB/Sources/Network/Foundation/NetworkResult.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+import enum Alamofire.AFError
+
 enum NetworkResult<T> {
   
   /// 성공
@@ -27,4 +29,30 @@ enum NetworkResult<T> {
   
   /// 경로 에러, path가 잘못된 경우
   case pathError
+}
+
+/// PLUB 에러 모음
+enum PLUBError<T>: Error {
+  
+  /// 요청 값에 문제가 발생한 경우 발생되는 에러입니다.
+  ///
+  /// 400~499 대의 응답코드가 이 에러에 속합니다.
+  case requestError(T)
+  
+  /// 서버에 문제가 생겼을 때 발생됩니다.
+  ///
+  /// 500번대 응답코드가 이 에러에 속합니다.
+  case serverError
+  
+  /// 사용자의 네트워크에 문제가 있어 값을 가져오지 못하는 경우
+  case networkError
+  
+  /// 서버로부터 받아온 값과 Codable 모델 간 디코딩 문제가 발생한 경우
+  case decodingError(raw: Data)
+  
+  /// Alamofire에서 직접 내려주는 에러
+  case alamofireError(AFError)
+  
+  /// 알 수 없는 에러
+  case unknownedError
 }

--- a/PLUB/Sources/Network/Foundation/NetworkResult.swift
+++ b/PLUB/Sources/Network/Foundation/NetworkResult.swift
@@ -9,6 +9,7 @@ import Foundation
 
 import enum Alamofire.AFError
 
+@available(*, deprecated)
 enum NetworkResult<T> {
   
   /// 성공


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 기존 NetworkResult타입에 존재했던 Error를 PLUBError로 이관하였고, enum case도 일부 수정했습니다.
   - pathError 제거: path가 잘못되면 결국 requestError로 넘어가게 되므로 불필요한 Error라 판단하여 삭제했습니다.
   - decodingError 추가: API 모델을 잘못 구성하여 데이터가 제대로 파싱되지 못하는 경우, success임에도 data프로퍼티가 nil로 처리되었습니다. 이제는 이를 감지하여 디코딩하려 헀던 data값과 함께 Error로 넘겨주도록 구현하였습니다. 
   - unknownedError 추가: PLUBError로 직접 해결할 수 없는 에러로, statusCode값을 받아오지 못했거나 statusCode가 비정상적인 값으로 받아졌을 때 해당 Error로 처리됩니다. 이 에러값은 불릴 일이 전혀 없을 것 같지만, 혹시 몰라 처리해두었습니다. 😅

🌱 PR 포인트
- sendRequest와 evaluateStatus는 이제 레거시 코드가 되었습니다..! 새로운 메서드인 `sendObservableRequest`를 사용해 주세요.
   - `sendObservableRequest`를 사용하게 되면 `sendRequest`에서 항상 보내야했던 `type` 파라미터를 넣을 필요가 없습니다(1번 사진 참고).
   - `sendObservableRequest`를 사용하면, data값이 Observable로 그대로 리턴되어 보다 깔끔하게 코드를 구성할 수 있습니다.(2번 사진, 3번 사진 참고)

- 에러는 이제 onError에서 처리할 수 있도록 수정했습니다. 기존에는 error도 success로 취급되어 들어갔으나, 이제 subscribe의 onError 클로저에서 처리하시면 됩니다.
```swift
// observable
.subscribe { _ in
} onError: { error in
  guard let plubError = error as? PLUBError<GeneralResponse<FeedsContent>> else { return }
  switch plubError {
    // 디코딩 미스인 경우
  case .decodingError(let rawData):
   // 여기서 rawData를 찍어서 어떻게 받아오는 지 확인할 수 있습니다. JSONSerialization을 애용해주세용
    print(rawData)
    
  case .requestError(let response):
    // 요청이 잘못된 경우, ex: statusCode: 9010
    print(response.statusCode)
  default: // 그 외 여러 에러들..
    // Log 처리
    break
  }
}
```

## 📸 스크린샷
|1번 사진|
|:--:|
|<img width="802" alt="image" src="https://user-images.githubusercontent.com/57972338/230713784-8d452858-f2c1-4284-9240-a6d78e42bc3d.png">|
|2번 사진|
|<img width="1036" alt="image" src="https://user-images.githubusercontent.com/57972338/230714094-c0319a50-3278-4866-8548-be296c9598ac.png">|
|3번 사진|
|![image](https://user-images.githubusercontent.com/57972338/230714698-260ad257-9b7b-47f1-96bc-d6950825b0eb.png)|
## 📮 관련 이슈
- #255

