### PR TITLE
댓글 삭제 API 연동

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -143,10 +143,10 @@
 		BA46CCA028EC9B05004953B1 /* Ex+UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA46CC9E28EC9B05004953B1 /* Ex+UIButton.swift */; };
 		BA4BD1AE29D6C4A800334C04 /* PagingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4BD1AD29D6C4A800334C04 /* PagingManager.swift */; };
 		BA4C46CA297ADB5900C914F3 /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C46C9297ADB5900C914F3 /* ProfileViewModel.swift */; };
+		BA4CCDF129EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4CCDF029EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift */; };
 		BA4CCDF329EAA33B0040D0D7 /* DateFormatterFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4CCDF229EAA33B0040D0D7 /* DateFormatterFactory.swift */; };
 		BA4CCDF729EAB9540040D0D7 /* GetArchiveUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4CCDF629EAB9540040D0D7 /* GetArchiveUseCase.swift */; };
 		BA4CCDFA29EAE6D50040D0D7 /* ArchivePopUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4CCDF929EAE6D50040D0D7 /* ArchivePopUpViewModel.swift */; };
-		BA4CCDF129EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4CCDF029EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift */; };
 		BA4DADB3295747E700C7ABD7 /* PageControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4DADB2295747E700C7ABD7 /* PageControl.swift */; };
 		BA52778428EECDC50036B825 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA52777B28EECDC50036B825 /* Pretendard-Medium.otf */; };
 		BA52778528EECDC50036B825 /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA52777C28EECDC50036B825 /* Pretendard-Black.otf */; };
@@ -158,6 +158,7 @@
 		BA52778B28EECDC50036B825 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA52778228EECDC50036B825 /* Pretendard-Regular.otf */; };
 		BA52778C28EECDC50036B825 /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA52778328EECDC50036B825 /* Pretendard-Light.otf */; };
 		BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52778F28EECEB40036B825 /* Ex+UIFont.swift */; };
+		BA57F3F629ED30D200A9F790 /* DeleteCommentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3F529ED30D200A9F790 /* DeleteCommentUseCase.swift */; };
 		BA590E7A29EBC6320017FAF1 /* GetArchiveDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA590E7929EBC6320017FAF1 /* GetArchiveDetailUseCase.swift */; };
 		BA590E7D29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA590E7C29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift */; };
 		BA5D9ECF29E3E9A300F06AB5 /* ArchiveRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5D9ECD29E3E9A300F06AB5 /* ArchiveRouter.swift */; };
@@ -507,10 +508,10 @@
 		BA46CC9E28EC9B05004953B1 /* Ex+UIButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Ex+UIButton.swift"; sourceTree = "<group>"; };
 		BA4BD1AD29D6C4A800334C04 /* PagingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingManager.swift; sourceTree = "<group>"; };
 		BA4C46C9297ADB5900C914F3 /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
+		BA4CCDF029EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentOptionBottomSheetViewController.swift; sourceTree = "<group>"; };
 		BA4CCDF229EAA33B0040D0D7 /* DateFormatterFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterFactory.swift; sourceTree = "<group>"; };
 		BA4CCDF629EAB9540040D0D7 /* GetArchiveUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetArchiveUseCase.swift; sourceTree = "<group>"; };
 		BA4CCDF929EAE6D50040D0D7 /* ArchivePopUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivePopUpViewModel.swift; sourceTree = "<group>"; };
-		BA4CCDF029EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentOptionBottomSheetViewController.swift; sourceTree = "<group>"; };
 		BA4DADB2295747E700C7ABD7 /* PageControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageControl.swift; sourceTree = "<group>"; };
 		BA52777B28EECDC50036B825 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
 		BA52777C28EECDC50036B825 /* Pretendard-Black.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Black.otf"; sourceTree = "<group>"; };
@@ -522,6 +523,7 @@
 		BA52778228EECDC50036B825 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		BA52778328EECDC50036B825 /* Pretendard-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.otf"; sourceTree = "<group>"; };
 		BA52778F28EECEB40036B825 /* Ex+UIFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+UIFont.swift"; sourceTree = "<group>"; };
+		BA57F3F529ED30D200A9F790 /* DeleteCommentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteCommentUseCase.swift; sourceTree = "<group>"; };
 		BA590E7929EBC6320017FAF1 /* GetArchiveDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetArchiveDetailUseCase.swift; sourceTree = "<group>"; };
 		BA590E7C29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailCollectionViewCell.swift; sourceTree = "<group>"; };
 		BA5D9ECD29E3E9A300F06AB5 /* ArchiveRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveRouter.swift; sourceTree = "<group>"; };
@@ -1241,6 +1243,7 @@
 			isa = PBXGroup;
 			children = (
 				BAB2E56B29E30A13006B7BDC /* PostCommentUseCase.swift */,
+				BA57F3F529ED30D200A9F790 /* DeleteCommentUseCase.swift */,
 				BAB2E56D29E30F96006B7BDC /* GetCommentsUseCase.swift */,
 			);
 			path = Feeds;
