### PR TITLE
아카이브 업로드 UI 구현

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52778F28EECEB40036B825 /* Ex+UIFont.swift */; };
 		BA57F3F929ED4EEC00A9F790 /* ArchiveUploadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3F729ED4EEC00A9F790 /* ArchiveUploadViewController.swift */; };
 		BA57F3FA29ED4EEC00A9F790 /* ArchiveUploadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3F829ED4EEC00A9F790 /* ArchiveUploadViewModel.swift */; };
+		BA57F3FD29ED5D6600A9F790 /* ArchiveUploadHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3FC29ED5D6600A9F790 /* ArchiveUploadHeaderView.swift */; };
 		BA590E7A29EBC6320017FAF1 /* GetArchiveDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA590E7929EBC6320017FAF1 /* GetArchiveDetailUseCase.swift */; };
 		BA590E7D29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA590E7C29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift */; };
 		BA5D9ECF29E3E9A300F06AB5 /* ArchiveRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5D9ECD29E3E9A300F06AB5 /* ArchiveRouter.swift */; };
@@ -526,6 +527,7 @@
 		BA52778F28EECEB40036B825 /* Ex+UIFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+UIFont.swift"; sourceTree = "<group>"; };
 		BA57F3F729ED4EEC00A9F790 /* ArchiveUploadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveUploadViewController.swift; sourceTree = "<group>"; };
 		BA57F3F829ED4EEC00A9F790 /* ArchiveUploadViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveUploadViewModel.swift; sourceTree = "<group>"; };
+		BA57F3FC29ED5D6600A9F790 /* ArchiveUploadHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveUploadHeaderView.swift; sourceTree = "<group>"; };
 		BA590E7929EBC6320017FAF1 /* GetArchiveDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetArchiveDetailUseCase.swift; sourceTree = "<group>"; };
 		BA590E7C29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailCollectionViewCell.swift; sourceTree = "<group>"; };
 		BA5D9ECD29E3E9A300F06AB5 /* ArchiveRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveRouter.swift; sourceTree = "<group>"; };
@@ -890,6 +892,7 @@
 		702876BD29A374C500E57509 /* Archive */ = {
 			isa = PBXGroup;
 			children = (
+				BA57F3FB29ED5D5100A9F790 /* Component */,
 				BA590E7B29EBF2850017FAF1 /* Cell */,
 				BA4CCDF829EAE6BC0040D0D7 /* ViewModel */,
 				BA8D949929E96FF00075ACD8 /* ArchivePopUpViewController.swift */,
@@ -1285,6 +1288,14 @@
 				BA8AA43129890083004E9403 /* NanumPen.otf */,
 			);
 			path = Font;
+			sourceTree = "<group>";
+		};
+		BA57F3FB29ED5D5100A9F790 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				BA57F3FC29ED5D6600A9F790 /* ArchiveUploadHeaderView.swift */,
+			);
+			path = Component;
 			sourceTree = "<group>";
 		};
 		BA590E7B29EBF2850017FAF1 /* Cell */ = {
@@ -2390,6 +2401,7 @@
 				705F81C529AFAA5200830C4F /* TodolistViewController.swift in Sources */,
 				C3CD674E29B4DD9C0052087E /* ScheduleParticipantTopView.swift in Sources */,
 				BA340E2029782301002BAF2C /* LeftAlignedCollectionViewFlowLayout.swift in Sources */,
+				BA57F3FD29ED5D6600A9F790 /* ArchiveUploadHeaderView.swift in Sources */,
 				C3EC027F29D958960024C962 /* WaitingViewModel.swift in Sources */,
 				BA8AA42D2988FCC3004E9403 /* OnboardingViewController.swift in Sources */,
 				C3413E15299548FB004B8DBD /* RecruitPostViewController.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -143,10 +143,10 @@
 		BA46CCA028EC9B05004953B1 /* Ex+UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA46CC9E28EC9B05004953B1 /* Ex+UIButton.swift */; };
 		BA4BD1AE29D6C4A800334C04 /* PagingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4BD1AD29D6C4A800334C04 /* PagingManager.swift */; };
 		BA4C46CA297ADB5900C914F3 /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C46C9297ADB5900C914F3 /* ProfileViewModel.swift */; };
