### PR TITLE
[FEAT] 마이페이지 > 프로필 편집 기능 구현

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -237,6 +237,7 @@
 		C316051B2997936200D27488 /* GuestQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C316051A2997936200D27488 /* GuestQuestionViewModel.swift */; };
 		C316051F2997F92200D27488 /* EditMeetingPostRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C316051E2997F92200D27488 /* EditMeetingPostRequest.swift */; };
 		C31605212997F9C800D27488 /* EditMeetingQuestionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31605202997F9C800D27488 /* EditMeetingQuestionRequest.swift */; };
+		C32AB19029DDB9000045B919 /* ProfileEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32AB18F29DDB9000045B919 /* ProfileEditViewModel.swift */; };
 		C332DFD52976E5440023B70B /* PhotoBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C332DFD42976E5440023B70B /* PhotoBottomSheetViewController.swift */; };
 		C33952EF29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33952EE29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift */; };
 		C33EF37D29A1DFD100D7A5CA /* ScheduleAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33EF37C29A1DFD100D7A5CA /* ScheduleAlarmView.swift */; };
@@ -320,6 +321,7 @@
 		C3B3435B29BE3E5100935B73 /* MyPlubbingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B3435A29BE3E5100935B73 /* MyPlubbingResponse.swift */; };
 		C3B3435D29BE4A3000935B73 /* MyPlubbingParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B3435C29BE4A3000935B73 /* MyPlubbingParameter.swift */; };
 		C3C24CD3298FBA6D00056313 /* PeopleNumberToolTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C24CD2298FBA6D00056313 /* PeopleNumberToolTip.swift */; };
+		C3C7197C29DC81C700A6DFD9 /* ProfileEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C7197B29DC81C700A6DFD9 /* ProfileEditViewController.swift */; };
 		C3CD674A29B4B37C0052087E /* ScheduleParticipantViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3CD674929B4B37C0052087E /* ScheduleParticipantViewController.swift */; };
 		C3CD674E29B4DD9C0052087E /* ScheduleParticipantTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3CD674D29B4DD9C0052087E /* ScheduleParticipantTopView.swift */; };
 		C3CD675029B4E5970052087E /* ScheduleParticipantViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3CD674F29B4E5970052087E /* ScheduleParticipantViewModel.swift */; };
@@ -567,6 +569,7 @@
 		C316051A2997936200D27488 /* GuestQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestQuestionViewModel.swift; sourceTree = "<group>"; };
 		C316051E2997F92200D27488 /* EditMeetingPostRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMeetingPostRequest.swift; sourceTree = "<group>"; };
 		C31605202997F9C800D27488 /* EditMeetingQuestionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMeetingQuestionRequest.swift; sourceTree = "<group>"; };
+		C32AB18F29DDB9000045B919 /* ProfileEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditViewModel.swift; sourceTree = "<group>"; };
 		C332DFD42976E5440023B70B /* PhotoBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoBottomSheetViewController.swift; sourceTree = "<group>"; };
 		C33952EE29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleParticipantCollectionViewCell.swift; sourceTree = "<group>"; };
 		C33EF37C29A1DFD100D7A5CA /* ScheduleAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleAlarmView.swift; sourceTree = "<group>"; };
@@ -647,6 +650,7 @@
 		C3B3435A29BE3E5100935B73 /* MyPlubbingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPlubbingResponse.swift; sourceTree = "<group>"; };
 		C3B3435C29BE4A3000935B73 /* MyPlubbingParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPlubbingParameter.swift; sourceTree = "<group>"; };
 		C3C24CD2298FBA6D00056313 /* PeopleNumberToolTip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleNumberToolTip.swift; sourceTree = "<group>"; };
+		C3C7197B29DC81C700A6DFD9 /* ProfileEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditViewController.swift; sourceTree = "<group>"; };
 		C3CD674929B4B37C0052087E /* ScheduleParticipantViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleParticipantViewController.swift; sourceTree = "<group>"; };
 		C3CD674D29B4DD9C0052087E /* ScheduleParticipantTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleParticipantTopView.swift; sourceTree = "<group>"; };
 		C3CD674F29B4E5970052087E /* ScheduleParticipantViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleParticipantViewModel.swift; sourceTree = "<group>"; };
@@ -1429,6 +1433,7 @@
 				C3100CBA29BD8A96005FCCAD /* Component */,
 				C3E0390629C2087000C4744C /* Recruiting */,
 				C3EC027B29D958070024C962 /* Waiting */,
+				C3C7197A29DC81A100A6DFD9 /* ProfileEdit */,
 			);
 			path = MyPage;
 			sourceTree = "<group>";
@@ -1860,6 +1865,15 @@
 			path = Response;
 			sourceTree = "<group>";
 		};
+		C3C7197A29DC81A100A6DFD9 /* ProfileEdit */ = {
+			isa = PBXGroup;
+			children = (
+				C3C7197B29DC81C700A6DFD9 /* ProfileEditViewController.swift */,
+				C32AB18F29DDB9000045B919 /* ProfileEditViewModel.swift */,
+			);
+			path = ProfileEdit;
+			sourceTree = "<group>";
+		};
 		C3CD675229B4FB3E0052087E /* ScheduleParticipant */ = {
 			isa = PBXGroup;
 			children = (
@@ -2217,11 +2231,13 @@
 				C36CE39F29731A0700E3A68C /* PhotoSelectView.swift in Sources */,
 				BA784FAE297937DA00E8B06F /* CalendarControl.swift in Sources */,
 				C31605192997935100D27488 /* MeetingInfoViewModel.swift in Sources */,
+				C32AB19029DDB9000045B919 /* ProfileEditViewModel.swift in Sources */,
 				70A420AB298FAD000026E9F9 /* TopTabCollectionViewCell.swift in Sources */,
 				70A420BF29914B690026E9F9 /* RequestBookmarkResponse.swift in Sources */,
 				BAE1AD952944775C00CE36B9 /* PolicyViewController.swift in Sources */,
 				BA5DEB302974D8E200650788 /* NetworkResult.swift in Sources */,
 				70A420C029914B690026E9F9 /* SearchRecruitmentResponse.swift in Sources */,
+				C3C7197C29DC81C700A6DFD9 /* ProfileEditViewController.swift in Sources */,
 				70F1DFDE297A8A6C00F9BC83 /* MeetingRouter.swift in Sources */,
 				70727A3B29D32E4C003DE956 /* InquireAllTodolistResponse.swift in Sources */,
 				C34F71C329799B1C003DB376 /* TimeControl.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		C31D577429E16DBD00E056BA /* MyInfoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31D577329E16DBD00E056BA /* MyInfoRequest.swift */; };
 		C32AB19029DDB9000045B919 /* ProfileEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32AB18F29DDB9000045B919 /* ProfileEditViewModel.swift */; };
 		C332DFD52976E5440023B70B /* PhotoBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C332DFD42976E5440023B70B /* PhotoBottomSheetViewController.swift */; };