@@ -2265,6 +2268,7 @@
 				C3775E2429C61B9C003A812F /* CustomAlertView.swift in Sources */,
 				701A9C9C29B72656006F53C2 /* MainPageClipboardView.swift in Sources */,
 				C3C24CD3298FBA6D00056313 /* PeopleNumberToolTip.swift in Sources */,
+				BA57F3F629ED30D200A9F790 /* DeleteCommentUseCase.swift in Sources */,
 				C3E0390F29C230F700C4744C /* RecruitingHeaderView.swift in Sources */,
 				BA814A3429890AB1003570D3 /* OnboardingViewModel.swift in Sources */,
 				C3B3435B29BE3E5100935B73 /* MyPlubbingResponse.swift in Sources */,

--- a/PLUB/Sources/Models/Feeds/FeedsContent.swift
+++ b/PLUB/Sources/Models/Feeds/FeedsContent.swift
@@ -66,7 +66,7 @@ struct FeedsContent: Codable {
   let title: String
   
   /// 게시글 내용
-  let content: String
+  let content: String?
   
   /// 게시글 이미지
   let feedImageURL: String?

--- a/PLUB/Sources/UseCases/Feeds/DeleteCommentUseCase.swift
+++ b/PLUB/Sources/UseCases/Feeds/DeleteCommentUseCase.swift
@@ -1,0 +1,19 @@
+// 
+//  DeleteCommentUseCase.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/17.
+//
+
+import RxSwift
+
+protocol DeleteCommentUseCase {
+  func execute(plubbingID: Int, feedID: Int, commentID: Int) -> Observable<BaseService.EmptyModel>
+}
+
+final class DefaultDeleteCommentUseCase: DeleteCommentUseCase {
+  
+  func execute(plubbingID: Int, feedID: Int, commentID: Int) -> Observable<BaseService.EmptyModel> {
+    FeedsService.shared.deleteComment(plubbingID: plubbingID, feedID: feedID, commentID: commentID)
+  }
+}

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -179,7 +179,7 @@ extension BoardDetailViewController: ReplyViewDelegate {
 
 extension BoardDetailViewController: CommentOptionBottomSheetDelegate {
   func deleteButtonTapped() {
-    print(#function)
+    viewModel.deleteOptionObserver.onNext(Void())
   }
   
   func editButtonTapped() {

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -117,7 +117,11 @@ final class BoardDetailViewController: BaseViewController {
     
     viewModel.showBottomSheetObservable
       .subscribe(with: self) { owner, userType in
-        owner.present(CommentOptionBottomSheetViewController(userAccessType: userType), animated: true)
+        let bottomSheetVC = CommentOptionBottomSheetViewController(userAccessType: userType).then {
+          $0.delegate = owner
+        }
+        owner.present(bottomSheetVC, animated: true)
+        
       }
       .disposed(by: disposeBag)
     
@@ -162,10 +166,28 @@ extension BoardDetailViewController: CommentInputViewDelegate {
   }
 }
 
+// MARK: - ReplyViewDelegate
+
 extension BoardDetailViewController: ReplyViewDelegate {
   func cancelButtonTapped() {
     viewModel.replyIDObserver.onNext(nil)
     replyView.isHidden = true
+  }
+}
+
+// MARK: - CommentOptionBottomSheetDelegate
+
+extension BoardDetailViewController: CommentOptionBottomSheetDelegate {
+  func deleteButtonTapped() {
+    print(#function)
+  }
+  
+  func editButtonTapped() {
+    print(#function)
+  }
+  
+  func reportButtonTapped() {
+    print(#function)
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
@@ -104,7 +104,8 @@ final class ClipboardViewController: BaseViewController {
               plubbingID: model.plubbingID!,
               content: model.toBoardModel,
               getCommentsUseCase: DefaultGetCommentsUseCase(),
-              postCommentUseCase: DefaultPostCommentUseCase()
+              postCommentUseCase: DefaultPostCommentUseCase(),
+              deleteCommentUseCase: DefaultDeleteCommentUseCase()
             )
           ),
           animated: true

--- a/PLUB/Sources/Views/Home/Clipboard/Component/CommentOptionBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/CommentOptionBottomSheetViewController.swift
@@ -7,8 +7,17 @@
 
 import UIKit
 
+import RxSwift
+import RxCocoa
 import SnapKit
 import Then
+
+protocol CommentOptionBottomSheetDelegate: AnyObject {
+  func deleteButtonTapped()
+  func editButtonTapped()
+  func reportButtonTapped()
+}
+
 
 final class CommentOptionBottomSheetViewController: BottomSheetViewController {
   
@@ -27,6 +36,8 @@ final class CommentOptionBottomSheetViewController: BottomSheetViewController {
   // MARK: - Properties
   
   private let userAccessType: UserAccessType
+  
+  weak var delegate: CommentOptionBottomSheetDelegate?
   
   // MARK: - UI Components
   
@@ -92,5 +103,16 @@ final class CommentOptionBottomSheetViewController: BottomSheetViewController {
     if userAccessType != .normal {
       deleteCommentView.snp.makeConstraints(heightConstraints)
     }
+  }
+  
+  override func bind() {
+    super.bind()
+    
+    deleteCommentView.button.rx.tap
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.deleteButtonTapped()
+        owner.dismiss(animated: true)
+      }
+      .disposed(by: disposeBag)
   }
 }

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -65,6 +65,7 @@ final class BoardDetailViewModel: BoardDetailDataStore {
   
   private let getCommentsUseCase: GetCommentsUseCase
   private let postCommentUseCase: PostCommentUseCase
+  private let deleteCommentUseCase: DeleteCommentUseCase
   
   // MARK: Subjects
   
@@ -81,11 +82,13 @@ final class BoardDetailViewModel: BoardDetailDataStore {
     plubbingID: Int,
     content: BoardModel,
     getCommentsUseCase: GetCommentsUseCase,
-    postCommentUseCase: PostCommentUseCase
+    postCommentUseCase: PostCommentUseCase,
+    deleteCommentUseCase: DeleteCommentUseCase
   ) {
     self.content = content
-    self.getCommentsUseCase = getCommentsUseCase
-    self.postCommentUseCase = postCommentUseCase
+    self.getCommentsUseCase   = getCommentsUseCase
+    self.postCommentUseCase   = postCommentUseCase
+    self.deleteCommentUseCase = deleteCommentUseCase
     
     fetchComments(plubbingID: plubbingID, content: content)
     createComments(plubbingID: plubbingID, content: content)

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -287,7 +287,7 @@ extension BoardDetailViewModel {
   private func applyInitialSnapshots() {
     var snapshot = Snapshot()
     
-    var sections = [-1] // 최소한 하나의 Section이라도 존재해야 함
+    var sections = [Constants.boardSection] // 최소한 하나의 Section이라도 존재해야 함
     sections.append(contentsOf: Array(Set(comments.map { $0.groupID })).sorted())
     snapshot.appendSections(sections)
     
@@ -303,9 +303,20 @@ extension BoardDetailViewModel {
     guard let dataSource else { return }
     
     var snapshot = dataSource.snapshot()
+    
+    // 삭제해야할 section 조회
+    let commentsGroupIDs = Set(comments.map(\.groupID)).union([Constants.boardSection])
+    let sectionsToRemove = snapshot.sectionIdentifiers.filter { !commentsGroupIDs.contains($0) }
+    snapshot.deleteSections(sectionsToRemove)
+    
+    // snapshot에서 삭제해야할 아이템 조회
+    let itemsToRemove = snapshot.itemIdentifiers.filter { !comments.contains($0) }
+    snapshot.deleteItems(itemsToRemove)
+    
+    
     let items = snapshot.itemIdentifiers // 전체 Item을 가져옴
     
-    // snapshot에 적용되지 않은 item 선별
+    // snapshot에 추가해야할 item 선별
     for content in comments where items.contains(content) == false {
       // 댓글인 경우
       if snapshot.sectionIdentifiers.contains(content.groupID) == false {
@@ -351,5 +362,13 @@ extension BoardDetailViewModel: BoardDetailCollectionViewCellDelegate {
     }
     
     showBottomSheetSubject.onNext(accessType)
+  }
+}
+
+// MARK: - Constants
+
+private extension BoardDetailViewModel {
+  enum Constants {
+    static let boardSection = -1
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -246,7 +246,8 @@ extension MainPageViewController: BoardViewControllerDelegate {
         plubbingID: plubbingID,
         content: content,
         getCommentsUseCase: DefaultGetCommentsUseCase(),
-        postCommentUseCase: DefaultPostCommentUseCase()
+        postCommentUseCase: DefaultPostCommentUseCase(),
+        deleteCommentUseCase: DefaultDeleteCommentUseCase()
       )
     )
     vc.navigationItem.largeTitleDisplayMode = .never


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 댓글 삭제 기능을 구현했습니다.

🌱 PR 포인트
- 바텀시트로부터 댓글 삭제, 수정, 신고 버튼에 대한 delegate 패턴을 구현했습니다.

전반적인 구성은 아래와 같습니다.

1. `삭제할 Cell의 설정(미트볼) 버튼 클릭` -> `delegate가 구현되어있는 ViewModel이 이를 확인` -> `ViewModel이 눌린 Cell의 commentID를 저장` -> `BottomSheet를 띄움`
2. `삭제 버튼 클릭` -> `ViewController가 ViewModel에게 삭제 버튼이 눌렸음을 전달` -> `1번에서 저장해둔 commentID를 가지고 삭제 API 호출` -> `API 성공 시 comments배열로부터 삭제된 댓글 정보를 제거` -> `didSet으로 트리거되어있는 updateSnapshot 호출` -> `제거해야할 snapshot 객체를 comments와 비교 후 제거` -> `Animation이 들어간 View 업데이트`

DiffableDataSource로 애니메이션을 쉽게 구현할 수 있어 참 좋은 것 같습니다. :-)


## 📸 스크린샷
|스크린샷|
|:--:|
|<img src="https://user-images.githubusercontent.com/57972338/232442854-db3f1e45-e6e2-4678-9217-d406e0587c4e.gif" width="50%"/>|

## 📮 관련 이슈
- #211