+		BA4CCDF129EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4CCDF029EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift */; };
 		BA4CCDF329EAA33B0040D0D7 /* DateFormatterFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4CCDF229EAA33B0040D0D7 /* DateFormatterFactory.swift */; };
 		BA4CCDF729EAB9540040D0D7 /* GetArchiveUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4CCDF629EAB9540040D0D7 /* GetArchiveUseCase.swift */; };
 		BA4CCDFA29EAE6D50040D0D7 /* ArchivePopUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4CCDF929EAE6D50040D0D7 /* ArchivePopUpViewModel.swift */; };
-		BA4CCDF129EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4CCDF029EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift */; };
 		BA4DADB3295747E700C7ABD7 /* PageControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4DADB2295747E700C7ABD7 /* PageControl.swift */; };
 		BA52778428EECDC50036B825 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA52777B28EECDC50036B825 /* Pretendard-Medium.otf */; };
 		BA52778528EECDC50036B825 /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA52777C28EECDC50036B825 /* Pretendard-Black.otf */; };
@@ -158,6 +158,8 @@
 		BA52778B28EECDC50036B825 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA52778228EECDC50036B825 /* Pretendard-Regular.otf */; };
 		BA52778C28EECDC50036B825 /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA52778328EECDC50036B825 /* Pretendard-Light.otf */; };
 		BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52778F28EECEB40036B825 /* Ex+UIFont.swift */; };
+		BA57F3F929ED4EEC00A9F790 /* ArchiveUploadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3F729ED4EEC00A9F790 /* ArchiveUploadViewController.swift */; };
+		BA57F3FA29ED4EEC00A9F790 /* ArchiveUploadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3F829ED4EEC00A9F790 /* ArchiveUploadViewModel.swift */; };
 		BA590E7A29EBC6320017FAF1 /* GetArchiveDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA590E7929EBC6320017FAF1 /* GetArchiveDetailUseCase.swift */; };
 		BA590E7D29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA590E7C29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift */; };
 		BA5D9ECF29E3E9A300F06AB5 /* ArchiveRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5D9ECD29E3E9A300F06AB5 /* ArchiveRouter.swift */; };
