### PR TITLE
[FEAT] 메인페이지 헤더뷰 탭 제스처 추가

### DIFF
--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -249,7 +249,7 @@ extension BoardViewController: UICollectionViewDelegateFlowLayout {
 }
 
 extension BoardViewController: BoardClipboardHeaderViewDelegate {
-  func didTappedClipboardButton() {
+  func didTappedBoardClipboardHeaderView() {
     let vc = ClipboardViewController(viewModel: ClipboardViewModel(plubbingID: plubbingID))
     vc.navigationItem.largeTitleDisplayMode = .never
     self.navigationController?.pushViewController(vc, animated: true)

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -18,6 +18,7 @@ enum BoardHeaderViewType {
 protocol BoardViewControllerDelegate: AnyObject {
   func calculateHeight(_ height: CGFloat)
   func didTappedBoardCollectionViewCell(plubbingID: Int, content: BoardModel)
+  func didTappedBoardClipboardHeaderView()
 }
 
 final class BoardViewController: BaseViewController {
@@ -250,9 +251,7 @@ extension BoardViewController: UICollectionViewDelegateFlowLayout {
 
 extension BoardViewController: BoardClipboardHeaderViewDelegate {
   func didTappedBoardClipboardHeaderView() {
-    let vc = ClipboardViewController(viewModel: ClipboardViewModel(plubbingID: plubbingID))
-    vc.navigationItem.largeTitleDisplayMode = .never
-    self.navigationController?.pushViewController(vc, animated: true)
+    delegate?.didTappedBoardClipboardHeaderView()
   }
 }
 

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
@@ -79,7 +79,7 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
   }
   
   private func bind() {
-    clipboardButton.rx.tap
+    tapGesture.rx.event
       .subscribe(with: self) { owner, _ in
         owner.delegate?.didTappedClipboardButton()
       }

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
@@ -12,7 +12,7 @@ import SnapKit
 import Then
 
 protocol BoardClipboardHeaderViewDelegate: AnyObject {
-  func didTappedClipboardButton()
+  func didTappedBoardClipboardHeaderView()
 }
 
 final class BoardClipboardHeaderView: UICollectionReusableView {
@@ -81,7 +81,7 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
   private func bind() {
     tapGesture.rx.event
       .subscribe(with: self) { owner, _ in
-        owner.delegate?.didTappedClipboardButton()
+        owner.delegate?.didTappedBoardClipboardHeaderView()
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
@@ -61,6 +61,8 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
     $0.distribution = .fillEqually
   }
   
+  private let tapGesture = UITapGestureRecognizer(target: BoardClipboardHeaderView.self, action: nil)
+  
   override init(frame: CGRect) {
     super.init(frame: frame)
     configureUI()

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
@@ -88,6 +88,7 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
   
   private func configureUI() {
     backgroundColor = .background
+    contentView.addGestureRecognizer(tapGesture)
     
     addSubview(contentView)
     contentView.snp.makeConstraints {

--- a/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/BoardClipboardHeaderView.swift
@@ -43,8 +43,9 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
     $0.textColor = .black
   }
   
-  private let clipboardButton = UIButton().then {
-    $0.setImage(UIImage(named: "rightIndicatorGray"), for: .normal)
+  private let clipboardImageView = UIImageView().then {
+    $0.image = UIImage(named: "rightIndicatorGray")
+    $0.contentMode = .scaleAspectFill
   }
   
   private let entireStackView = UIStackView().then {
@@ -96,14 +97,14 @@ final class BoardClipboardHeaderView: UICollectionReusableView {
       $0.bottom.equalToSuperview().inset(8)
     }
     
-    [pinImageView, clipboardLabel, clipboardButton].forEach { horizontalStackView.addArrangedSubview($0) }
+    [pinImageView, clipboardLabel, clipboardImageView].forEach { horizontalStackView.addArrangedSubview($0) }
     pinImageView.snp.makeConstraints {
       $0.size.equalTo(24)
     }
     
     [horizontalStackView, entireStackView].forEach { contentView.addSubview($0) }
     
-    clipboardButton.snp.makeConstraints {
+    clipboardImageView.snp.makeConstraints {
       $0.size.equalTo(32)
     }
     

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -234,6 +234,12 @@ extension MainPageViewController: UIScrollViewDelegate {
 }
 
 extension MainPageViewController: BoardViewControllerDelegate {
+  func didTappedBoardClipboardHeaderView() {
+    let vc = ClipboardViewController(viewModel: ClipboardViewModel(plubbingID: plubbingID))
+    vc.navigationItem.largeTitleDisplayMode = .never
+    self.navigationController?.pushViewController(vc, animated: true)
+  }
+  
   func didTappedBoardCollectionViewCell(plubbingID: Int, content: BoardModel) {
     let vc = BoardDetailViewController(viewModel: BoardDetailViewModel(
       plubbingID: plubbingID,


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 메인페이지 헤더뷰 탭에 따른 클립보드화면이동
- 헤더뷰 클립보드버튼 탭 제스터 미동작에 따른 이미지뷰로 수정

🌱 PR 포인트
- 클립보드화면에 title은 아직 보내지않았습니다, 추후 헤더뷰에 관련된 데이터를 연동시킬때 추가해주도록 하겠습니다

## 📸 동작영상
https://user-images.githubusercontent.com/39263235/230719280-4c0d17c7-3442-4dbc-885d-40f147d61e41.mp4

## 📮 관련 이슈
- Resolved: #262 