+		C3394CB929E177D2005EECD7 /* UpdateImageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3394CB829E177D2005EECD7 /* UpdateImageRequest.swift */; };
 		C33952EF29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33952EE29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift */; };
 		C33EF37D29A1DFD100D7A5CA /* ScheduleAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33EF37C29A1DFD100D7A5CA /* ScheduleAlarmView.swift */; };
 		C33FB0722993F84A00BEB15B /* EditMeetingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33FB0712993F84A00BEB15B /* EditMeetingViewController.swift */; };
@@ -573,6 +574,7 @@
 		C31D577329E16DBD00E056BA /* MyInfoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoRequest.swift; sourceTree = "<group>"; };
 		C32AB18F29DDB9000045B919 /* ProfileEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditViewModel.swift; sourceTree = "<group>"; };
 		C332DFD42976E5440023B70B /* PhotoBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoBottomSheetViewController.swift; sourceTree = "<group>"; };
+		C3394CB829E177D2005EECD7 /* UpdateImageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateImageRequest.swift; sourceTree = "<group>"; };
 		C33952EE29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleParticipantCollectionViewCell.swift; sourceTree = "<group>"; };
 		C33EF37C29A1DFD100D7A5CA /* ScheduleAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleAlarmView.swift; sourceTree = "<group>"; };
 		C33FB0712993F84A00BEB15B /* EditMeetingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMeetingViewController.swift; sourceTree = "<group>"; };
@@ -1791,6 +1793,7 @@
 			isa = PBXGroup;
 			children = (
 				C3B04E452981788800188E60 /* UploadImageRequest.swift */,
+				C3394CB829E177D2005EECD7 /* UpdateImageRequest.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -2298,6 +2301,7 @@
 				70F1DFE8297D969000F9BC83 /* RecruitmentRouter.swift in Sources */,
 				BA784FAA2978EB9900E8B06F /* SignUpViewModel.swift in Sources */,
 				702876C229A3751400E57509 /* ArchiveViewController.swift in Sources */,
+				C3394CB929E177D2005EECD7 /* UpdateImageRequest.swift in Sources */,
 				BA340E2229782311002BAF2C /* MeetingIntroduceView.swift in Sources */,
 				C38D65622987F0990052013F /* CategoryHeaderView.swift in Sources */,
 				C3EB29CB29A91CC600615B6B /* MeetingScheduleViewModel.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -237,6 +237,7 @@
 		C316051B2997936200D27488 /* GuestQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C316051A2997936200D27488 /* GuestQuestionViewModel.swift */; };
 		C316051F2997F92200D27488 /* EditMeetingPostRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C316051E2997F92200D27488 /* EditMeetingPostRequest.swift */; };
 		C31605212997F9C800D27488 /* EditMeetingQuestionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31605202997F9C800D27488 /* EditMeetingQuestionRequest.swift */; };
+		C31D577429E16DBD00E056BA /* MyInfoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31D577329E16DBD00E056BA /* MyInfoRequest.swift */; };
 		C32AB19029DDB9000045B919 /* ProfileEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32AB18F29DDB9000045B919 /* ProfileEditViewModel.swift */; };
 		C332DFD52976E5440023B70B /* PhotoBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C332DFD42976E5440023B70B /* PhotoBottomSheetViewController.swift */; };
 		C33952EF29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33952EE29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift */; };
@@ -569,6 +570,7 @@
 		C316051A2997936200D27488 /* GuestQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestQuestionViewModel.swift; sourceTree = "<group>"; };
 		C316051E2997F92200D27488 /* EditMeetingPostRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMeetingPostRequest.swift; sourceTree = "<group>"; };
 		C31605202997F9C800D27488 /* EditMeetingQuestionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMeetingQuestionRequest.swift; sourceTree = "<group>"; };
+		C31D577329E16DBD00E056BA /* MyInfoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoRequest.swift; sourceTree = "<group>"; };
 		C32AB18F29DDB9000045B919 /* ProfileEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditViewModel.swift; sourceTree = "<group>"; };
 		C332DFD42976E5440023B70B /* PhotoBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoBottomSheetViewController.swift; sourceTree = "<group>"; };
 		C33952EE29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleParticipantCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -995,6 +997,7 @@
 			isa = PBXGroup;
 			children = (
 				70CF332F299793220077FF47 /* RegisterInterestRequest.swift */,
+				C31D577329E16DBD00E056BA /* MyInfoRequest.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -2136,6 +2139,7 @@
 				70BD5F3729657E3E002CBA89 /* ApplyQuestionViewModel.swift in Sources */,
 				C332DFD52976E5440023B70B /* PhotoBottomSheetViewController.swift in Sources */,
 				70197B812955A68C000503F6 /* CategoryInfoListView.swift in Sources */,
+				C31D577429E16DBD00E056BA /* MyInfoRequest.swift in Sources */,
 				70BD5F2C2963204D002CBA89 /* DetailRecruitmentViewController.swift in Sources */,
 				BAE0AC7629B5D67D00F46F3D /* BoardDetailViewController.swift in Sources */,
 				C34F048429C715A800E5B67E /* SettingSubview.swift in Sources */,