@@ -507,10 +509,10 @@
 		BA46CC9E28EC9B05004953B1 /* Ex+UIButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Ex+UIButton.swift"; sourceTree = "<group>"; };
 		BA4BD1AD29D6C4A800334C04 /* PagingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingManager.swift; sourceTree = "<group>"; };
 		BA4C46C9297ADB5900C914F3 /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
+		BA4CCDF029EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentOptionBottomSheetViewController.swift; sourceTree = "<group>"; };
 		BA4CCDF229EAA33B0040D0D7 /* DateFormatterFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterFactory.swift; sourceTree = "<group>"; };
 		BA4CCDF629EAB9540040D0D7 /* GetArchiveUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetArchiveUseCase.swift; sourceTree = "<group>"; };
 		BA4CCDF929EAE6D50040D0D7 /* ArchivePopUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivePopUpViewModel.swift; sourceTree = "<group>"; };
-		BA4CCDF029EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentOptionBottomSheetViewController.swift; sourceTree = "<group>"; };
 		BA4DADB2295747E700C7ABD7 /* PageControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageControl.swift; sourceTree = "<group>"; };
 		BA52777B28EECDC50036B825 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
 		BA52777C28EECDC50036B825 /* Pretendard-Black.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Black.otf"; sourceTree = "<group>"; };
@@ -522,6 +524,8 @@
 		BA52778228EECDC50036B825 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		BA52778328EECDC50036B825 /* Pretendard-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.otf"; sourceTree = "<group>"; };
 		BA52778F28EECEB40036B825 /* Ex+UIFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+UIFont.swift"; sourceTree = "<group>"; };
+		BA57F3F729ED4EEC00A9F790 /* ArchiveUploadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveUploadViewController.swift; sourceTree = "<group>"; };
+		BA57F3F829ED4EEC00A9F790 /* ArchiveUploadViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveUploadViewModel.swift; sourceTree = "<group>"; };
 		BA590E7929EBC6320017FAF1 /* GetArchiveDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetArchiveDetailUseCase.swift; sourceTree = "<group>"; };
 		BA590E7C29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailCollectionViewCell.swift; sourceTree = "<group>"; };
 		BA5D9ECD29E3E9A300F06AB5 /* ArchiveRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveRouter.swift; sourceTree = "<group>"; };
@@ -886,9 +890,10 @@
 		702876BD29A374C500E57509 /* Archive */ = {
 			isa = PBXGroup;
 			children = (
-				BA4CCDF829EAE6BC0040D0D7 /* ViewModel */,
 				BA590E7B29EBF2850017FAF1 /* Cell */,
+				BA4CCDF829EAE6BC0040D0D7 /* ViewModel */,
 				BA8D949929E96FF00075ACD8 /* ArchivePopUpViewController.swift */,
+				BA57F3F729ED4EEC00A9F790 /* ArchiveUploadViewController.swift */,
 				702876C129A3751400E57509 /* ArchiveViewController.swift */,
 			);
 			path = Archive;
@@ -1259,6 +1264,7 @@
 			isa = PBXGroup;
 			children = (
 				BA4CCDF929EAE6D50040D0D7 /* ArchivePopUpViewModel.swift */,
+				BA57F3F829ED4EEC00A9F790 /* ArchiveUploadViewModel.swift */,
 				BAB9DFD029BB17B90062807C /* ArchiveViewModel.swift */,
 			);
 			path = ViewModel;
@@ -2306,6 +2312,7 @@
 				70197B7D29549B96000503F6 /* SelectedCategoryFilterHeaderView.swift in Sources */,
 				C39E09B829C6089300ECAD11 /* RecruitingSectionFooterView.swift in Sources */,
 				701A9C9C29B72656006F53C2 /* MainPageClipboardView.swift in Sources */,
+				BA57F3F929ED4EEC00A9F790 /* ArchiveUploadViewController.swift in Sources */,
 				701A9C9C29B72656006F53C2 /* MainPageClipboardView.swift in Sources */,
 				701A9C9C29B72656006F53C2 /* MainPageClipboardView.swift in Sources */,
 				70A420B429914B370026E9F9 /* AllCategoryListResponse.swift in Sources */,
@@ -2478,6 +2485,7 @@
 				C307826329CF4B9B00E1D44B /* MeetingCollectionMoreCell.swift in Sources */,
 				705F81C329AFAA3B00830C4F /* BoardViewController.swift in Sources */,
 				BAE5D3352975B10F00268D44 /* ReissuanceRequest.swift in Sources */,
+				BA57F3FA29ED4EEC00A9F790 /* ArchiveUploadViewModel.swift in Sources */,
 				70197B6E29535BAA000503F6 /* HomeViewModel.swift in Sources */,
 				BA5D9ED929E3F16900F06AB5 /* ArchiveContent.swift in Sources */,
 				70F1DFE0297A90AE00F9BC83 /* MeetingService.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		BA57F3F929ED4EEC00A9F790 /* ArchiveUploadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3F729ED4EEC00A9F790 /* ArchiveUploadViewController.swift */; };
 		BA57F3FA29ED4EEC00A9F790 /* ArchiveUploadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3F829ED4EEC00A9F790 /* ArchiveUploadViewModel.swift */; };
 		BA57F3FD29ED5D6600A9F790 /* ArchiveUploadHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3FC29ED5D6600A9F790 /* ArchiveUploadHeaderView.swift */; };
+		BA57F3FF29ED814500A9F790 /* ArchiveUploadCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3FE29ED814500A9F790 /* ArchiveUploadCollectionViewCell.swift */; };
 		BA590E7A29EBC6320017FAF1 /* GetArchiveDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA590E7929EBC6320017FAF1 /* GetArchiveDetailUseCase.swift */; };
 		BA590E7D29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA590E7C29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift */; };
 		BA5D9ECF29E3E9A300F06AB5 /* ArchiveRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5D9ECD29E3E9A300F06AB5 /* ArchiveRouter.swift */; };
@@ -528,6 +529,7 @@
 		BA57F3F729ED4EEC00A9F790 /* ArchiveUploadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveUploadViewController.swift; sourceTree = "<group>"; };
 		BA57F3F829ED4EEC00A9F790 /* ArchiveUploadViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveUploadViewModel.swift; sourceTree = "<group>"; };
 		BA57F3FC29ED5D6600A9F790 /* ArchiveUploadHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveUploadHeaderView.swift; sourceTree = "<group>"; };
+		BA57F3FE29ED814500A9F790 /* ArchiveUploadCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveUploadCollectionViewCell.swift; sourceTree = "<group>"; };
 		BA590E7929EBC6320017FAF1 /* GetArchiveDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetArchiveDetailUseCase.swift; sourceTree = "<group>"; };
 		BA590E7C29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailCollectionViewCell.swift; sourceTree = "<group>"; };
 		BA5D9ECD29E3E9A300F06AB5 /* ArchiveRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveRouter.swift; sourceTree = "<group>"; };
@@ -1303,6 +1305,7 @@
 			children = (
 				BAAD0AD429BB2E72007B33D9 /* ArchiveCollectionViewCell.swift */,
 				BA590E7C29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift */,
