### PR TITLE
로깅 구현

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -59,8 +59,8 @@
 		70727A4529D5E570003DE956 /* TodoAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A4429D5E570003DE956 /* TodoAlertView.swift */; };
 		70727A4729D6D507003DE956 /* TodoInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A4629D6D507003DE956 /* TodoInfoView.swift */; };
 		70727ABB29DAA745003DE956 /* SuccessApply.json in Resources */ = {isa = PBXBuildFile; fileRef = 70727ABA29DAA745003DE956 /* SuccessApply.json */; };
-		70727ABF29DE8B82003DE956 /* CategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727ABE29DE8B82003DE956 /* CategoryModel.swift */; };
 		70727ABD29DDD519003DE956 /* SelectedCategoryCollectionViewCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727ABC29DDD519003DE956 /* SelectedCategoryCollectionViewCellModel.swift */; };
+		70727ABF29DE8B82003DE956 /* CategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727ABE29DE8B82003DE956 /* CategoryModel.swift */; };
 		7085678628EE9A92008047DC /* HomeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678528EE9A92008047DC /* HomeCollectionViewCell.swift */; };
 		7085678828EEACFB008047DC /* InterestSelectCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678728EEACFB008047DC /* InterestSelectCollectionViewCell.swift */; };
 		7085678A28EEB73F008047DC /* InterestSelectCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7085678928EEB73F008047DC /* InterestSelectCollectionHeaderView.swift */; };
@@ -217,6 +217,7 @@
 		BAE1AD952944775C00CE36B9 /* PolicyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */; };
 		BAE1AD972944C16600CE36B9 /* PolicyHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */; };
 		BAE1AD992944C75F00CE36B9 /* PolicyBodyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE1AD982944C75F00CE36B9 /* PolicyBodyTableViewCell.swift */; };
+		BAE234BA29E2832200F779B2 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE234B929E2832200F779B2 /* Log.swift */; };
 		BAE2B362297C1D6C0000D5B9 /* AccountRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE2B361297C1D6C0000D5B9 /* AccountRouter.swift */; };
 		BAE2B364297C1D720000D5B9 /* AccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE2B363297C1D720000D5B9 /* AccountService.swift */; };
 		BAE5D3352975B10F00268D44 /* ReissuanceRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE5D3342975B10F00268D44 /* ReissuanceRequest.swift */; };
@@ -406,8 +407,8 @@
 		70727A4429D5E570003DE956 /* TodoAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoAlertView.swift; sourceTree = "<group>"; };
 		70727A4629D6D507003DE956 /* TodoInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoInfoView.swift; sourceTree = "<group>"; };
 		70727ABA29DAA745003DE956 /* SuccessApply.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = SuccessApply.json; sourceTree = "<group>"; };
-		70727ABE29DE8B82003DE956 /* CategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModel.swift; sourceTree = "<group>"; };
 		70727ABC29DDD519003DE956 /* SelectedCategoryCollectionViewCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedCategoryCollectionViewCellModel.swift; sourceTree = "<group>"; };
+		70727ABE29DE8B82003DE956 /* CategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModel.swift; sourceTree = "<group>"; };
 		7085678528EE9A92008047DC /* HomeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCollectionViewCell.swift; sourceTree = "<group>"; };
 		7085678728EEACFB008047DC /* InterestSelectCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestSelectCollectionViewCell.swift; sourceTree = "<group>"; };
 		7085678928EEB73F008047DC /* InterestSelectCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestSelectCollectionHeaderView.swift; sourceTree = "<group>"; };
@@ -556,6 +557,7 @@
 		BAE1AD942944775C00CE36B9 /* PolicyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyViewController.swift; sourceTree = "<group>"; };
 		BAE1AD962944C16600CE36B9 /* PolicyHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyHeaderTableViewCell.swift; sourceTree = "<group>"; };
 		BAE1AD982944C75F00CE36B9 /* PolicyBodyTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyBodyTableViewCell.swift; sourceTree = "<group>"; };
+		BAE234B929E2832200F779B2 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		BAE2B361297C1D6C0000D5B9 /* AccountRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountRouter.swift; sourceTree = "<group>"; };
 		BAE2B363297C1D720000D5B9 /* AccountService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountService.swift; sourceTree = "<group>"; };
 		BAE5D3342975B10F00268D44 /* ReissuanceRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReissuanceRequest.swift; sourceTree = "<group>"; };
@@ -1221,6 +1223,7 @@
 			children = (
 				BA771651296FBF4400762362 /* KeyChainWrapper.swift */,
 				BA117A3A297440B500B37E03 /* UserDefaultsWrapper.swift */,
