### PR TITLE
[FEAT] 모집상세글 호스트여부에 따른 구현

### DIFF
--- a/PLUB/Sources/Network/Routers/RecruitmentRouter.swift
+++ b/PLUB/Sources/Network/Routers/RecruitmentRouter.swift
@@ -85,10 +85,7 @@ extension RecruitmentRouter: Router {
   }
   
   var headers: HeaderType {
-    switch self {
-    case .inquireDetailRecruitment, .inquireRecruitmentQuestion, .inquireAllBookmark, .searchRecruitment, .requestBookmark, .editMeetingPost, .editMeetingQuestion, .applyForRecruitment, .inquireApplicant, .approvalApplicant, .refuseApplicant, .inquireMyApplication, .cancelApplication, .endRecruitment:
-      return .withAccessToken
-    }
+    return .withAccessToken
   }
 }
 

--- a/PLUB/Sources/Network/Routers/RecruitmentRouter.swift
+++ b/PLUB/Sources/Network/Routers/RecruitmentRouter.swift
@@ -21,6 +21,7 @@ enum RecruitmentRouter {
   case refuseApplicant(Int, Int)
   case inquireMyApplication(Int)
   case cancelApplication(Int)
+  case endRecruitment(Int)
 }
 
 extension RecruitmentRouter: Router {
@@ -30,7 +31,7 @@ extension RecruitmentRouter: Router {
       return .get
     case .requestBookmark, .applyForRecruitment, .approvalApplicant, .refuseApplicant:
       return .post
-    case .editMeetingPost, .editMeetingQuestion:
+    case .editMeetingPost, .editMeetingQuestion, .endRecruitment:
       return .put
     case .cancelApplication:
       return .delete
@@ -63,12 +64,14 @@ extension RecruitmentRouter: Router {
       return "/plubbings/\(plubbingID)/recruit/applicants/\(accountID)/refuse"
     case .inquireMyApplication(let plubbingID), .cancelApplication(let plubbingID):
       return "/plubbings/\(plubbingID)/recruit/applicants/me"
+    case .endRecruitment(let plubbingID):
+      return "/plubbings/\(plubbingID)/recruit/end"
     }
   }
   
   var parameters: ParameterType {
     switch self {
-    case .inquireDetailRecruitment, .inquireRecruitmentQuestion, .inquireAllBookmark, .requestBookmark, .inquireApplicant, .approvalApplicant, .refuseApplicant, .inquireMyApplication, .cancelApplication:
+    case .inquireDetailRecruitment, .inquireRecruitmentQuestion, .inquireAllBookmark, .requestBookmark, .inquireApplicant, .approvalApplicant, .refuseApplicant, .inquireMyApplication, .cancelApplication, .endRecruitment:
       return .plain
     case .searchRecruitment(let parameter):
       return .query(parameter)
@@ -83,7 +86,7 @@ extension RecruitmentRouter: Router {
   
   var headers: HeaderType {
     switch self {
-    case .inquireDetailRecruitment, .inquireRecruitmentQuestion, .inquireAllBookmark, .searchRecruitment, .requestBookmark, .editMeetingPost, .editMeetingQuestion, .applyForRecruitment, .inquireApplicant, .approvalApplicant, .refuseApplicant, .inquireMyApplication, .cancelApplication:
+    case .inquireDetailRecruitment, .inquireRecruitmentQuestion, .inquireAllBookmark, .searchRecruitment, .requestBookmark, .editMeetingPost, .editMeetingQuestion, .applyForRecruitment, .inquireApplicant, .approvalApplicant, .refuseApplicant, .inquireMyApplication, .cancelApplication, .endRecruitment:
       return .withAccessToken
     }
   }

--- a/PLUB/Sources/Network/Services/RecruitmentService.swift
+++ b/PLUB/Sources/Network/Services/RecruitmentService.swift
@@ -65,4 +65,8 @@ extension RecruitmentService {
   func cancelApplication(plubbingID: Int) -> PLUBResult<EmptyModel> {
     return sendRequest(RecruitmentRouter.cancelApplication(plubbingID))
   }
+  
+  func endRecruitment(plubbingID: Int) -> Observable<EmptyModel> {
+    return sendObservableRequest(RecruitmentRouter.endRecruitment(plubbingID))
+  }
 }

--- a/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
+++ b/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
@@ -224,13 +224,13 @@ final class DetailRecruitmentViewController: BaseViewController {
             )
           ) { [weak self] in
             guard let self = self else { return }
-            // 지원취소 [네] 선택했을때의 동작을 작성
+            // 지원취소 [네] 선택했을때의 동작
             self.viewModel.selectCancelApplication.onNext(())
           }
           alert.show()
         }
         else { // 호스트일 경우, [모집 끝내기] 버튼을 선택했음에 따른 동작 구현
-          
+          self.viewModel.selectEndRecruitment.onNext(())
         }
       }
       .disposed(by: disposeBag)

--- a/PLUB/Sources/Views/Home/Model/SelectedCategoryCollectionViewCellModel.swift
+++ b/PLUB/Sources/Views/Home/Model/SelectedCategoryCollectionViewCellModel.swift
@@ -15,6 +15,7 @@ struct SelectedCategoryCollectionViewCellModel { // 차트, 그리드일때 둘 
   let introduce: String
   var isBookmarked: Bool
   let selectedCategoryInfoModel: CategoryInfoListModel
+  let isHost: Bool
   
   init(content: Content) {
     plubbingID = content.plubbingID
@@ -31,6 +32,7 @@ struct SelectedCategoryCollectionViewCellModel { // 차트, 그리드일때 둘 
         .joined(separator: ",")
       + " | "
       + "(data.time)")
+    isHost = content.isHost
   }
   
   init(content: CategoryContent) {
@@ -48,5 +50,6 @@ struct SelectedCategoryCollectionViewCellModel { // 차트, 그리드일때 둘 
         .joined(separator: ",")
       + " | "
       + "(data.time)")
+    isHost = false
   }
 }

--- a/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
+++ b/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
@@ -183,7 +183,8 @@ extension SelectedCategoryViewController: UICollectionViewDelegate, UICollection
   }
   
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    let vc = DetailRecruitmentViewController(plubbingID: model[indexPath.row].plubbingID, isHost: false)
+    let model = model[indexPath.row]
+    let vc = DetailRecruitmentViewController(plubbingID: model.plubbingID, isHost: model.isHost)
     vc.navigationItem.largeTitleDisplayMode = .never
     self.navigationController?.pushViewController(vc, animated: true)
   }