--- a/PLUB/Sources/Models/Account/Request/MyInfoRequest.swift
+++ b/PLUB/Sources/Models/Account/Request/MyInfoRequest.swift
@@ -10,7 +10,7 @@ import Foundation
 struct MyInfoRequest: Codable {
   let nickname: String
   let introduce: String
-  let profileImage: String
+  let profileImage: String?
 }
 
 extension MyInfoRequest {

--- a/PLUB/Sources/Models/Account/Request/MyInfoRequest.swift
+++ b/PLUB/Sources/Models/Account/Request/MyInfoRequest.swift
@@ -1,0 +1,21 @@
+//
+//  MyInfoRequest.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/04/08.
+//
+
+import Foundation
+
+struct MyInfoRequest: Codable {
+  let nickname: String
+  let introduce: String
+  let profileImage: String
+}
+
+extension MyInfoRequest {
+  enum CodingKeys: String, CodingKey {
+    case nickname, introduce
+    case profileImage = "profileImageUrl"
+  }
+}

--- a/PLUB/Sources/Models/Image/Request/UpdateImageRequest.swift
+++ b/PLUB/Sources/Models/Image/Request/UpdateImageRequest.swift
@@ -1,0 +1,16 @@
+//
+//  UpdateImageRequest.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/04/08.
+//
+
+struct UpdateImageRequest: Codable {
+  let type: ImageType
+  let deleteURL: String
+  
+  enum CodingKeys: String, CodingKey {
+    case type
+    case deleteURL = "toDeleteUrls"
+  }
+}

--- a/PLUB/Sources/Network/Routers/AccountRouter.swift
+++ b/PLUB/Sources/Network/Routers/AccountRouter.swift
@@ -12,6 +12,7 @@ enum AccountRouter {
   case validateNickname(String)
   case inquireInterest
   case registerInterest(RegisterInterestRequest)
+  case updateMyInfo(MyInfoRequest)
 }
 
 extension AccountRouter: Router {
@@ -19,7 +20,7 @@ extension AccountRouter: Router {
     switch self {
     case .inquireMyInfo, .validateNickname, .inquireInterest:
       return .get
-    case .registerInterest:
+    case .registerInterest, .updateMyInfo:
       return .post
     }
   }
@@ -34,6 +35,8 @@ extension AccountRouter: Router {
       return "/accounts/me/interest"
     case .registerInterest:
       return "/accounts/interest"
+    case .updateMyInfo:
+      return "/accounts/me/profile"
     }
   }
   
@@ -41,7 +44,7 @@ extension AccountRouter: Router {
     switch self {
     case .validateNickname:
       return .default
-    case .inquireMyInfo, .inquireInterest, .registerInterest:
+    case .inquireMyInfo, .inquireInterest, .registerInterest, .updateMyInfo:
       return .withAccessToken
     }
   }
@@ -51,6 +54,8 @@ extension AccountRouter: Router {
     case .inquireMyInfo, .inquireInterest, .validateNickname:
       return .plain
     case .registerInterest(let request):
+      return .body(request)
+    case .updateMyInfo(let request):
       return .body(request)
     }
   }

--- a/PLUB/Sources/Network/Services/AccountService.swift
+++ b/PLUB/Sources/Network/Services/AccountService.swift
@@ -32,4 +32,8 @@ extension AccountService {
   func registerInterest(request: RegisterInterestRequest) -> PLUBResult<EmptyModel> {
     return sendRequest(AccountRouter.registerInterest(request))
   }
+  
+  func updateMyInfo(request: MyInfoRequest) -> PLUBResult<MyInfoResponse> {
+    return sendRequest(AccountRouter.updateMyInfo(request), type: MyInfoResponse.self)
+  }
 }

--- a/PLUB/Sources/Network/Services/ImageService.swift
+++ b/PLUB/Sources/Network/Services/ImageService.swift
@@ -11,6 +11,11 @@ import Alamofire
 import RxCocoa
 import RxSwift
 
+enum ImageServiceType {
+  case upload
+  case update
+}
+
 final class ImageService: BaseService {
   static let shared = ImageService()
   
@@ -32,9 +37,25 @@ extension ImageService {
     )
   }
   
+  func updateImage(
+    images: [UIImage],
+    params: UpdateImageRequest
+) -> PLUBResult<UploadImageResponse> {
+    return sendRequestWithImage(
+      setUpImageData(
+        images: images,
+        params: params.toDictionary,
+        type: .update
+      ),
+      ImageRouter.updateImage,
+      type: UploadImageResponse.self
+    )
+  }
+  
   private func setUpImageData(
     images: [UIImage],
-    params: [String: Any]
+    params: [String: Any],
+    type: ImageServiceType = .upload
   ) -> MultipartFormData {
     let formData = MultipartFormData()
 
@@ -42,7 +63,7 @@ extension ImageService {
       guard let imageData = image.jpegData(compressionQuality: 0.1) else { continue }
       formData.append(
         imageData,
-        withName: "files",
+        withName: type == .upload ? "files" : "newFiles",
         fileName: "\(image).jpeg",
         mimeType: "image/jpeg"
       )

--- a/PLUB/Sources/Views/Meeting/MeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewController.swift
@@ -197,8 +197,9 @@ extension MeetingViewController: UICollectionViewDelegate, UICollectionViewDataS
     }
     
     guard let previousIndex = previousIndex,
-      previousIndex != index
-    else { return }
+      previousIndex != index,
+      previousIndex < meetingList.count else { return }
+    
     meetingList[previousIndex].isDimmed = true
   }
 }

--- a/PLUB/Sources/Views/MyPage/Cell/MyPageSectionHeaderView.swift
+++ b/PLUB/Sources/Views/MyPage/Cell/MyPageSectionHeaderView.swift
@@ -47,8 +47,8 @@ final class MyPageSectionHeaderView: UITableViewHeaderFooterView {
   }
   
   private let foldImageView = UIImageView().then {
-    $0.image = UIImage(named: "foldedArrow")
-    $0.highlightedImage = UIImage(named: "unfoldedArrow")
+    $0.image = UIImage(named: "unfoldedArrow")
+    $0.highlightedImage = UIImage(named: "foldedArrow")
   }
   
   private let button = UIButton()