+				BAE234B929E2832200F779B2 /* Log.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2115,6 +2118,7 @@
 				70197B722953698F000503F6 /* SelectedCategoryViewController.swift in Sources */,
 				BA876BA1296514DA0029CF34 /* PaddingTextField.swift in Sources */,
 				C361743329AF9B2D006AEAB1 /* MeetingViewModel.swift in Sources */,
+				BAE234BA29E2832200F779B2 /* Log.swift in Sources */,
 				C38D6566298852F80052013F /* PaddingLabel.swift in Sources */,
 				70197B7B29549B6A000503F6 /* SelectedCategoryChartCollectionViewCell.swift in Sources */,
 				70A4209C2988B1DC0026E9F9 /* SortControl.swift in Sources */,

--- a/PLUB/Configuration/Utils/Log.swift
+++ b/PLUB/Configuration/Utils/Log.swift
@@ -1,0 +1,18 @@
+//
+//  Log.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/09.
+//
+
+import class Foundation.Bundle
+import struct os.Logger
+
+enum Log {
+  
+  private static let subsystem = Bundle.main.bundleIdentifier!
+  
+  static private func logger(category: String) -> Logger {
+    return .init(subsystem: subsystem, category: category)
+  }
+}

--- a/PLUB/Configuration/Utils/Log.swift
+++ b/PLUB/Configuration/Utils/Log.swift
@@ -16,7 +16,7 @@ enum Log {
     return .init(subsystem: subsystem, category: category)
   }
   
