### PR TITLE
BoardDetailViewModel 리팩토링

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		BAAD0AD529BB2E72007B33D9 /* ArchiveCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAD0AD429BB2E72007B33D9 /* ArchiveCollectionViewCell.swift */; };
 		BAB033FA29B5C5580077C4D9 /* BoardDetailCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB033F929B5C5580077C4D9 /* BoardDetailCollectionHeaderView.swift */; };
 		BAB2E56C29E30A13006B7BDC /* PostCommentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB2E56B29E30A13006B7BDC /* PostCommentUseCase.swift */; };
+		BAB2E56E29E30F96006B7BDC /* GetCommentsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB2E56D29E30F96006B7BDC /* GetCommentsUseCase.swift */; };
 		BAB9DFD229BB17B90062807C /* ArchiveViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB9DFD029BB17B90062807C /* ArchiveViewModel.swift */; };
 		BABB011A297ED415004178EC /* InterestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB0119297ED415004178EC /* InterestViewController.swift */; };
 		BABB011C297ED74C004178EC /* InterestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB011B297ED74C004178EC /* InterestViewModel.swift */; };
@@ -541,6 +542,7 @@
 		BAAD0AD429BB2E72007B33D9 /* ArchiveCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveCollectionViewCell.swift; sourceTree = "<group>"; };
 		BAB033F929B5C5580077C4D9 /* BoardDetailCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailCollectionHeaderView.swift; sourceTree = "<group>"; };
 		BAB2E56B29E30A13006B7BDC /* PostCommentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCommentUseCase.swift; sourceTree = "<group>"; };
+		BAB2E56D29E30F96006B7BDC /* GetCommentsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCommentsUseCase.swift; sourceTree = "<group>"; };
 		BAB9DFD029BB17B90062807C /* ArchiveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveViewModel.swift; sourceTree = "<group>"; };
 		BABB0119297ED415004178EC /* InterestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewController.swift; sourceTree = "<group>"; };
 		BABB011B297ED74C004178EC /* InterestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewModel.swift; sourceTree = "<group>"; };
@@ -1343,6 +1345,7 @@
 			isa = PBXGroup;
 			children = (
 				BAB2E56B29E30A13006B7BDC /* PostCommentUseCase.swift */,
+				BAB2E56D29E30F96006B7BDC /* GetCommentsUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -2327,6 +2330,7 @@
 				70F1DFEA297D992100F9BC83 /* RecruitmentService.swift in Sources */,
 				C3E0390C29C21F0C00C4744C /* RecruitingViewModel.swift in Sources */,
 				BA6D7C5329A7D46900D8E928 /* CommentsRequest.swift in Sources */,
+				BAB2E56E29E30F96006B7BDC /* GetCommentsUseCase.swift in Sources */,
 				BA8E2B4829746881009DDF32 /* SignInResponse.swift in Sources */,
 				7028770729A8C9A100E57509 /* RecruitmentFilterViewModel.swift in Sources */,
 				C3413E1729954910004B8DBD /* MeetingInfoViewController.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 		BA98B34929AC956A00307073 /* CommentContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA98B34829AC956A00307073 /* CommentContent.swift */; };
 		BAAD0AD529BB2E72007B33D9 /* ArchiveCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAD0AD429BB2E72007B33D9 /* ArchiveCollectionViewCell.swift */; };
 		BAB033FA29B5C5580077C4D9 /* BoardDetailCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB033F929B5C5580077C4D9 /* BoardDetailCollectionHeaderView.swift */; };
+		BAB2E56C29E30A13006B7BDC /* PostCommentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB2E56B29E30A13006B7BDC /* PostCommentUseCase.swift */; };
 		BAB9DFD229BB17B90062807C /* ArchiveViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB9DFD029BB17B90062807C /* ArchiveViewModel.swift */; };
 		BABB011A297ED415004178EC /* InterestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB0119297ED415004178EC /* InterestViewController.swift */; };
 		BABB011C297ED74C004178EC /* InterestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB011B297ED74C004178EC /* InterestViewModel.swift */; };
