### PR TITLE
댓글 페이징 시 앱 크래시 이슈

### DIFF
--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -240,13 +240,12 @@ extension BoardDetailViewModel {
     guard let dataSource else { return }
     
     var snapshot = dataSource.snapshot()
-    let sections = snapshot.sectionIdentifiers
     let items = snapshot.itemIdentifiers // 전체 Item을 가져옴
     
     // snapshot에 적용되지 않은 item 선별
     for content in comments where items.contains(content) == false {
       // 댓글인 경우
-      if sections.contains(content.groupID) == false {
+      if snapshot.sectionIdentifiers.contains(content.groupID) == false {
         snapshot.appendSections([content.groupID])
       }
       snapshot.appendItems([content], toSection: content.groupID)


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용

- snapshot에 section을 적용했음에도, 이전 section값을 갖고있는 변수로 값을 비교하여 `중복된 section`을 넣는 현상이 발생하였습니다. (수정 완료)


## 📮 관련 이슈
- Resolved: #281