+				BA57F3FE29ED814500A9F790 /* ArchiveUploadCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -2418,6 +2421,7 @@
 				BA784FAE297937DA00E8B06F /* CalendarControl.swift in Sources */,
 				C31605192997935100D27488 /* MeetingInfoViewModel.swift in Sources */,
 				C32AB19029DDB9000045B919 /* ProfileEditViewModel.swift in Sources */,
+				BA57F3FF29ED814500A9F790 /* ArchiveUploadCollectionViewCell.swift in Sources */,
 				70A420AB298FAD000026E9F9 /* TopTabCollectionViewCell.swift in Sources */,
 				70A420BF29914B690026E9F9 /* RequestBookmarkResponse.swift in Sources */,
 				BAE1AD952944775C00CE36B9 /* PolicyViewController.swift in Sources */,

--- a/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
@@ -1,0 +1,56 @@
+// 
+//  ArchiveUploadViewController.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/17.
+//
+
+import UIKit
+
+import RxSwift
+import RxCocoa
+import SnapKit
+import Then
+
+final class ArchiveUploadViewController: BaseViewController {
+  
+  // MARK: - Properties
+  
+  private let viewModel: ArchiveUploadViewModelType
+  
+  
+  // MARK: - Initializations
+  
+  init(viewModel: ArchiveUploadViewModelType) {
+    self.viewModel = viewModel
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Life Cycles
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+  }
+  
+  // MARK: - Configuration
+  
+  override func setupLayouts() {
+    super.setupLayouts()
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+  }
+  
+  override func setupStyles() {
+    super.setupStyles()
+  }
+  
+  override func bind() {
+    super.bind()
+  }
+}