@@ -539,6 +540,7 @@
 		BA98B34829AC956A00307073 /* CommentContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentContent.swift; sourceTree = "<group>"; };
 		BAAD0AD429BB2E72007B33D9 /* ArchiveCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveCollectionViewCell.swift; sourceTree = "<group>"; };
 		BAB033F929B5C5580077C4D9 /* BoardDetailCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailCollectionHeaderView.swift; sourceTree = "<group>"; };
+		BAB2E56B29E30A13006B7BDC /* PostCommentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCommentUseCase.swift; sourceTree = "<group>"; };
 		BAB9DFD029BB17B90062807C /* ArchiveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveViewModel.swift; sourceTree = "<group>"; };
 		BABB0119297ED415004178EC /* InterestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewController.swift; sourceTree = "<group>"; };
 		BABB011B297ED74C004178EC /* InterestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestViewModel.swift; sourceTree = "<group>"; };
@@ -767,6 +769,7 @@
 		0A3E42E228E7369600F62BF0 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				BAB2E56A29E30053006B7BDC /* UseCases */,
 				BA36EED5295463AA00D30169 /* Models */,
 				BA36EED4295463A600D30169 /* Network */,
 				BA36EED32954637F00D30169 /* Views */,
@@ -1334,6 +1337,14 @@
 				BAC5EF2A2989F58900F3955E /* Onboarding */,
 			);
 			path = Lottie;