--- a/PLUB/Sources/Views/Home/ViewModel/DetailRecruitmentViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/DetailRecruitmentViewModel.swift
@@ -11,6 +11,7 @@ import RxCocoa
 protocol DetailRecruitmentViewModelType {
   // Input
   var selectPlubbingID: AnyObserver<Int> { get }
+  var selectCancelApplication: AnyObserver<Void> { get }
   
   // Output
   var introduceCategoryTitleViewModel: Driver<IntroduceCategoryTitleViewModel> { get }
@@ -18,6 +19,7 @@ protocol DetailRecruitmentViewModelType {
   var participantListViewModel: Driver<[AccountInfo]> { get }
   var meetingIntroduceModel: Driver<MeetingIntroduceModel> { get }
   var isApplied: Driver<Bool> { get }
+  var successCancelApplication: Signal<Void> { get }
 }
 
 // TODO: 이건준 -추후 API요청에 따른 result failure에 대한 에러 묶어서 처리하기
@@ -27,6 +29,7 @@ final class DetailRecruitmentViewModel: DetailRecruitmentViewModelType {
   
   // Input
   let selectPlubbingID: AnyObserver<Int> // 세부정보를 보고싶은 모집글에 대한 ID
+  let selectCancelApplication: AnyObserver<Void>
   
   // Output
   let introduceCategoryTitleViewModel: Driver<IntroduceCategoryTitleViewModel> // 모집글 세부정보를 표시하기위한 UI 모델
@@ -34,11 +37,15 @@ final class DetailRecruitmentViewModel: DetailRecruitmentViewModelType {
   let participantListViewModel: Driver<[AccountInfo]> // 모집글 세부정보를 표시하기위한 UI 모델
   let meetingIntroduceModel: Driver<MeetingIntroduceModel> // 모집글 세부정보를 표시하기위한 UI 모델
   let isApplied: Driver<Bool> // 해당 모집글을 신청했는지
+  let successCancelApplication: Signal<Void> // [지원취소] 성공했는지
   
   init() {
     let selectingPlubbingID = PublishSubject<Int>()
     let successFetchingDetail = PublishRelay<DetailRecruitmentResponse>()
+    let selectingCancelApplication = PublishSubject<Void>()
+    
     self.selectPlubbingID = selectingPlubbingID.asObserver()
+    self.selectCancelApplication = selectingCancelApplication.asObserver()
     
     let fetchingDetail = selectingPlubbingID
       .flatMapLatest(RecruitmentService.shared.inquireDetailRecruitment(plubbingID:))
@@ -50,6 +57,11 @@ final class DetailRecruitmentViewModel: DetailRecruitmentViewModelType {
     }
     .bind(to: successFetchingDetail)
     .disposed(by: disposeBag)
+    
+    let requestCancelApplication = selectingCancelApplication
+      .withLatestFrom(selectingPlubbingID)
+      .flatMapLatest(RecruitmentService.shared.cancelApplication(plubbingID:))
+    
     
     introduceCategoryTitleViewModel = successFetchingDetail.map { response -> IntroduceCategoryTitleViewModel in
       return IntroduceCategoryTitleViewModel(
@@ -90,5 +102,12 @@ final class DetailRecruitmentViewModel: DetailRecruitmentViewModelType {
       )
     }
     .asDriver(onErrorDriveWith: .empty())
+    
+    successCancelApplication = requestCancelApplication
+      .compactMap { result -> Void? in
+        guard case .success(_) = result else { return nil }
+        return ()
+      }
+      .asSignal(onErrorSignalWith: .empty())
   }
 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 호스트인지, 지원을 한 모집글인지에 따라 서로 다른 UI 구현
- [지원취소] 버튼 눌렀을때 로직 구현
- [모집끝내기] 버튼 눌렀을때 로직 구현
- 각각의 로직이 길어짐에 따라서 주석으로 설명을 추가하였습니다

🌱 PR 포인트
- [지원자보기]에 대한 UI를 알지못해 추후에 추가하도록 하겠습니다
- 추천모임조회로 인한 받아온 모집글에 따른 호스트값은 추후에 다른 pr로 추가하도록 하겠습니다

## 📮 관련 이슈
- Resolved: #290 

