### PR TITLE
[FEAT] 최근 검색어목록 유지를 UserDefaults 추가

### DIFF
--- a/PLUB/Configuration/Manager/UserManager.swift
+++ b/PLUB/Configuration/Manager/UserManager.swift
@@ -43,6 +43,11 @@ final class UserManager {
   var hasAccessToken: Bool { return accessToken != nil }
   var hasRefreshToken: Bool { return refreshToken != nil }
   
+  // MARK: - Recent Search KeywordList
+  
+  @UserDefaultsWrapper<[String]>(key: "recentKeywordList")
+  private(set) var recentKeywordList
+  
   // MARK: - Initialization
   
   private init() { }
@@ -105,6 +110,31 @@ extension UserManager {
           return false // 에러
         }
       }
+  }
+  
+  /// 최근 검색어목록에 키워드를 추가합니다
+  /// - Parameter keyword: 검색한 키워드
+  func addKeyword(keyword: String) {
+    let recentKeywordList = recentKeywordList ?? []
+    var filterList = recentKeywordList.filter { $0 != keyword }
+    filterList.insert(keyword, at: 0)
+    self.recentKeywordList = filterList
+  }
+  
+  /// 최근 검색어목록에 특정 인덱스에 위치한 키워드를 삭제합니다
+  /// - Parameter index: 삭제하고자하는 키워드의 위치
+  func removeKeyword(index: Int) {
+    guard var recentKeywordList = recentKeywordList,
+          index < recentKeywordList.count && 0 <= index else { return }
+    recentKeywordList.remove(at: index)
+    self.recentKeywordList = recentKeywordList
+  }
+  
+  /// 최근 검색어목록을 초기화합니다
+  func clearKeywordList() {
+    guard var recentKeywordList = recentKeywordList else { return }
+    recentKeywordList.removeAll()
+    self.recentKeywordList = recentKeywordList
   }
 }
 

--- a/PLUB/Configuration/Manager/UserManager.swift
+++ b/PLUB/Configuration/Manager/UserManager.swift
@@ -125,16 +125,14 @@ extension UserManager {
   /// - Parameter index: 삭제하고자하는 키워드의 위치
   func removeKeyword(index: Int) {
     guard var recentKeywordList = recentKeywordList,
-          index < recentKeywordList.count && 0 <= index else { return }
+          (0..<recentKeywordList.count) ~= index else { return }
     recentKeywordList.remove(at: index)
     self.recentKeywordList = recentKeywordList
   }
   
   /// 최근 검색어목록을 초기화합니다
   func clearKeywordList() {
-    guard var recentKeywordList = recentKeywordList else { return }
-    recentKeywordList.removeAll()
-    self.recentKeywordList = recentKeywordList
+    self.recentKeywordList?.removeAll()
   }
 }
 

--- a/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/SearchInputViewModel.swift
@@ -53,7 +53,7 @@ final class SearchInputViewModel: SearchInputViewModelType {
     let searchSortType = BehaviorSubject<SortType>(value: .popular)
     let searchFilterType = BehaviorSubject<FilterType>(value: .title)
     let fetchingSearchOutput = BehaviorRelay<[SelectedCategoryCollectionViewCellModel]>(value: [])
-    let recentKeywordList = BehaviorRelay<[String]>(value: [])
+    let recentKeywordList = BehaviorRelay<[String]>(value: UserManager.shared.recentKeywordList ?? [])
     let removeKeyword = PublishSubject<Int>()
     let removeAllKeyword = PublishSubject<Void>()
     let whichBookmark = PublishSubject<Int>()
@@ -143,20 +143,21 @@ final class SearchInputViewModel: SearchInputViewModelType {
       var list = recentKeywordList.value
       list.remove(at: index)
       recentKeywordList.accept(list)
+      UserManager.shared.removeKeyword(index: index)
     })
     .disposed(by: disposeBag)
     
     searchKeyword.skip(1).subscribe(onNext: { keyword in
       let list = recentKeywordList.value
-      var filterList = list.filter { $0 != keyword }
-      filterList.insert(keyword, at: 0)
-      recentKeywordList.accept(filterList)
+      UserManager.shared.addKeyword(keyword: keyword)
+      recentKeywordList.accept(UserManager.shared.recentKeywordList!)
     })
     .disposed(by: disposeBag)
     
     removeAllKeyword
       .subscribe(onNext: { _ in
-        recentKeywordList.accept([])
+        UserManager.shared.clearKeywordList()
+        recentKeywordList.accept(UserManager.shared.recentKeywordList!)
       })
       .disposed(by: disposeBag)
     


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 최근 검색어 목록 유지를 위한 recentKeywordList를 키로 가지고있는 UserDefaultsWrapper를 추가하였습니다
- UserDefaultsWrapper추가에 따른 최근 검색어목록 초깃값 수정 및 UserDefaults에서 값을 관리할 수 있도록 하였습니다

``` swift
// MARK: - Recent Search KeywordList
  
  @UserDefaultsWrapper<[String]>(key: "recentKeywordList")
  private(set) var recentKeywordList

/// 최근 검색어목록에 키워드를 추가합니다
  /// - Parameter keyword: 검색한 키워드
  func addKeyword(keyword: String) {
    let recentKeywordList = recentKeywordList ?? []
    var filterList = recentKeywordList.filter { $0 != keyword }
    filterList.insert(keyword, at: 0)
    self.recentKeywordList = filterList
  }
  
  /// 최근 검색어목록에 특정 인덱스에 위치한 키워드를 삭제합니다
  /// - Parameter index: 삭제하고자하는 키워드의 위치
  func removeKeyword(index: Int) {
    guard var recentKeywordList = recentKeywordList,
          index < recentKeywordList.count && 0 <= index else { return }
    recentKeywordList.remove(at: index)
    self.recentKeywordList = recentKeywordList
  }
  
  /// 최근 검색어목록을 초기화합니다
  func clearKeywordList() {
    guard var recentKeywordList = recentKeywordList else { return }
    recentKeywordList.removeAll()
    self.recentKeywordList = recentKeywordList
  }
```

## 📸 동작영상
https://user-images.githubusercontent.com/39263235/232224207-061529a2-207c-497c-a32a-c920334585f0.mp4

## 📮 관련 이슈
- Resolved: #288 