--- a/PLUB/Sources/Views/MyPage/Cell/MyPageTableViewCell.swift
+++ b/PLUB/Sources/Views/MyPage/Cell/MyPageTableViewCell.swift
@@ -48,7 +48,7 @@ final class MyPageTableViewCell: UITableViewCell {
   }
   
   private func setupLayouts() {
-    addSubview(contentStackView)
+    contentView.addSubview(contentStackView)
     [meetingImageView, textStackView].forEach {
       contentStackView.addArrangedSubview($0)
     }

--- a/PLUB/Sources/Views/MyPage/Component/MyProfileView.swift
+++ b/PLUB/Sources/Views/MyPage/Component/MyProfileView.swift
@@ -15,7 +15,7 @@ final class MyProfileView: UIView {
     $0.layer.cornerRadius = 32
   }
   
-  private let editButton = UIButton().then {
+  let editButton = UIButton().then {
     $0.setImage(UIImage(named: "pencil"), for: .normal)
   }
   

--- a/PLUB/Sources/Views/MyPage/Component/MyProfileView.swift
+++ b/PLUB/Sources/Views/MyPage/Component/MyProfileView.swift
@@ -12,7 +12,9 @@ import SnapKit
 final class MyProfileView: UIView {
   
   private let profileImageView = UIImageView().then {
+    $0.contentMode = .scaleAspectFill
     $0.layer.cornerRadius = 32
+    $0.clipsToBounds = true
   }
   
   let editButton = UIButton().then {

--- a/PLUB/Sources/Views/MyPage/MyPageViewController.swift
+++ b/PLUB/Sources/Views/MyPage/MyPageViewController.swift
@@ -94,6 +94,7 @@ final class MyPageViewController: BaseViewController {
         let vc = ProfileEditViewController(
           viewModel: ProfileEditViewModel(myInfoData: myInfoData)
         )
+        vc.delegate = owner
         vc.hidesBottomBarWhenPushed = true
         owner.navigationController?.pushViewController(vc, animated: true)
       }
@@ -222,5 +223,11 @@ extension MyPageViewController: MyPageNoneViewDelegate {
 extension MyPageViewController: MyPageCellDelegate {
   func removeCell(plubbingID: Int) {
     viewModel.removeCell(with: plubbingID)
+  }
+}
+
+extension MyPageViewController: ProfileEditDelegate {
+  func updateProfile(myInfo: MyInfoResponse) {
+    viewModel.updateMyInfo.onNext(myInfo)
   }
 }

--- a/PLUB/Sources/Views/MyPage/MyPageViewController.swift
+++ b/PLUB/Sources/Views/MyPage/MyPageViewController.swift
@@ -85,6 +85,19 @@ final class MyPageViewController: BaseViewController {
         owner.tableView.reloadSections([index], with: .automatic)
       }
       .disposed(by: disposeBag)
+    
+    profileView.editButton
+      .rx.tap
+      .asDriver()
+      .drive(with: self) { owner, _ in
+        guard let myInfoData = owner.viewModel.myInfoData else { return }
+        let vc = ProfileEditViewController(
+          viewModel: ProfileEditViewModel(myInfoData: myInfoData)
+        )
+        vc.hidesBottomBarWhenPushed = true
+        owner.navigationController?.pushViewController(vc, animated: true)
+      }
+      .disposed(by: disposeBag)
   }
 }
 

--- a/PLUB/Sources/Views/MyPage/MyPageViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/MyPageViewModel.swift
@@ -20,6 +20,7 @@ final class MyPageViewModel {
   
   // Input
   let sectionTapped: AnyObserver<Int> // 섹션뷰 클릭 이벤트
+  let updateMyInfo: AnyObserver<MyInfoResponse> // 내 정보 데이터 갱신
   
   // Output
   let myInfo: Driver<MyInfoResponse> // 내 정보 데이터
@@ -27,6 +28,7 @@ final class MyPageViewModel {
   let reloadSection: Driver<Int> // 테이블 뷰 섹션 갱신
   
   private let sectionTappedSubject = PublishSubject<Int>()
+  private let updateMyInfoSubject = PublishSubject<MyInfoResponse>()
   private let myInfoSubject = PublishSubject<MyInfoResponse>()
   private let reloadDataSubject = PublishSubject<Void>()
   private let reloadSectionSubject = PublishSubject<Int>()
@@ -37,6 +39,7 @@ final class MyPageViewModel {
   
   init() {
     sectionTapped = sectionTappedSubject.asObserver()
+    updateMyInfo = updateMyInfoSubject.asObserver()
     
     myInfo = myInfoSubject.asDriver(onErrorDriveWith: .empty())
     reloadData = reloadDataSubject.asDriver(onErrorDriveWith: .empty())
@@ -49,6 +52,13 @@ final class MyPageViewModel {
         owner.reloadSectionSubject.onNext(index)
       })
       .disposed(by: disposeBag)
+    
+    updateMyInfoSubject
+      .withUnretained(self)
+      .subscribe(onNext: { owner, myInfo in
+        owner.setupMyInfoData(myInfo: myInfo)
+      })
+      .disposed(by: disposeBag)
   }
   
   func fetchMyInfoData() {
@@ -59,8 +69,7 @@ final class MyPageViewModel {
         case .success(let model):
           print(model)
           guard let data = model.data else { return }
-          owner.myInfoData = data
-          owner.myInfoSubject.onNext(data)
+          owner.setupMyInfoData(myInfo: data)
         default:
           break
         }
@@ -117,5 +126,10 @@ final class MyPageViewModel {
         }
       }
     }
+  }
+  
+  private func setupMyInfoData(myInfo: MyInfoResponse) {
+    myInfoData = myInfo
+    myInfoSubject.onNext(myInfo)
   }
 }

--- a/PLUB/Sources/Views/MyPage/MyPageViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/MyPageViewModel.swift
@@ -22,7 +22,7 @@ final class MyPageViewModel {
   let sectionTapped: AnyObserver<Int> // 섹션뷰 클릭 이벤트
   
   // Output
-  var myInfo: Driver<MyInfoResponse> // 내 정보 데이터
+  let myInfo: Driver<MyInfoResponse> // 내 정보 데이터
   let reloadData: Driver<Void> // 테이블 뷰 갱신
   let reloadSection: Driver<Int> // 테이블 뷰 섹션 갱신
   

--- a/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewController.swift
+++ b/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewController.swift
@@ -1,0 +1,328 @@
+//
+//  ProfileEditViewController.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/04/05.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
+
+final class ProfileEditViewController: BaseViewController {
+  
+  // MARK: - Property
+  
+  weak var delegate: SignUpChildViewControllerDelegate?
+  
+  private let viewModel = ProfileEditViewModel()
+  
+  private let wholeStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 48
+  }
+  
+  // MARK: Profile Part
+  
+  private let profileStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.alignment = .center
+    $0.spacing = 16
+  }
+  
+  private let profileLabel = UILabel().then {
+    $0.text = "프로필 사진"
+    $0.font = .subtitle
+  }
+  
+  private let uploadImageButton = UIButton().then {
+    $0.imageView?.contentMode = .scaleAspectFill
+    $0.layer.cornerRadius = 60
+    $0.clipsToBounds = true
+    $0.setImage(UIImage(named: "userDefaultImage"), for: .normal)
+  }
+  
+  private let pencilImageView = UIImageView(image: UIImage(named: "pencilCircle")).then {
+    $0.layer.borderColor = UIColor.background.cgColor
+    $0.layer.borderWidth = 2
+    $0.layer.cornerRadius = 16
+    $0.contentMode = .scaleAspectFit
+  }
+  
+  // MARK: Nickname Part
+  
+  private let nicknameStackView: UIStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 8
+  }
+  
+  private let nicknameLabel: UILabel = UILabel().then {
+    $0.text = "닉네임"
+    $0.font = .subtitle
+  }
+  
+  private lazy var nicknameTextField = PaddingTextField(left: 8, right: 8).then {
+    $0.layer.borderWidth = 1
+    $0.layer.cornerRadius = 8
+    
+    $0.rightView = UIButton().then {
+      $0.setImage(UIImage(named: "xMark")?.withRenderingMode(.alwaysTemplate), for: .normal)
+    }
+    $0.textColor = .black
+    $0.font = .body1
+    
+    $0.delegate = self
+  }
+  
+  // MARK: Alert in Nickname
+  
+  private let alertStackView: UIStackView = UIStackView().then {
+    $0.spacing = 4
+    $0.distribution = .fillProportionally
+    $0.alignment = .center
+  }
+  
+  private let alertImageView: UIImageView = UIImageView().then {
+    $0.contentMode = .scaleAspectFit
+  }
+  
+  private let alertLabel: UILabel = UILabel().then {
+    $0.font = .caption
+  }
+  
+  // MARK: Introduction
+  
+  private let introductionTextView = InputTextView(
+    title: Constants.introduction,
+    placeHolder: Constants.introductionPlaceholder,
+    options: [.textCount],
+    totalCharacterLimit: 150
+  )
+  
+  // MARK: Save Button
+  
+  private let saveButton = UIButton(configuration: .plain()).then {
+    $0.configurationUpdateHandler = $0.configuration?.plubButton(label: "저장")
+  }
+  
+  // MARK: - Configuration
+  
+  override func setupLayouts() {
+    super.setupLayouts()
+    
+    [wholeStackView, pencilImageView, saveButton].forEach {
+      view.addSubview($0)
+    }
+    
+    [profileStackView, nicknameStackView, introductionTextView].forEach {
+      wholeStackView.addArrangedSubview($0)
+    }
+    
+    wholeStackView.setCustomSpacing(39, after: nicknameStackView)
+    
+    [profileLabel, uploadImageButton].forEach {
+      profileStackView.addArrangedSubview($0)
+    }
+    
+    [nicknameLabel, nicknameTextField, alertStackView].forEach {
+      nicknameStackView.addArrangedSubview($0)
+    }
+    
+    [alertImageView, alertLabel].forEach {
+      alertStackView.addArrangedSubview($0)
+    }
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    
+    wholeStackView.snp.makeConstraints {
+      $0.top.equalTo(view.safeAreaLayoutGuide).inset(30)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(24)
+    }
+    
+    uploadImageButton.snp.makeConstraints {
+      $0.size.equalTo(120)
+    }
+    
+    pencilImageView.snp.makeConstraints {
+      $0.size.equalTo(32)
+      $0.trailing.bottom.equalTo(uploadImageButton)
+    }
+    
+    saveButton.snp.makeConstraints {
+      $0.height.equalTo(46)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(16)
+      $0.bottom.equalToSuperview().inset(26)
+    }
+    
+    profileLabel.snp.makeConstraints {
+      $0.leading.equalToSuperview()
+    }
+    
+    nicknameTextField.snp.makeConstraints {
+      $0.height.equalTo(46)
+    }
+    
+    alertImageView.snp.makeConstraints {
+      $0.size.equalTo(18)
+    }
+  }
+  
+  override func setupStyles() {
+    super.setupStyles()
+    configureInitialUI()
+    setupNavigationBar()
+  }
+  
+  override func bind() {
+    super.bind()
+    
+    uploadImageButton.rx.tap
+      .asDriver()
+      .drive(with: self, onNext: { owner, _ in
+        let photoVC = PhotoBottomSheetViewController()
+        photoVC.modalPresentationStyle = .overFullScreen
+        photoVC.delegate = owner
+        owner.parent?.present(photoVC, animated: false)
+      })
+      .disposed(by: disposeBag)
+    
+    
+    // textField의 clean button 구현
+    (nicknameTextField.rightView as? UIButton)?.rx.tap
+      .asDriver()
+      .drive(with: self, onNext: { owner, _ in
+        owner.nicknameTextField.text = ""
+        owner.configureInitialUI()
+      })
+      .disposed(by: disposeBag)
+    
+    // 텍스트가 비어있으면 UI 회색 처리
+    nicknameTextField.rx.text
+      .orEmpty
+      .skip(1)
+      .distinctUntilChanged()
+      .filter { $0 == "" }
+      .withUnretained(self)
+      .subscribe(onNext: { owner, _ in
+        owner.configureInitialUI()
+      })
+      .disposed(by: disposeBag)
+    
+    // ===  ViewModel Binding  ===
+    
+    // 빨리 입력하면 api가 여러번 호출되므로, 0.5초동안 입력 없을 시 데이터 emit
+    nicknameTextField.rx.text
+      .orEmpty
+      .distinctUntilChanged()
+      .skip(1)
+      .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
+      .filter { $0 != "" }
+      .bind(to: viewModel.nicknameText)
+      .disposed(by: disposeBag)
+    
+    // 닉네임 사용가능여부를 판단하고 UI 업데이트
+    viewModel.isAvailableNickname
+      .drive(with: self) { owner, flag in
+        owner.updateNicknameValidationUI(isValid: flag)
+        // 부모 뷰컨의 `확인 버튼` 활성화 처리
+        owner.delegate?.checkValidation(index: 2, state: flag)
+      }
+      .disposed(by: disposeBag)
+    
+    viewModel.isAvailableNickname
+      .filter { $0 }
+      .withLatestFrom(nicknameTextField.rx.text.asDriver())
+      .compactMap { $0 }
+      .drive(with: self) { owner, nickname in
+        // 사용가능한 닉네임 전달
+        owner.delegate?.information(nickname: nickname)
+      }
+      .disposed(by: disposeBag)
+    
+    // 메시지 처리
+    viewModel.alertMessage
+      .drive(alertLabel.rx.text)
+      .disposed(by: disposeBag)
+  }
+  
+  /// 최초 상태의 UI를 설정합니다. (textField, label, bubble image 등)
+  private func configureInitialUI() {
+    
+    // placeholder 폰트 설정
+    nicknameTextField.attributedPlaceholder = NSAttributedString(
+      string: Constants.nicknamePlaceholder,
+      attributes: [.font: UIFont.body2]
+    )
+    
+    nicknameTextField.layer.borderColor = UIColor.mediumGray.cgColor
+    nicknameTextField.rightView?.tintColor = .mediumGray
+    
+    alertLabel.text = Constants.nicknameAlertMessage
+    alertLabel.textColor = .mediumGray
+    
+    alertImageView.image = UIImage(named: "bubbleWarning")
+  }
+  
+  private func setupNavigationBar() {
+    navigationItem.leftBarButtonItem = UIBarButtonItem(
+      image: UIImage(named: "backButton"),
+      style: .plain,
+      target: self,
+      action: #selector(didTappedBackButton)
+    )
+  }
+  
+  @objc
+  private func didTappedBackButton() {
+    navigationController?.popViewController(animated: true)
+  }
+  
+  /// 닉네임 검증 여부에 따라 색을 지정해줍니다.
+  private func updateNicknameValidationUI(isValid: Bool) {
+    if isValid {
+      alertLabel.textColor = .main
+      nicknameTextField.rightView?.tintColor = .main
+      nicknameTextField.layer.borderColor = UIColor.main.cgColor
+      alertImageView.image = UIImage(named: "bubbleCheck")
+    } else {
+      alertLabel.textColor = .error
+      alertImageView.tintColor = .error
+      nicknameTextField.textColor = .error
+      nicknameTextField.rightView?.tintColor = .error
+      nicknameTextField.layer.borderColor = UIColor.error.cgColor
+      alertImageView.image = UIImage(named: "bubbleWarning")?.withRenderingMode(.alwaysTemplate)
+    }
+  }
+}
+
+extension ProfileEditViewController: PhotoBottomSheetDelegate {
+  func selectImage(image: UIImage) {
+    uploadImageButton.setImage(image, for: .normal)
+    delegate?.information(profile: image) // 프로필 이미지 전달
+  }
+}
+
+extension ProfileEditViewController: UITextFieldDelegate {
+  
+  func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+    delegate?.checkValidation(index: 2, state: false)
+    textField.textColor = .black
+    return range.location < 15
+  }
+}
+
+extension ProfileEditViewController {
+  
+  enum Constants {
+    static let nicknamePlaceholder = "한글, 영문, 숫자 포함 8글자로 입력가능해요."
+    static let nicknameAlertMessage = "닉네임 변경은 한번만 가능해요"
+    static let introduction = "소개"
+    static let introductionPlaceholder = "소개하는 내용을 입력해주세요"
+  }
+  
+}