-  static func debug<T>(_ value: T, category: Category, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
+  static func debug<T>(_ value: T, category: Category = .default, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
     let message = String(describing: value)
     switch privacy {
     case .auto:       logger(category: category.rawValue).debug("[\(fileID):\(line)] \(message, privacy: .auto)")
@@ -25,7 +25,7 @@ enum Log {
     }
   }
   
-  static func info<T>(_ value: T, category: Category, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
+  static func info<T>(_ value: T, category: Category = .default, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
     let message = String(describing: value)
     switch privacy {
     case .auto:       logger(category: category.rawValue).info("[\(fileID):\(line)] \(message, privacy: .auto)")
@@ -34,7 +34,7 @@ enum Log {
     }
   }
   
-  static func notice<T>(_ value: T, category: Category, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
+  static func notice<T>(_ value: T, category: Category = .default, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
     let message = String(describing: value)
     switch privacy {
     case .auto:       logger(category: category.rawValue).notice("[\(fileID):\(line)] \(message, privacy: .auto)")
@@ -43,7 +43,7 @@ enum Log {
     }
   }
   
-  static func error<T>(_ value: T, category: Category, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
+  static func error<T>(_ value: T, category: Category = .default, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
     let message = String(describing: value)
     switch privacy {
     case .auto:       logger(category: category.rawValue).error("[\(fileID):\(line)] \(message, privacy: .auto)")
@@ -52,7 +52,7 @@ enum Log {
     }
   }
   
-  static func fault<T>(_ value: T, category: Category, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
+  static func fault<T>(_ value: T, category: Category = .default, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
     let message = String(describing: value)
     switch privacy {
     case .auto:       logger(category: category.rawValue).fault("[\(fileID):\(line)] \(message, privacy: .auto)")
@@ -72,6 +72,7 @@ extension Log {
   }
   
   enum Category: String {
+    case `default`
     case network
     case ui
   }

--- a/PLUB/Configuration/Utils/Log.swift
+++ b/PLUB/Configuration/Utils/Log.swift
@@ -16,73 +16,63 @@ enum Log {
     return .init(subsystem: subsystem, category: category)
   }
   
-  static func debug<T>(_ value: T, category: String = #fileID, privacy: Privacy = .auto) {
+  static func debug<T>(_ value: T, category: Category, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
     let message = String(describing: value)
     switch privacy {
-    case .auto:
-      logger(category: category).debug("\(message, privacy: .auto)")
-    case .public:
-      logger(category: category).debug("\(message, privacy: .public)")
-    case .private:
-      logger(category: category).debug("\(message, privacy: .private)")
+    case .auto:       logger(category: category.rawValue).debug("[\(fileID):\(line)] \(message, privacy: .auto)")
+    case .public:     logger(category: category.rawValue).debug("[\(fileID):\(line)] \(message, privacy: .public)")
+    case .private:    logger(category: category.rawValue).debug("[\(fileID):\(line)] \(message, privacy: .private)")
     }
   }
   
-  static func info<T>(_ value: T, category: String = #fileID, privacy: Privacy = .auto) {
+  static func info<T>(_ value: T, category: Category, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
     let message = String(describing: value)
     switch privacy {
-    case .auto:
-      logger(category: category).info("\(message, privacy: .auto)")
-    case .public:
-      logger(category: category).info("\(message, privacy: .public)")
-    case .private:
-      logger(category: category).info("\(message, privacy: .private)")
+    case .auto:       logger(category: category.rawValue).info("[\(fileID):\(line)] \(message, privacy: .auto)")
+    case .public:     logger(category: category.rawValue).info("[\(fileID):\(line)] \(message, privacy: .public)")
+    case .private:    logger(category: category.rawValue).info("[\(fileID):\(line)] \(message, privacy: .private)")
     }
   }
   
-  static func notice<T>(_ value: T, category: String = #fileID, privacy: Privacy = .auto) {
+  static func notice<T>(_ value: T, category: Category, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
     let message = String(describing: value)
     switch privacy {
-    case .auto:
-      logger(category: category).notice("\(message, privacy: .auto)")
-    case .public:
-      logger(category: category).notice("\(message, privacy: .public)")
-    case .private:
-      logger(category: category).notice("\(message, privacy: .private)")
+    case .auto:       logger(category: category.rawValue).notice("[\(fileID):\(line)] \(message, privacy: .auto)")
+    case .public:     logger(category: category.rawValue).notice("[\(fileID):\(line)] \(message, privacy: .public)")
+    case .private:    logger(category: category.rawValue).notice("[\(fileID):\(line)] \(message, privacy: .private)")
     }
   }
   
-  static func error<T>(_ value: T, category: String = #fileID, privacy: Privacy = .auto) {
+  static func error<T>(_ value: T, category: Category, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
     let message = String(describing: value)
     switch privacy {
-    case .auto:
-      logger(category: category).error("\(message, privacy: .auto)")
-    case .public:
-      logger(category: category).error("\(message, privacy: .public)")
-    case .private:
-      logger(category: category).error("\(message, privacy: .private)")
+    case .auto:       logger(category: category.rawValue).error("[\(fileID):\(line)] \(message, privacy: .auto)")
+    case .public:     logger(category: category.rawValue).error("[\(fileID):\(line)] \(message, privacy: .public)")
+    case .private:    logger(category: category.rawValue).error("[\(fileID):\(line)] \(message, privacy: .private)")
     }
   }
   
-  static func fault<T>(_ value: T, category: String = #fileID, privacy: Privacy = .auto) {
+  static func fault<T>(_ value: T, category: Category, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
     let message = String(describing: value)
     switch privacy {
-    case .auto:
-      logger(category: category).fault("\(message, privacy: .auto)")
-    case .public:
-      logger(category: category).fault("\(message, privacy: .public)")
-    case .private:
-      logger(category: category).fault("\(message, privacy: .private)")
+    case .auto:       logger(category: category.rawValue).fault("[\(fileID):\(line)] \(message, privacy: .auto)")
+    case .public:     logger(category: category.rawValue).fault("[\(fileID):\(line)] \(message, privacy: .public)")
+    case .private:    logger(category: category.rawValue).fault("[\(fileID):\(line)] \(message, privacy: .private)")
     }
   }
 }
 
-// MARK: - Log Privacy
+// MARK: - Log Enum Cases
 
 extension Log {
   enum Privacy {
     case auto
     case `public`
     case `private`
+  }
+  
+  enum Category: String {
+    case network
+    case ui
   }
 }

--- a/PLUB/Configuration/Utils/Log.swift
+++ b/PLUB/Configuration/Utils/Log.swift
@@ -15,4 +15,74 @@ enum Log {
   static private func logger(category: String) -> Logger {
     return .init(subsystem: subsystem, category: category)
   }
+  
+  static func debug<T>(_ value: T, category: String = #fileID, privacy: Privacy = .auto) {
+    let message = String(describing: value)
+    switch privacy {
+    case .auto:
+      logger(category: category).debug("\(message, privacy: .auto)")
+    case .public:
+      logger(category: category).debug("\(message, privacy: .public)")
+    case .private:
+      logger(category: category).debug("\(message, privacy: .private)")
+    }
+  }
+  
+  static func info<T>(_ value: T, category: String = #fileID, privacy: Privacy = .auto) {
+    let message = String(describing: value)
+    switch privacy {
+    case .auto:
+      logger(category: category).info("\(message, privacy: .auto)")
+    case .public:
+      logger(category: category).info("\(message, privacy: .public)")
+    case .private:
+      logger(category: category).info("\(message, privacy: .private)")
+    }
+  }
+  
+  static func notice<T>(_ value: T, category: String = #fileID, privacy: Privacy = .auto) {
+    let message = String(describing: value)
+    switch privacy {
+    case .auto:
+      logger(category: category).notice("\(message, privacy: .auto)")
+    case .public:
+      logger(category: category).notice("\(message, privacy: .public)")
+    case .private:
+      logger(category: category).notice("\(message, privacy: .private)")
+    }
+  }
+  
+  static func error<T>(_ value: T, category: String = #fileID, privacy: Privacy = .auto) {
+    let message = String(describing: value)
+    switch privacy {
+    case .auto:
+      logger(category: category).error("\(message, privacy: .auto)")
+    case .public:
+      logger(category: category).error("\(message, privacy: .public)")
+    case .private:
+      logger(category: category).error("\(message, privacy: .private)")
+    }
+  }
+  
+  static func fault<T>(_ value: T, category: String = #fileID, privacy: Privacy = .auto) {
+    let message = String(describing: value)
+    switch privacy {
+    case .auto:
+      logger(category: category).fault("\(message, privacy: .auto)")
+    case .public:
+      logger(category: category).fault("\(message, privacy: .public)")
+    case .private:
+      logger(category: category).fault("\(message, privacy: .private)")
+    }
+  }
+}
+
+// MARK: - Log Privacy
+
+extension Log {
+  enum Privacy {
+    case auto
+    case `public`
+    case `private`
+  }
 }

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -123,8 +123,17 @@ class BaseService {
     case 200..<300 where decodedData.data != nil:
       return .success(decodedData)
     case 200..<300 where decodedData.data == nil:
+      // 로깅을 위해 json을 이쁘게 포맷팅
+      guard let jsonData = try? JSONSerialization.jsonObject(with: data),
+            let prettyJsonData = try? JSONSerialization.data(withJSONObject: jsonData, options: .prettyPrinted),
+            let formattedString = String(data: prettyJsonData, encoding: .utf8)
+      else {
+        return .failure(.decodingError(raw: data))
+      }
+      Log.fault("decodingError: \(formattedString)", category: .network)
       return .failure(.decodingError(raw: data))
     case 400..<500:
+      Log.error("Request Error: \(decodedData)", category: .network)
       return .failure(.requestError(decodedData))
     case 500..<600:
       return .failure(.serverError)


### PR DESCRIPTION
## 📌 PR 요약

### Log 구현

- Log라는 enum을 구현했습니다. 사용할 수 있는 함수는 아래와 같습니다.
```swift
enum Log {
  
  static func debug<T>(_ value: T, category: Category = .default, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
  }

  static func info<T>(_ value: T, category: Category = .default, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
  }

  static func notice<T>(_ value: T, category: Category = .default, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
  }

  static func error<T>(_ value: T, category: Category = .default, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
  }

  static func fault<T>(_ value: T, category: Category = .default, privacy: Privacy = .auto, fileID: String = #fileID, line: Int = #line) {
  }
```

#### 메서드 소개

##### 1. `debug(_:)`

제일 성능이 빠른 녀석입니다. 단순히 값 만을 확인하는 싶은 경우에 사용하시면 됩니다. 굳이 `mac console`에 기록을 저장할 필요가 없는 경우도 여기에 포함됩니다.

```swift

button.rx.tap
  .subscribe(onNext: { _ in
    Log.debug("button Tapped")
  })
  .disposed(by: disposeBag)
```

##### 2. `info(_:)`

앱에 대한 중요한 정보를 기록할 때 사용됩니다. plubbingID, feedID와 같은 정보를 처리할 때 이 메서드를 사용하시면 됩니다. 

```swift
let plubbingID = 20
Log.info(plubbingID)
```

##### 3. `notice(_:)`

os_log topLevel의 `default`와 동질인 녀석입니다. 디버깅 목적으로 세부 정보를 기록할 때 자주 사용됩니다.


##### 4. `error(_:)`

예외 상황이나 오류가 발생했을 때 사용됩니다.
78859db2ed41d895add098f6f9ed4b474d1e4119 참조해주세요.

##### 5. `fault(_:)`

심각한 문제가 발생한 경우에 사용됩니다. 애플리케이션에서 재부팅이나 중단 등을 유발할 수 있는 치명적인 오류를 기록할 때 사용됩니다.
78859db2ed41d895add098f6f9ed4b474d1e4119 참조해주세요.

#### Category

카테고리에 따라 로깅을 분류할 수 있습니다. 현재는 `network`, `ui`만 존재하는 상태입니다.
따라서 network에 관해 로깅을 남기고싶다면 다음과 같이 작성하면 됩니다.

```swift
Log.debug("Decoded Data: \(data)", category: .network)
```

반면, UI에 관한 로깅 처리를 하고싶다면 아래와 같이 작성해주세요.

```swift
Log.debug("collectionView frame: \(collectionView.frame)", category: .ui)
```

#### Privacy

Log에서는 privacy라는 강력한 기능을 제공합니다. 기본값은 자동(`.auto`)이며 디버깅 시에는 값이 나타나되, 디버깅 중이 아닌 경우에는 보안에 의해 값을 보이지 않게 처리합니다.

<img width="1365" alt="image" src="https://user-images.githubusercontent.com/57972338/230759258-9dde11c9-9817-4d1a-abb7-a2360a9374be.png">

만약 디버깅이 아닐 시에도 값이 보이도록 처리하고 싶다면 `.public`으로 세팅해주세요.

```swift
Log.notice("Value: \(data)", privacy: .public)
```

## 📮 관련 이슈
- Resolved: #272
- Upgrade PR: https://github.com/PLUB2022/PLUB-iOS/pull/386

## References.

[WWDC20 - Explore logging in Swift](https://developer.apple.com/wwdc20/10168)