+			sourceTree = "<group>";
+		};
+		BAB2E56A29E30053006B7BDC /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				BAB2E56B29E30A13006B7BDC /* PostCommentUseCase.swift */,
+			);
+			path = UseCases;
 			sourceTree = "<group>";
 		};
 		BAC5EF2A2989F58900F3955E /* Onboarding */ = {
@@ -2171,6 +2182,7 @@
 				BAE0AC7629B5D67D00F46F3D /* BoardDetailViewController.swift in Sources */,
 				C34F048429C715A800E5B67E /* SettingSubview.swift in Sources */,
 				BA46CC9F28EC9B05004953B1 /* Ex+UIColor.swift in Sources */,
+				BAB2E56C29E30A13006B7BDC /* PostCommentUseCase.swift in Sources */,
 				C39E09B629C604DE00ECAD11 /* RecruitingFooterView.swift in Sources */,
 				BA340E1629782207002BAF2C /* IntroduceTagCollectionViewCell.swift in Sources */,
 				70197B7D29549B96000503F6 /* SelectedCategoryFilterHeaderView.swift in Sources */,

--- a/PLUB/Sources/UseCases/GetCommentsUseCase.swift
+++ b/PLUB/Sources/UseCases/GetCommentsUseCase.swift
@@ -1,0 +1,38 @@
+//
+//  GetCommentsUseCase.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/10.
+//
+
+import RxSwift
+
+protocol GetCommentsUseCase {
+  func execute(
+    plubbingID: Int,
+    feedID: Int,
+    nextCursorID: Int
+  ) -> Observable<(content: [CommentContent], nextCursorID: Int, isLast: Bool)>
+}
+
+final class DefaultGetCommentsUseCase: GetCommentsUseCase {
+  func execute(
+    plubbingID: Int,
+    feedID: Int,
+    nextCursorID: Int
+  ) -> Observable<(content: [CommentContent], nextCursorID: Int, isLast: Bool)> {
+    FeedsService.shared.fetchComments(
+      plubbingID: plubbingID,
+      feedID: feedID,
+      nextCursorID: nextCursorID
+    )
+    .map { data in
+      // Mapping for page manager
+      return (
+        content: data.content,
+        nextCursorID: data.content.last?.commentID ?? 0,
+        isLast: data.isLast
+      )
+    }
+  }
+}

--- a/PLUB/Sources/UseCases/PostCommentUseCase.swift
+++ b/PLUB/Sources/UseCases/PostCommentUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  PostCommentUseCase.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/09.
+//
+
+import RxSwift
+
+protocol PostCommentUseCase {
+  func execute(plubbingID: Int, feedID: Int, context: String, commentParentID: Int) -> Observable<CommentContent>
+}
+
+final class DefaultPostCommentUseCase: PostCommentUseCase {
+  func execute(
+    plubbingID: Int,
+    feedID: Int,
+    context: String,
+    commentParentID: Int
+  ) -> Observable<CommentContent> {
+    FeedsService.shared.createComments(
+      plubbingID: plubbingID,
+      feedID: feedID,
+      comment: context,
+      commentParentID: commentParentID
+    )
+  }
+}

--- a/PLUB/Sources/UseCases/PostCommentUseCase.swift
+++ b/PLUB/Sources/UseCases/PostCommentUseCase.swift
@@ -8,7 +8,7 @@
 import RxSwift
 
 protocol PostCommentUseCase {
-  func execute(plubbingID: Int, feedID: Int, context: String, commentParentID: Int) -> Observable<CommentContent>
+  func execute(plubbingID: Int, feedID: Int, context: String, commentParentID: Int?) -> Observable<CommentContent>
 }
 
 final class DefaultPostCommentUseCase: PostCommentUseCase {
@@ -16,7 +16,7 @@ final class DefaultPostCommentUseCase: PostCommentUseCase {
     plubbingID: Int,
     feedID: Int,
     context: String,
-    commentParentID: Int
+    commentParentID: Int?
   ) -> Observable<CommentContent> {
     FeedsService.shared.createComments(
       plubbingID: plubbingID,

--- a/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
@@ -99,7 +99,14 @@ final class ClipboardViewController: BaseViewController {
     collectionView.rx.modelSelected(FeedsContent.self)
       .subscribe(with: self) { owner, model in
         owner.navigationController?.pushViewController(
-          BoardDetailViewController(viewModel: BoardDetailViewModel(plubbingID: model.plubbingID!, content: model.toBoardModel)),
+          BoardDetailViewController(
+            viewModel: BoardDetailViewModel(
+              plubbingID: model.plubbingID!,
+              content: model.toBoardModel,
+              getCommentsUseCase: DefaultGetCommentsUseCase(),
+              postCommentUseCase: DefaultPostCommentUseCase()
+            )
+          ),
           animated: true
         )
       }

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -241,9 +241,13 @@ extension MainPageViewController: BoardViewControllerDelegate {
   }
   
   func didTappedBoardCollectionViewCell(plubbingID: Int, content: BoardModel) {
-    let vc = BoardDetailViewController(viewModel: BoardDetailViewModel(
-      plubbingID: plubbingID,
-      content: content)
+    let vc = BoardDetailViewController(
+      viewModel: BoardDetailViewModel(
+        plubbingID: plubbingID,
+        content: content,
+        getCommentsUseCase: DefaultGetCommentsUseCase(),
+        postCommentUseCase: DefaultPostCommentUseCase()
+      )
     )
     vc.navigationItem.largeTitleDisplayMode = .never
     navigationController?.pushViewController(vc, animated: true)


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- UseCase 도입
- 지난 회의 때 정했던 ViewModel 구조로 변경

🌱 PR 포인트
- UseCase에 대해 이런 저런 정보를 찾아보고 공부한 뒤 적용해보았습니다. [References 참조]
   - UseCases라는 폴더를 Sources 하위에 두었습니다.
   - ViewModel과의 일대일대응 관계가 아닌, N:N 관계로 구성하기 위해 UseCase를 잘게 나눴습니다.


## 📮 관련 이슈
- Resolved: #267

## References

1. [Clean Architecture - 2. 클린 아키텍쳐의 핵심: Use Case](https://alphahackerhan.tistory.com/28)
   - UseCase가 하나의 기능을 하는것에 대해 설명합니다.
2. [[iOS] - Clean Architecture, 직접 해보기](https://yoojin99.github.io/app/클린-아키텍처/)
   - 위 글을 읽고 UseCase에 execute라는 메서드로 통일해보았습니다.
3. [In Clean Architecture, how do we name UseCases that get more and more specific without the names becoming too long?](https://softwareengineering.stackexchange.com/questions/442559/in-clean-architecture-how-do-we-name-usecases-that-get-more-and-more-specific-w)
   - UseCase의 네이밍을 어떻게 가져가야하는 가에 대한 질문과 답변입니다.
4. [Clean Architecture - Use case in Android"](https://mashup-android.vercel.app/mashup-11th/heejin/useCase/useCase/)
   - 이 글이 UseCase를 이해하는 데 많은 도움이 되었습니다. UseCase에는 하나의 메서드만 구현되어있는데, 왜 이렇게 해야하는 지 자세한 설명이 나와있습니다.
5. [iOS-Clean-Architecture-MVVM-RxSwift](https://github.com/kwontaewan/iOS-Clean-Architecture-MVVM-RxSwift)
   - RxSwift와 MVVM 구조를 갖는 클린 아키텍처입니다. 해당 코드를 많이 참고했습니다.