--- a/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewController.swift
+++ b/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewController.swift
@@ -12,7 +12,13 @@ import RxSwift
 import SnapKit
 import Then
 
+protocol ProfileEditDelegate: AnyObject {
+  func updateProfile(myInfo: MyInfoResponse)
+}
+
 final class ProfileEditViewController: BaseViewController {
+  
+  weak var delegate: ProfileEditDelegate?
   
   // MARK: - Property
   
@@ -228,7 +234,6 @@ final class ProfileEditViewController: BaseViewController {
     introductionTextView.textView.rx.text
       .orEmpty
       .distinctUntilChanged()
-      .skip(1)
       .bind(to: viewModel.introduceText)
       .disposed(by: disposeBag)
     
@@ -249,6 +254,14 @@ final class ProfileEditViewController: BaseViewController {
     saveButton
       .rx.tap
       .bind(to: viewModel.updateButtonTapped)
+      .disposed(by: disposeBag)
+    
+    viewModel
+      .successUpdateProfile
+      .drive(with: self) { owner, myInfo in
+        owner.delegate?.updateProfile(myInfo: myInfo)
+        owner.navigationController?.popViewController(animated: true)
+      }
       .disposed(by: disposeBag)
   }
   
@@ -321,7 +334,6 @@ extension ProfileEditViewController: PhotoBottomSheetDelegate {
 extension ProfileEditViewController: UITextFieldDelegate {
   
   func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-//    delegate?.checkValidation(index: 2, state: false)
     textField.textColor = .black
     return range.location < 15
   }

--- a/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 import RxCocoa
 import RxSwift
@@ -13,29 +14,66 @@ import RxSwift
 final class ProfileEditViewModel {
   // input
   let nicknameText: AnyObserver<String> // 닉네임 텍스트
+  let introduceText: AnyObserver<String> // 소개 텍스트
+  let editedImage: AnyObserver<UIImage?> // 변경된 이미지
+  let updateButtonTapped: AnyObserver<Void> // 변경 버튼 클릭 이벤트
   
   // output
   let isAvailableNickname: Driver<Bool> // 닉네임 사용 가능 여부
   let alertMessage: Driver<String>      // 닉네임 관련 알림 문구
+  let isButtonEnabled: Driver<Bool> // 버튼 활성화 제어
+  
+  private let nicknameSubject = PublishSubject<String>()
+  private let introduceSubject = PublishSubject<String>()
+  private let editedImageSubject = PublishSubject<UIImage?>()
+  private let updateButtonSubject = PublishSubject<Void>()
   
   private let isAvailableRelay = PublishRelay<Bool>()
   private let alertMessageRelay = PublishRelay<String>()
-  private let nicknameSubject = PublishSubject<String>()
-  
   private let disposeBag = DisposeBag()
   
-  init() {
+  private(set) var myInfoData: MyInfoResponse // 내정보
+  
+  init(myInfoData: MyInfoResponse) {
+    self.myInfoData = myInfoData
+    
     nicknameText = nicknameSubject.asObserver()
+    introduceText = introduceSubject.asObserver()
+    editedImage = editedImageSubject.asObserver()
+    updateButtonTapped = updateButtonSubject.asObserver()
+    
     isAvailableNickname = isAvailableRelay.asDriver(onErrorDriveWith: .empty())
     alertMessage = alertMessageRelay.asDriver(onErrorDriveWith: .empty())
-    bind()
-  }
-  
-  private func bind() {
+    
+    isButtonEnabled = Driver.combineLatest(
+      introduceSubject.asDriver(onErrorDriveWith: .empty()),
+      isAvailableNickname
+    ) { introduce, isAvailable in
+      !introduce.isEmpty && isAvailable
+    }
+    
     nicknameSubject
       .withUnretained(self)
       .subscribe(onNext: { owner, text in
         owner.validate(text: text)
+      })
+      .disposed(by: disposeBag)
+    
+    updateButtonSubject
+      .withLatestFrom(
+        Observable.combineLatest(
+          nicknameSubject,
+          introduceSubject,
+          editedImageSubject
+        )
+      )
+      .subscribe(onNext: { [weak self] nickName, introduce, image in
+        guard let self = self else { return }
+        self.updateMyInfo(
+          nickName: nickName,
+          introduce: introduce,
+          image: image
+        )
       })
       .disposed(by: disposeBag)
   }
@@ -87,5 +125,109 @@ final class ProfileEditViewModel {
         }
       })
       .disposed(by: disposeBag)
+  }
+  
+  private func updateMyInfo(
+    nickName: String,
+    introduce: String,
+    image: UIImage?
+  ) {
+    if let image = image { // 변경된 이미지 있을 때
+      if let prevImageURL = myInfoData.profileImage { // 이전 이미지 존재하는 경우
+        updateImage(
+          nickName: nickName,
+          introduce: introduce,
+          deleteURL: prevImageURL,
+          image: image
+        )
+      } else { // 처음 이미지 올리는 경우
+        uploadImage(
+          nickName: nickName,
+          introduce: introduce,
+          image: image
+        )
+      }
+    } else { // 변경된 이미지 없을 때
+      updateMyInfo(
+        request: MyInfoRequest(
+          nickname: nickName,
+          introduce: introduce,
+          profileImage: nil
+        )
+      )
+    }
+  }
+  
+  private func updateMyInfo(request: MyInfoRequest) {
+    AccountService.shared.updateMyInfo(request: request)
+      .withUnretained(self)
+      .subscribe(onNext: { owner, result in
+        switch result {
+        case .success(let model):
+          print(model.data)
+        default:
+          break
+        }
+      })
+      .disposed(by: disposeBag)
+  }
+  
+  private func uploadImage(
+    nickName: String,
+    introduce: String,
+    image: UIImage
+  ) {
+    ImageService.shared.uploadImage(
+      images: [image],
+      params: UploadImageRequest(type: .plubbingMain)
+    )
+    .withUnretained(self)
+    .subscribe(onNext: { owner, result in
+      switch result {
+      case .success(let model):
+        guard let data = model.data,
+              let fileUrl = data.files.first?.fileUrl else { return }
+        owner.updateMyInfo(
+          request: MyInfoRequest(
+            nickname: nickName,
+            introduce: introduce,
+            profileImage: fileUrl
+          )
+        )
+        
+      default: break// TODO: 수빈 - PLUB 에러 Alert 띄우기
+      }
+    })
+    .disposed(by: disposeBag)
+  }
+  
+  private func updateImage(
+    nickName: String,
+    introduce: String,
+    deleteURL: String,
+    image: UIImage
+  ) {
+    ImageService.shared.updateImage(
+      images: [image],
+      params: UpdateImageRequest(type: .plubbingMain, deleteURL: deleteURL)
+    )
+    .withUnretained(self)
+    .subscribe(onNext: { owner, result in
+      switch result {
+      case .success(let model):
+        guard let data = model.data,
+              let fileUrl = data.files.first?.fileUrl else { return }
+        owner.updateMyInfo(
+          request: MyInfoRequest(
+            nickname: nickName,
+            introduce: introduce,
+            profileImage: fileUrl
+          )
+        )
+        
+      default: break// TODO: 수빈 - PLUB 에러 Alert 띄우기
+      }
+    })
+    .disposed(by: disposeBag)
   }
 }

--- a/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewModel.swift
@@ -84,6 +84,13 @@ final class ProfileEditViewModel {
   private func validate(text: String) {
     let characterRegex = "[^a-zA-Z가-힣0-9]" // 한글, 영어, 숫자를 제외한 문자를 찾는 정규표현식 (특수문자 찾기용)
     
+    // 기존 닉네임과 동일
+    if text == myInfoData.nickname {
+      isAvailableRelay.accept(true)
+      alertMessageRelay.accept("닉네임 변경은 한번만 가능해요")
+      return
+    }
+    
     // 2~8자가 아닌 경우
     if text.count < 2 || text.count > 8 {
       isAvailableRelay.accept(false)

--- a/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewModel.swift
@@ -72,11 +72,20 @@ final class ProfileEditViewModel {
       )
       .subscribe(onNext: { [weak self] nickName, introduce, image in
         guard let self = self else { return }
-        self.updateMyInfo(
-          nickName: nickName,
-          introduce: introduce,
-          image: image
-        )
+        
+        if nickName == self.myInfoData.nickname {
+          self.updateMyInfo(
+            nickName: nickName,
+            introduce: introduce,
+            image: image
+          )
+        } else {
+          self.showNicknameAlert(
+            nickName: nickName,
+            introduce: introduce,
+            image: image
+          )
+        }
       })
       .disposed(by: disposeBag)
   }
@@ -240,5 +249,29 @@ final class ProfileEditViewModel {
       }
     })
     .disposed(by: disposeBag)
+  }
+  
+  private func showNicknameAlert(
+    nickName: String,
+    introduce: String,
+    image: UIImage?
+  ) {
+    let alert = CustomAlertView(
+      AlertModel(
+        title: "닉네임을 변경할까요?",
+        message: "닉네임 변경은 1회만 가능해요.\n지금 변경한 닉네임은 탈퇴 시까지 사용됩니다",
+        cancelButton: "취소",
+        confirmButton: "네, 할게요",
+        height: 210
+      )
+    ) { [weak self] in
+      guard let self = self else { return }
+      self.updateMyInfo(
+        nickName: nickName,
+        introduce: introduce,
+        image: image
+      )
+    }
+    alert.show()
   }
 }