--- a/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
@@ -28,6 +28,10 @@ final class ArchiveUploadViewController: BaseViewController {
   
   private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then {
     $0.register(
+      ArchiveUploadCollectionViewCell.self,
+      forCellWithReuseIdentifier: ArchiveUploadCollectionViewCell.identifier
+    )
+    $0.register(
       ArchiveUploadHeaderView.self,
       forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
       withReuseIdentifier: ArchiveUploadHeaderView.identifier

--- a/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
@@ -18,6 +18,16 @@ final class ArchiveUploadViewController: BaseViewController {
   
   private let viewModel: ArchiveUploadViewModelType
   
+  // MARK: - UI Components
+  
+  private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then {
+    $0.backgroundColor = .background
+  }
+  
+  private let completeButton = UIButton(configuration: .plain()).then {
+    $0.configurationUpdateHandler = $0.configuration?.plubButton(label: "완료")
+    $0.isEnabled = false
+  }
   
   // MARK: - Initializations
   
@@ -40,10 +50,25 @@ final class ArchiveUploadViewController: BaseViewController {
   
   override func setupLayouts() {
     super.setupLayouts()
+    [collectionView, completeButton].forEach {
+      view.addSubview($0)
+    }
   }
   
   override func setupConstraints() {
     super.setupConstraints()
+    
+    collectionView.snp.makeConstraints {
+      $0.directionalHorizontalEdges.equalToSuperview().inset(Margin.horizontal)
+      $0.top.equalTo(view.safeAreaLayoutGuide)
+      $0.bottom.equalTo(completeButton.snp.top)
+    }
+    
+    completeButton.snp.makeConstraints {
+      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(Margin.horizontal)
+      $0.height.equalTo(Size.buttonHeight)
+    }
   }
   
   override func setupStyles() {
@@ -52,5 +77,16 @@ final class ArchiveUploadViewController: BaseViewController {
   
   override func bind() {
     super.bind()
+  }
+}
+
+private extension ArchiveUploadViewController {
+  
+  enum Margin {
+    static let horizontal = 16
+  }
+  
+  enum Size {
+    static let buttonHeight = 46
   }
 }

--- a/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
@@ -80,7 +80,7 @@ final class ArchiveUploadViewController: BaseViewController {
     
     collectionView.snp.makeConstraints {
       $0.directionalHorizontalEdges.equalToSuperview().inset(Margin.horizontal)
-      $0.top.equalTo(archiveTitleLabel.snp.bottom).offset(24)
+      $0.top.equalTo(archiveTitleLabel.snp.bottom)
       $0.bottom.equalTo(completeButton.snp.top)
     }
     
@@ -114,7 +114,11 @@ private extension ArchiveUploadViewController {
     
     let section = NSCollectionLayoutSection(group: group)
     section.interGroupSpacing = 12
-    section.contentInsets = .init(top: 0, leading: 0, bottom: 32, trailing: 0)
+    section.contentInsets = .init(top: 8, leading: 0, bottom: 32, trailing: 0)
+    
+    let headerItem = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: .init(widthDimension: .fractionalWidth(1), heightDimension: .estimated(124)), elementKind: UICollectionView.elementKindSectionHeader, alignment: .top)
+    section.boundarySupplementaryItems = [headerItem]
+    
     
     return UICollectionViewCompositionalLayout(section: section)
   }

--- a/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
@@ -20,6 +20,12 @@ final class ArchiveUploadViewController: BaseViewController {
   
   // MARK: - UI Components
   
+  private let archiveTitleLabel = UILabel().then {
+    $0.text = "아카이브 업로드"
+    $0.textColor = .black
+    $0.font = .h3
+  }
+  
   private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then {
     $0.register(
       ArchiveUploadHeaderView.self,
@@ -55,7 +61,7 @@ final class ArchiveUploadViewController: BaseViewController {
   
   override func setupLayouts() {
     super.setupLayouts()
-    [collectionView, completeButton].forEach {
+    [archiveTitleLabel, collectionView, completeButton].forEach {
       view.addSubview($0)
     }
   }
@@ -63,9 +69,14 @@ final class ArchiveUploadViewController: BaseViewController {
   override func setupConstraints() {
     super.setupConstraints()
     
+    archiveTitleLabel.snp.makeConstraints {
+      $0.top.equalTo(view.safeAreaLayoutGuide).inset(14)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(Margin.horizontal)
+    }
+    
     collectionView.snp.makeConstraints {
       $0.directionalHorizontalEdges.equalToSuperview().inset(Margin.horizontal)
-      $0.top.equalTo(view.safeAreaLayoutGuide)
+      $0.top.equalTo(archiveTitleLabel.snp.bottom).offset(24)
       $0.bottom.equalTo(completeButton.snp.top)
     }
     

--- a/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
@@ -20,10 +20,17 @@ final class ArchiveUploadViewController: BaseViewController {
   
   // MARK: - UI Components
   
+  private let archiveTitleLabelContainerView = UIView()
+  
   private let archiveTitleLabel = UILabel().then {
     $0.text = "아카이브 업로드"
     $0.textColor = .black
     $0.font = .h3
+  }
+  
+  private let gradientLayer = CAGradientLayer().then {
+    $0.locations = [0.7]
+    $0.colors = [UIColor.background.cgColor, UIColor.background.withAlphaComponent(0).cgColor]
   }
   
   private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then {
@@ -37,6 +44,7 @@ final class ArchiveUploadViewController: BaseViewController {
       withReuseIdentifier: ArchiveUploadHeaderView.identifier
     )
     $0.backgroundColor = .background
+    $0.showsVerticalScrollIndicator = false
   }
   
   private let completeButton = UIButton(configuration: .plain()).then {
@@ -61,21 +69,34 @@ final class ArchiveUploadViewController: BaseViewController {
     super.viewDidLoad()
   }
   
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    var frame = archiveTitleLabelContainerView.bounds
+    frame.size.height += 32
+    gradientLayer.frame = frame
+  }
+  
   // MARK: - Configuration
   
   override func setupLayouts() {
     super.setupLayouts()
-    [archiveTitleLabel, collectionView, completeButton].forEach {
+    [collectionView, archiveTitleLabelContainerView, completeButton].forEach {
       view.addSubview($0)
     }
+    archiveTitleLabelContainerView.layer.addSublayer(gradientLayer)
+    archiveTitleLabelContainerView.addSubview(archiveTitleLabel)
   }
   
   override func setupConstraints() {
     super.setupConstraints()
     
-    archiveTitleLabel.snp.makeConstraints {
+    archiveTitleLabelContainerView.snp.makeConstraints {
       $0.top.equalTo(view.safeAreaLayoutGuide).inset(14)
       $0.directionalHorizontalEdges.equalToSuperview().inset(Margin.horizontal)
+    }
+    
+    archiveTitleLabel.snp.makeConstraints {
+      $0.directionalEdges.equalToSuperview()
     }
     
     collectionView.snp.makeConstraints {

--- a/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
@@ -21,6 +21,11 @@ final class ArchiveUploadViewController: BaseViewController {
   // MARK: - UI Components
   
   private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then {
+    $0.register(
+      ArchiveUploadHeaderView.self,
+      forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+      withReuseIdentifier: ArchiveUploadHeaderView.identifier
+    )
     $0.backgroundColor = .background
   }
   

--- a/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
@@ -65,9 +65,6 @@ final class ArchiveUploadViewController: BaseViewController {
   
   // MARK: - Life Cycles
   
-  override func viewDidLoad() {
-    super.viewDidLoad()
-  }
   
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()

--- a/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
@@ -89,12 +89,34 @@ final class ArchiveUploadViewController: BaseViewController {
   
   override func setupStyles() {
     super.setupStyles()
+    collectionView.collectionViewLayout = createLayouts()
   }
   
   override func bind() {
     super.bind()
   }
 }
+
+// MARK: - UICollectionViewCompositionalLayout
+
+private extension ArchiveUploadViewController {
+  func createLayouts() -> UICollectionViewLayout {
+    let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalWidth(0.5))
+    let item = NSCollectionLayoutItem(layoutSize: itemSize)
+    
+    let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(100))
+    let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, repeatingSubitem: item, count: 2)
+    group.interItemSpacing = .fixed(12)
+    
+    let section = NSCollectionLayoutSection(group: group)
+    section.interGroupSpacing = 12
+    section.contentInsets = .init(top: 0, leading: 0, bottom: 32, trailing: 0)
+    
+    return UICollectionViewCompositionalLayout(section: section)
+  }
+}
+
+// MARK: - Constants
 
 private extension ArchiveUploadViewController {
   

--- a/PLUB/Sources/Views/Home/Archive/ArchiveViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveViewController.swift
@@ -135,6 +135,13 @@ final class ArchiveViewController: BaseViewController {
       }
       .bind(to: viewModel.offsetObserver)
       .disposed(by: disposeBag)
+    
+    uploadButton.rx.tap
+      .subscribe(with: self) { owner, _ in
+        let uploadVC = ArchiveUploadViewController(viewModel: ArchiveUploadViewModel())
+        owner.navigationController?.pushViewController(uploadVC, animated: true)
+      }
+      .disposed(by: disposeBag)
   }
 }
 

--- a/PLUB/Sources/Views/Home/Archive/Cell/ArchiveUploadCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Archive/Cell/ArchiveUploadCollectionViewCell.swift
@@ -1,0 +1,42 @@
+//
+//  ArchiveUploadCollectionViewCell.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/17.
+//
+
+import UIKit
+
+final class ArchiveUploadCollectionViewCell: UICollectionViewCell {
+  
+  // MARK: - Properties
+  
+  static let identifier = "\(ArchiveUploadCollectionViewCell.self)"
+  
+  // MARK: - Initializations
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupLayouts()
+    setupConstraints()
+    setupStyles()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Configurations
+  
+  private func setupLayouts() {
+    
+  }
+  
+  private func setupConstraints() {
+    
+  }
+  
+  private func setupStyles() {
+    
+  }
+}

--- a/PLUB/Sources/Views/Home/Archive/Component/ArchiveUploadHeaderView.swift
+++ b/PLUB/Sources/Views/Home/Archive/Component/ArchiveUploadHeaderView.swift
@@ -1,0 +1,42 @@
+//
+//  ArchiveUploadHeaderView.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/17.
+//
+
+import UIKit
+
+final class ArchiveUploadHeaderView: UICollectionReusableView {
+  
+  // MARK: - Properties
+  
+  static let identifier = "\(ArchiveUploadHeaderView.self)"
+  
+  // MARK: - Initializations
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupLayouts()
+    setupConstraints()
+    setupStyles()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Configurations
+  
+  private func setupLayouts() {
+    
+  }
+  
+  private func setupConstraints() {
+    
+  }
+  
+  private func setupStyles() {
+    backgroundColor = .systemGray // for test
+  }
+}

--- a/PLUB/Sources/Views/Home/Archive/Component/ArchiveUploadHeaderView.swift
+++ b/PLUB/Sources/Views/Home/Archive/Component/ArchiveUploadHeaderView.swift
@@ -7,11 +7,43 @@
 
 import UIKit
 
+import RxSwift
+import RxCocoa
+import SnapKit
+import Then
+
 final class ArchiveUploadHeaderView: UICollectionReusableView {
   
   // MARK: - Properties
   
   static let identifier = "\(ArchiveUploadHeaderView.self)"
+  
+  private let disposeBag = DisposeBag()
+  
+  // MARK: - UI Components
+  
+  private let titleLabel = UILabel().then {
+    $0.text = "제목"
+    $0.textColor = .black
+    $0.font = .subtitle
+  }
+  
+  private let textField = PaddingTextField(left: 8, right: 8).then {
+    $0.layer.cornerRadius = 8
+    $0.backgroundColor = .white
+    $0.textColor = .black
+    $0.font = .body1
+    $0.attributedPlaceholder = NSAttributedString(
+      string: "제목을 입력해주세요",
+      attributes: [.font: UIFont.body2]
+    )
+  }
+  
+  private let pictureLabel = UILabel().then {
+    $0.text = "사진"
+    $0.textColor = .black
+    $0.font = .subtitle
+  }
   
   // MARK: - Initializations
   
@@ -29,11 +61,28 @@ final class ArchiveUploadHeaderView: UICollectionReusableView {
   // MARK: - Configurations
   
   private func setupLayouts() {
-    
+    [titleLabel, textField, pictureLabel].forEach {
+      addSubview($0)
+    }
   }
   
   private func setupConstraints() {
     
+    titleLabel.snp.makeConstraints {
+      $0.directionalHorizontalEdges.equalToSuperview()
+      $0.top.equalToSuperview().inset(24)
+    }
+    
+    textField.snp.makeConstraints {
+      $0.top.equalTo(titleLabel.snp.bottom).offset(8)
+      $0.directionalHorizontalEdges.equalToSuperview()
+      $0.height.equalTo(46)
+    }
+    
+    pictureLabel.snp.makeConstraints {
+      $0.top.equalTo(textField.snp.bottom).offset(32)
+      $0.bottom.directionalHorizontalEdges.equalToSuperview()
+    }
   }
   
   private func setupStyles() {

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
@@ -1,0 +1,30 @@
+// 
+//  ArchiveUploadViewModel.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/17.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+protocol ArchiveUploadViewModelType {
+  // Input
+  
+  // Output
+}
+
+final class ArchiveUploadViewModel: ArchiveUploadViewModelType {
+  
+  // Input
+  
+  // Output
+  
+  init() {
+    
+  }
+  
+  private let disposeBag = DisposeBag()
+}


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 업로드 UI를 구현했습니다. 단순 Mock Up으로만 구성되어있습니다.

🌱 PR 포인트
- 레이아웃을 Compositional Layout으로 구성했습니다. 그 이유는 각 기기의 너비에 맞게 정사각형 형태의 셀을 보여주어야 했는데, FlowLayout을 사용하게 되면 itemSize를 별도로 설정해주어야하지만, Compositional Layout은 비율에 맞게 설정할 수 있는 API가 들어가 있어 더욱 편리하게 구현할 수 있었기 때문입니다.
- archiveTitleLabel(`아카이브 업로드`라고 텍스트가 써져있는 레이블)을 archiveTitleLabelContainerView로 감쌌는데, 그 이유는 gradientLayer를 적용하기 위함입니다. figma에서 보다시피 상단쪽을 보면, 살짝의 `gradient`가 들어가있는 것을 보실 수 있을 겁니다.
- 레이아웃은 다음과 같이 구성되어 있습니다.
![image](https://user-images.githubusercontent.com/57972338/232565781-d6c59b2f-3bd6-4999-9f5b-0fc2c12c705d.png)


## 📸 스크린샷
|스크린샷|
|:--:|
|<img src="https://user-images.githubusercontent.com/57972338/232564280-99501531-ba80-40a2-9137-fd6a3f44f2d1.gif" width="50%"/>|

## 📮 관련 이슈
- #299