--- a/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewModel.swift
@@ -70,17 +70,17 @@ final class ProfileEditViewModel {
           editedImageSubject
         )
       )
-      .subscribe(onNext: { [weak self] nickName, introduce, image in
-        guard let self = self else { return }
-        
-        if nickName == self.myInfoData.nickname {
-          self.updateMyInfo(
+      .withUnretained(self)
+      .subscribe(onNext: { (owner: ProfileEditViewModel, info: (String, String, UIImage?)) in
+        let (nickName, introduce, image) = info
+        if nickName == owner.myInfoData.nickname {
+          owner.updateMyInfo(
             nickName: nickName,
             introduce: introduce,
             image: image
           )
         } else {
-          self.showNicknameAlert(
+          owner.showNicknameAlert(
             nickName: nickName,
             introduce: introduce,
             image: image

--- a/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewModel.swift
@@ -22,11 +22,13 @@ final class ProfileEditViewModel {
   let isAvailableNickname: Driver<Bool> // 닉네임 사용 가능 여부
   let alertMessage: Driver<String>      // 닉네임 관련 알림 문구
   let isButtonEnabled: Driver<Bool> // 버튼 활성화 제어
+  let successUpdateProfile: Driver<MyInfoResponse> // 프로필 변경 완료
   
   private let nicknameSubject = PublishSubject<String>()
   private let introduceSubject = PublishSubject<String>()
-  private let editedImageSubject = PublishSubject<UIImage?>()
+  private let editedImageSubject = BehaviorSubject<UIImage?>(value: nil)
   private let updateButtonSubject = PublishSubject<Void>()
+  private let successUpdateProfileSubject = PublishSubject<MyInfoResponse>()
   
   private let isAvailableRelay = PublishRelay<Bool>()
   private let alertMessageRelay = PublishRelay<String>()
@@ -44,6 +46,7 @@ final class ProfileEditViewModel {
     
     isAvailableNickname = isAvailableRelay.asDriver(onErrorDriveWith: .empty())
     alertMessage = alertMessageRelay.asDriver(onErrorDriveWith: .empty())
+    successUpdateProfile = successUpdateProfileSubject.asDriver(onErrorDriveWith: .empty())
     
     isButtonEnabled = Driver.combineLatest(
       introduceSubject.asDriver(onErrorDriveWith: .empty()),
@@ -164,7 +167,8 @@ final class ProfileEditViewModel {
       .subscribe(onNext: { owner, result in
         switch result {
         case .success(let model):
-          print(model.data)
+          guard let data = model.data else { return }
+          owner.successUpdateProfileSubject.onNext(data)
         default:
           break
         }

--- a/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewModel.swift
+++ b/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewModel.swift
@@ -1,0 +1,91 @@
+//
+//  ProfileEditViewModel.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/04/05.
+//
+
+import Foundation
+
+import RxCocoa
+import RxSwift
+
+final class ProfileEditViewModel {
+  // input
+  let nicknameText: AnyObserver<String> // 닉네임 텍스트
+  
+  // output
+  let isAvailableNickname: Driver<Bool> // 닉네임 사용 가능 여부
+  let alertMessage: Driver<String>      // 닉네임 관련 알림 문구
+  
+  private let isAvailableRelay = PublishRelay<Bool>()
+  private let alertMessageRelay = PublishRelay<String>()
+  private let nicknameSubject = PublishSubject<String>()
+  
+  private let disposeBag = DisposeBag()
+  
+  init() {
+    nicknameText = nicknameSubject.asObserver()
+    isAvailableNickname = isAvailableRelay.asDriver(onErrorDriveWith: .empty())
+    alertMessage = alertMessageRelay.asDriver(onErrorDriveWith: .empty())
+    bind()
+  }
+  
+  private func bind() {
+    nicknameSubject
+      .withUnretained(self)
+      .subscribe(onNext: { owner, text in
+        owner.validate(text: text)
+      })
+      .disposed(by: disposeBag)
+  }
+  
+  private func validate(text: String) {
+    let characterRegex = "[^a-zA-Z가-힣0-9]" // 한글, 영어, 숫자를 제외한 문자를 찾는 정규표현식 (특수문자 찾기용)
+    
+    // 2~8자가 아닌 경우
+    if text.count < 2 || text.count > 8 {
+      isAvailableRelay.accept(false)
+      alertMessageRelay.accept("2자에서 8자 사이로 입력해주세요.")
+      return
+    }
+    
+    // text에 공백이 존재하는 경우
+    if text.range(of: " ") != nil {
+      isAvailableRelay.accept(false)
+      alertMessageRelay.accept("띄어쓰기를 할 수 없어요.")
+      return
+    }
+    
+    // 특수문자가 발생한 경우
+    if text.range(of: characterRegex, options: .regularExpression) != nil {
+      isAvailableRelay.accept(false)
+      alertMessageRelay.accept("특수문자는 사용할 수 없어요.")
+      return
+    }
+    
+    // 닉네임 중복 검사
+    AccountService.shared.validateNickname(text)
+      .withUnretained(self)
+      .subscribe(onNext: { owner, result in
+        switch result {
+        case .success:
+          owner.isAvailableRelay.accept(true)
+          owner.alertMessageRelay.accept("사용가능한 닉네임이에요.")
+        case let .requestError(model):
+          // 중복인 닉네임일 때
+          if model.statusCode == 2060 {
+            owner.isAvailableRelay.accept(false)
+            owner.alertMessageRelay.accept("이미 사용중인 닉네임이에요.")
+          } else {
+            owner.isAvailableRelay.accept(false)
+            owner.alertMessageRelay.accept("잘못된 값을 입력했어요.")
+          }
+        // TODO: 승헌 - path error, server error, network error에 따른 alert 처리
+        default:
+          break
+        }
+      })
+      .disposed(by: disposeBag)
+  }
+}

--- a/PLUB/Sources/Views/MyPage/Recruiting/Cell/RecruitingSectionHeaderView.swift
+++ b/PLUB/Sources/Views/MyPage/Recruiting/Cell/RecruitingSectionHeaderView.swift
@@ -50,8 +50,8 @@ final class RecruitingSectionHeaderView: UITableViewHeaderFooterView {
   }
   
   private let foldImageView = UIImageView().then {
-    $0.image = UIImage(named: "foldedArrow")
-    $0.highlightedImage = UIImage(named: "unfoldedArrow")
+    $0.image = UIImage(named: "unfoldedArrow")
+    $0.highlightedImage = UIImage(named: "foldedArrow")
   }
   
   private let button = UIButton()


### PR DESCRIPTION
## 📌 PR 요약
마이페이지 > 프로필 편집 기능을 구현 하였습니다.

🌱 작업한 내용
- 프로필 편집 화면 UI 작업
- 프로필 편집 API 연동
- 이미지 편집 API 연동
- 이미지 업로드 API 연동

🌱 PR 포인트
### 프로필 편집 로직 간단 정리
✔️ updateButton 눌렀을 때
1) 닉네임이 이전과 동일할 때
 : updateMyInfo 함수 호출
2) 닉네임이 이전과 다를때
: 닉네임 변경 Alert -> updateMyInfo 함수 호출

✔️ updateMyInfo 함수 내부 로직
1) 변경된 이미지 있을 때
 1-1) 이전 이미지 존재하는 경우 : 이미지 업데이트 API -> 프로필 편집 API 
 1-2) 처음 이미지 올리는 경우: 이미지 업로드 API -> 프로필 편집 API 
2) 변경된 이미지 없는 경우
 : 프로필 편집 API 

```swift
  private func updateMyInfo(
    nickName: String,
    introduce: String,
    image: UIImage?
  ) {
    if let image = image { // 변경된 이미지 있을 때
      if let prevImageURL = myInfoData.profileImage { // 이전 이미지 존재하는 경우
        updateImage(
          nickName: nickName,
          introduce: introduce,
          deleteURL: prevImageURL,
          image: image
        )
      } else { // 처음 이미지 올리는 경우
        uploadImage(
          nickName: nickName,
          introduce: introduce,
          image: image
        )
      }
    } else { // 변경된 이미지 없을 때
      updateMyInfo(
        request: MyInfoRequest(
          nickname: nickName,
          introduce: introduce,
          profileImage: nil
        )
      )
    }
  }
``` 

## 📸 스크린샷

https://user-images.githubusercontent.com/77331348/230729397-c59c59bc-0bb1-4df1-a221-efc9b6e1248e.mov


## 📮 관련 이슈
-  #130 이

