### PR TITLE
댓글 수정 기능 구현

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -114,7 +114,7 @@
 		70F1DFEA297D992100F9BC83 /* RecruitmentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F1DFE9297D992100F9BC83 /* RecruitmentService.swift */; };
 		70F1DFEF297D9E1C00F9BC83 /* DetailRecruitmentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F1DFEE297D9E1C00F9BC83 /* DetailRecruitmentViewModel.swift */; };
 		70F1DFF1297DA3CE00F9BC83 /* DetailRecruitmentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F1DFF0297DA3CE00F9BC83 /* DetailRecruitmentModel.swift */; };
-		BA034D3229E864CA003B7192 /* ReplyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA034D3129E864CA003B7192 /* ReplyView.swift */; };
+		BA034D3229E864CA003B7192 /* CommentOptionDecoratorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA034D3129E864CA003B7192 /* CommentOptionDecoratorView.swift */; };
 		BA117A3B297440B500B37E03 /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA117A3A297440B500B37E03 /* UserDefaultsWrapper.swift */; };
 		BA117A3D297440D900B37E03 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA117A3C297440D900B37E03 /* UserManager.swift */; };
 		BA117A4E297444EE00B37E03 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = BA117A4D297444EE00B37E03 /* KakaoSDKAuth */; };
@@ -483,7 +483,7 @@
 		70F1DFE9297D992100F9BC83 /* RecruitmentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecruitmentService.swift; sourceTree = "<group>"; };
 		70F1DFEE297D9E1C00F9BC83 /* DetailRecruitmentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailRecruitmentViewModel.swift; sourceTree = "<group>"; };
 		70F1DFF0297DA3CE00F9BC83 /* DetailRecruitmentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailRecruitmentModel.swift; sourceTree = "<group>"; };
-		BA034D3129E864CA003B7192 /* ReplyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplyView.swift; sourceTree = "<group>"; };
+		BA034D3129E864CA003B7192 /* CommentOptionDecoratorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentOptionDecoratorView.swift; sourceTree = "<group>"; };
 		BA117A3A297440B500B37E03 /* UserDefaultsWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsWrapper.swift; sourceTree = "<group>"; };
 		BA117A3C297440D900B37E03 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
 		BA1BEDC2296454AB00C6BD41 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
@@ -1564,7 +1564,7 @@
 			children = (
 				BAB033F929B5C5580077C4D9 /* BoardDetailCollectionHeaderView.swift */,
 				BAC9794429CF0E9E00A5DF1B /* CommentInputView.swift */,
-				BA034D3129E864CA003B7192 /* ReplyView.swift */,
+				BA034D3129E864CA003B7192 /* CommentOptionDecoratorView.swift */,
 				BA4CCDF029EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift */,
 			);
 			path = Component;
@@ -2255,7 +2255,7 @@
 				70A4209C2988B1DC0026E9F9 /* SortControl.swift in Sources */,
 				BA5D9EDB29E406AD00F06AB5 /* Day.swift in Sources */,
 				70A420A7298D0F140026E9F9 /* RecentSearchListCollectionViewCell.swift in Sources */,
-				BA034D3229E864CA003B7192 /* ReplyView.swift in Sources */,
+				BA034D3229E864CA003B7192 /* CommentOptionDecoratorView.swift in Sources */,
 				C3E0390A29C2125700C4744C /* InquireApplicantResponse.swift in Sources */,
 				C3B3435629BE3A2200935B73 /* MyPageService.swift in Sources */,
 				C36F31C729E3072800AC2C8A /* ScheduleBottomSheetViewController.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		BA5D9EDB29E406AD00F06AB5 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5D9EDA29E406AD00F06AB5 /* Day.swift */; };
 		BA5DEB302974D8E200650788 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5DEB2F2974D8E200650788 /* NetworkResult.swift */; };
 		BA5DEB3329751E5F00650788 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = BA5DEB3229751E5F00650788 /* GoogleSignIn */; };
+		BA5EC6C629EFD4E5000A68B7 /* EditCommentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5EC6C529EFD4E5000A68B7 /* EditCommentUseCase.swift */; };
 		BA6D7C5329A7D46900D8E928 /* CommentsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6D7C5229A7D46900D8E928 /* CommentsRequest.swift */; };
 		BA7255C12992445600A3E8F5 /* PLUBTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7255C02992445600A3E8F5 /* PLUBTabBarController.swift */; };
 		BA72BCF029BB03FF007165E5 /* BaseNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA72BCEF29BB03FF007165E5 /* BaseNavigationController.swift */; };
@@ -534,6 +535,7 @@
 		BA5D9ED829E3F16900F06AB5 /* ArchiveContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveContent.swift; sourceTree = "<group>"; };
 		BA5D9EDA29E406AD00F06AB5 /* Day.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Day.swift; sourceTree = "<group>"; };
 		BA5DEB2F2974D8E200650788 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
+		BA5EC6C529EFD4E5000A68B7 /* EditCommentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EditCommentUseCase.swift; path = PLUB/Sources/UseCases/Feeds/EditCommentUseCase.swift; sourceTree = SOURCE_ROOT; };
 		BA6D7C5229A7D46900D8E928 /* CommentsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentsRequest.swift; sourceTree = "<group>"; };
 		BA7255C02992445600A3E8F5 /* PLUBTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLUBTabBarController.swift; sourceTree = "<group>"; };
 		BA72BCEF29BB03FF007165E5 /* BaseNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNavigationController.swift; sourceTree = "<group>"; };
@@ -1244,9 +1246,10 @@
 		BA4CCDF429EAB91D0040D0D7 /* Feeds */ = {
 			isa = PBXGroup;
 			children = (
-				BAB2E56B29E30A13006B7BDC /* PostCommentUseCase.swift */,
 				BA57F3F529ED30D200A9F790 /* DeleteCommentUseCase.swift */,
+				BA5EC6C529EFD4E5000A68B7 /* EditCommentUseCase.swift */,
 				BAB2E56D29E30F96006B7BDC /* GetCommentsUseCase.swift */,
+				BAB2E56B29E30A13006B7BDC /* PostCommentUseCase.swift */,
 			);
 			path = Feeds;
 			sourceTree = "<group>";
@@ -2368,6 +2371,7 @@
 				BA8E2B46297467A2009DDF32 /* AuthService.swift in Sources */,
 				BAC923DF29546BF500385841 /* BirthViewController.swift in Sources */,
 				C3EC027D29D9582D0024C962 /* WaitingViewController.swift in Sources */,
+				BA5EC6C629EFD4E5000A68B7 /* EditCommentUseCase.swift in Sources */,
 				70A420B329914B370026E9F9 /* SubCategoryListResponse.swift in Sources */,
 				BA88125228E48A2F00BD832A /* HomeViewController.swift in Sources */,
 				BA340E2529782356002BAF2C /* ProfileViewController.swift in Sources */,

--- a/PLUB/Sources/Models/Feeds/CommentContent.swift
+++ b/PLUB/Sources/Models/Feeds/CommentContent.swift
@@ -24,7 +24,7 @@ struct CommentContent: Codable {
   let commentID: Int
   
   /// 댓글 내용
-  let content: String
+  var content: String
   
   /// 프로필 이미지 URL
   let profileImageURL: String?

--- a/PLUB/Sources/UseCases/Feeds/EditCommentUseCase.swift
+++ b/PLUB/Sources/UseCases/Feeds/EditCommentUseCase.swift
@@ -1,0 +1,19 @@
+// 
+//  EditCommentUseCase.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/19.
+//
+
+import RxSwift
+
+protocol EditCommentUseCase {
+  func execute(plubbingID: Int, feedID: Int, commentID: Int, content: String) -> Observable<CommentContent>
+}
+
+final class DefaultEditCommentUseCase: EditCommentUseCase {
+  
+  func execute(plubbingID: Int, feedID: Int, commentID: Int, content: String) -> Observable<CommentContent> {
+    FeedsService.shared.updateComment(plubbingID: plubbingID, feedID: feedID, commentID: commentID, comment: content)
+  }
+}

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -183,7 +183,7 @@ extension BoardDetailViewController: CommentOptionBottomSheetDelegate {
   }
   
   func editButtonTapped() {
-    print(#function)
+    viewModel.editOptionObserver.onNext(Void())
   }
   
   func reportButtonTapped() {

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -126,6 +126,10 @@ final class BoardDetailViewController: BaseViewController {
       }
       .disposed(by: disposeBag)
     
+    viewModel.editCommentTextObservable
+      .bind(to: commentInputView.rx.commentText)
+      .disposed(by: disposeBag)
+    
     // ViewModel에게 `DiffableDataSource`처리를 해주기 위해 collectionView를 전달
     viewModel.setCollectionViewObserver.onNext(collectionView)
     

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -118,12 +118,11 @@ final class BoardDetailViewController: BaseViewController {
       .disposed(by: disposeBag)
     
     viewModel.showBottomSheetObservable
-      .subscribe(with: self) { owner, userType in
-        let bottomSheetVC = CommentOptionBottomSheetViewController(userAccessType: userType).then {
+      .subscribe(with: self) { owner, tuple in
+        let bottomSheetVC = CommentOptionBottomSheetViewController(commentID: tuple.commentID, userAccessType: tuple.userType).then {
           $0.delegate = owner
         }
         owner.present(bottomSheetVC, animated: true)
-        
       }
       .disposed(by: disposeBag)
     
@@ -180,15 +179,15 @@ extension BoardDetailViewController: CommentOptionViewDelegate {
 // MARK: - CommentOptionBottomSheetDelegate
 
 extension BoardDetailViewController: CommentOptionBottomSheetDelegate {
-  func deleteButtonTapped() {
+  func deleteButtonTapped(commentID: Int) {
     viewModel.deleteOptionObserver.onNext(Void())
   }
   
-  func editButtonTapped() {
+  func editButtonTapped(commentID: Int) {
     viewModel.editOptionObserver.onNext(Void())
   }
   
-  func reportButtonTapped() {
+  func reportButtonTapped(commentID: Int) {
     print(#function)
   }
 }

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -171,7 +171,7 @@ extension BoardDetailViewController: CommentInputViewDelegate {
 
 extension BoardDetailViewController: CommentOptionViewDelegate {
   func cancelButtonTapped() {
-    viewModel.replyIDObserver.onNext(nil)
+    viewModel.targetIDObserver.onNext(nil)
     decoratorView.isHidden = true
   }
 }
@@ -180,10 +180,12 @@ extension BoardDetailViewController: CommentOptionViewDelegate {
 
 extension BoardDetailViewController: CommentOptionBottomSheetDelegate {
   func deleteButtonTapped(commentID: Int) {
+    viewModel.targetIDObserver.onNext(commentID)
     viewModel.deleteOptionObserver.onNext(Void())
   }
   
   func editButtonTapped(commentID: Int) {
+    viewModel.targetIDObserver.onNext(commentID)
     viewModel.editOptionObserver.onNext(Void())
   }
   

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -171,6 +171,7 @@ extension BoardDetailViewController: CommentInputViewDelegate {
 
 extension BoardDetailViewController: CommentOptionViewDelegate {
   func cancelButtonTapped() {
+    viewModel.commentOptionObserver.onNext(.commentOrReply)
     viewModel.targetIDObserver.onNext(nil)
     decoratorView.isHidden = true
   }
@@ -180,13 +181,15 @@ extension BoardDetailViewController: CommentOptionViewDelegate {
 
 extension BoardDetailViewController: CommentOptionBottomSheetDelegate {
   func deleteButtonTapped(commentID: Int) {
+    // 순서 중요
     viewModel.targetIDObserver.onNext(commentID)
-    viewModel.deleteOptionObserver.onNext(Void())
+    viewModel.commentOptionObserver.onNext(.delete)
   }
   
   func editButtonTapped(commentID: Int) {
+    // 순서 중요
     viewModel.targetIDObserver.onNext(commentID)
-    viewModel.editOptionObserver.onNext(Void())
+    viewModel.commentOptionObserver.onNext(.edit)
   }
   
   func reportButtonTapped(commentID: Int) {

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -168,6 +168,7 @@ extension BoardDetailViewController: CommentInputViewDelegate {
   func commentInputView(_ textView: UITextView, writtenText: String) {
     textView.text = ""
     viewModel.commentsInput.onNext(writtenText)
+    decoratorView.isHidden = true
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -32,7 +32,8 @@ final class BoardDetailViewController: BaseViewController {
   
   // MARK: Comment Posting View (댓글 작성 UI)
   
-  private let replyView = ReplyView().then {
+  /// 답글을 달거나 댓글을 수정할 때 보여지는 데코레이터 뷰
+  private let decoratorView = CommentOptionDecoratorView().then {
     $0.backgroundColor = .background
     $0.isHidden = true
   }
@@ -68,7 +69,7 @@ final class BoardDetailViewController: BaseViewController {
   
   override func setupLayouts() {
     super.setupLayouts()
-    [collectionView, commentInputView, replyView].forEach {
+    [collectionView, commentInputView, decoratorView].forEach {
       view.addSubview($0)
     }
   }
@@ -85,7 +86,7 @@ final class BoardDetailViewController: BaseViewController {
       $0.bottom.equalTo(view.safeAreaLayoutGuide)
     }
     
-    replyView.snp.makeConstraints {
+    decoratorView.snp.makeConstraints {
       $0.directionalHorizontalEdges.equalTo(view.safeAreaLayoutGuide)
       $0.bottom.equalTo(commentInputView.snp.top)
       $0.height.equalTo(28)
@@ -101,17 +102,18 @@ final class BoardDetailViewController: BaseViewController {
     
     // == comment posting delegate ==
     commentInputView.delegate = self
-    replyView.delegate = self
+    decoratorView.delegate = self
   }
   
   override func bind() {
     super.bind()
     collectionView.rx.setDelegate(self).disposed(by: disposeBag)
     
-    viewModel.replyNicknameObserable
-      .subscribe(with: self) { owner, nickname in
-        owner.replyView.nickname = nickname
-        owner.replyView.isHidden = false
+    viewModel.decoratorNameObserable
+      .subscribe(with: self) { owner, tuple in
+        owner.decoratorView.labelText = tuple.labelText
+        owner.decoratorView.buttonText = tuple.buttonText
+        owner.decoratorView.isHidden = false
       }
       .disposed(by: disposeBag)
     
@@ -166,12 +168,12 @@ extension BoardDetailViewController: CommentInputViewDelegate {
   }
 }
 
-// MARK: - ReplyViewDelegate
+// MARK: - CommentOptionViewDelegate
 
-extension BoardDetailViewController: ReplyViewDelegate {
+extension BoardDetailViewController: CommentOptionViewDelegate {
   func cancelButtonTapped() {
     viewModel.replyIDObserver.onNext(nil)
-    replyView.isHidden = true
+    decoratorView.isHidden = true
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
@@ -105,7 +105,8 @@ final class ClipboardViewController: BaseViewController {
               content: model.toBoardModel,
               getCommentsUseCase: DefaultGetCommentsUseCase(),
               postCommentUseCase: DefaultPostCommentUseCase(),
-              deleteCommentUseCase: DefaultDeleteCommentUseCase()
+              deleteCommentUseCase: DefaultDeleteCommentUseCase(),
+              editCommentUseCase: DefaultEditCommentUseCase()
             )
           ),
           animated: true

--- a/PLUB/Sources/Views/Home/Clipboard/Component/CommentInputView.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/CommentInputView.swift
@@ -24,6 +24,15 @@ final class CommentInputView: UIView {
   
   // MARK: - Properties
   
+  /// 댓글 작성란에 들어갈 텍스트를 입력합니다.
+  var commentText: String {
+    get {
+      textView.text
+    } set {
+      textView.text = newValue
+    }
+  }
+  
   private let disposeBag = DisposeBag()
   
   weak var delegate: CommentInputViewDelegate?

--- a/PLUB/Sources/Views/Home/Clipboard/Component/CommentOptionBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/CommentOptionBottomSheetViewController.swift
@@ -13,9 +13,9 @@ import SnapKit
 import Then
 
 protocol CommentOptionBottomSheetDelegate: AnyObject {
-  func deleteButtonTapped()
-  func editButtonTapped()
-  func reportButtonTapped()
+  func deleteButtonTapped(commentID: Int)
+  func editButtonTapped(commentID: Int)
+  func reportButtonTapped(commentID: Int)
 }
 
 
@@ -35,6 +35,8 @@ final class CommentOptionBottomSheetViewController: BottomSheetViewController {
   
   // MARK: - Properties
   
+  private let commentID: Int
+  
   private let userAccessType: UserAccessType
   
   weak var delegate: CommentOptionBottomSheetDelegate?
@@ -53,7 +55,8 @@ final class CommentOptionBottomSheetViewController: BottomSheetViewController {
   
   // MARK: - Initializations
   
-  init(userAccessType: UserAccessType) {
+  init(commentID: Int, userAccessType: UserAccessType) {
+    self.commentID = commentID
     self.userAccessType = userAccessType
     super.init(nibName: nil, bundle: nil)
   }
@@ -110,14 +113,14 @@ final class CommentOptionBottomSheetViewController: BottomSheetViewController {
     
     deleteCommentView.button.rx.tap
       .subscribe(with: self) { owner, _ in
-        owner.delegate?.deleteButtonTapped()
+        owner.delegate?.deleteButtonTapped(commentID: owner.commentID)
         owner.dismiss(animated: true)
       }
       .disposed(by: disposeBag)
     
     editCommentView.button.rx.tap
       .subscribe(with: self) { owner, _ in
-        owner.delegate?.editButtonTapped()
+        owner.delegate?.editButtonTapped(commentID: owner.commentID)
         owner.dismiss(animated: true)
       }
       .disposed(by: disposeBag)

--- a/PLUB/Sources/Views/Home/Clipboard/Component/CommentOptionBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/CommentOptionBottomSheetViewController.swift
@@ -114,5 +114,12 @@ final class CommentOptionBottomSheetViewController: BottomSheetViewController {
         owner.dismiss(animated: true)
       }
       .disposed(by: disposeBag)
+    
+    editCommentView.button.rx.tap
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.editButtonTapped()
+        owner.dismiss(animated: true)
+      }
+      .disposed(by: disposeBag)
   }
 }

--- a/PLUB/Sources/Views/Home/Clipboard/Component/CommentOptionDecoratorView.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/CommentOptionDecoratorView.swift
@@ -1,5 +1,5 @@
 //
-//  ReplyView.swift
+//  CommentOptionDecoratorView.swift
 //  PLUB
 //
 //  Created by 홍승현 on 2023/04/14.
@@ -12,22 +12,29 @@ import RxCocoa
 import SnapKit
 import Then
 
-protocol ReplyViewDelegate: AnyObject {
+protocol CommentOptionViewDelegate: AnyObject {
   func cancelButtonTapped()
 }
 
-final class ReplyView: UIView {
+final class CommentOptionDecoratorView: UIView {
   
   // MARK: - Properties
   
-  /// 답글을 달 닉네임을 설정합니다.
-  var nickname: String = "Unknown" {
+  /// 왼쪽에 들어갈 label text를 설정합니다.
+  var labelText: String = "Unknown" {
     didSet {
-      replyIndicatorLabel.text = "\(nickname)님에게 답글 쓰는 중..."
+      indicatorLabel.text = labelText
     }
   }
   
-  weak var delegate: ReplyViewDelegate?
+  /// 오른쪽 버튼에 들어갈 text를 설정합니다.
+  var buttonText: String = "취소" {
+    didSet {
+      cancelButton.setTitle(buttonText, for: .normal)
+    }
+  }
+  
+  weak var delegate: CommentOptionViewDelegate?
   
   private let disposeBag = DisposeBag()
   
@@ -37,12 +44,12 @@ final class ReplyView: UIView {
     $0.backgroundColor = .lightGray
   }
   
-  private let replyIndicatorLabel = UILabel().then {
+  private let indicatorLabel = UILabel().then {
     $0.font = .overLine
     $0.textColor = .black
   }
   
-  private let replyCancelButton = UIButton().then {
+  private let cancelButton = UIButton().then {
     $0.setTitleColor(.main, for: .normal)
     $0.setTitle("답글 작성 취소", for: .normal)
     $0.titleLabel?.font = .overLine
@@ -64,18 +71,18 @@ final class ReplyView: UIView {
   // MARK: - Configuration
   
   private func setupLayouts() {
-    [replyIndicatorLabel, replyCancelButton, separatorLineView].forEach {
+    [indicatorLabel, cancelButton, separatorLineView].forEach {
       addSubview($0)
     }
   }
   
   private func setupConstraints() {
-    replyIndicatorLabel.snp.makeConstraints {
+    indicatorLabel.snp.makeConstraints {
       $0.leading.equalToSuperview().inset(Metrics.directionalHorizontalInset)
       $0.centerY.equalToSuperview()
     }
     
-    replyCancelButton.snp.makeConstraints {
+    cancelButton.snp.makeConstraints {
       $0.centerY.equalToSuperview()
       $0.trailing.equalToSuperview().inset(Metrics.directionalHorizontalInset)
     }
@@ -87,7 +94,7 @@ final class ReplyView: UIView {
   }
   
   private func bind() {
-    replyCancelButton.rx.tap
+    cancelButton.rx.tap
       .subscribe(with: self) { owner, _ in
         owner.delegate?.cancelButtonTapped()
       }
@@ -95,7 +102,7 @@ final class ReplyView: UIView {
   }
 }
 
-extension ReplyView {
+extension CommentOptionDecoratorView {
   enum Metrics {
     static let directionalHorizontalInset = 24
     static let separatorHeight = 1

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -288,28 +288,39 @@ extension BoardDetailViewModel {
 // MARK: - BoardDetailViewModelType
 
 extension BoardDetailViewModel: BoardDetailViewModelType {
+  
   // Input
+  
   var setCollectionViewObserver: AnyObserver<UICollectionView> {
     collectionViewSubject.asObserver()
   }
+  
   var commentsInput: AnyObserver<String> {
     commentInputSubject.asObserver()
   }
-  var editCommentTextObservable: Observable<String> {
-    editCommentTextSubject.asObservable()
-  }
+  
   var offsetObserver: AnyObserver<(collectionViewHeight: CGFloat, offset: CGFloat)> {
     bottomCellSubject.asObserver()
   }
+  
   var targetIDObserver: AnyObserver<Int?> {
     targetIDSubject.asObserver()
   }
+  
   var commentOptionObserver: AnyObserver<CommentOption> {
     commentOptionSubject.asObserver()
   }
+  
+  // Output
+  
+  var editCommentTextObservable: Observable<String> {
+    editCommentTextSubject.asObservable()
+  }
+  
   var decoratorNameObserable: Observable<(labelText: String, buttonText: String)> {
     decoratorNameSubject.asObservable()
   }
+  
   var showBottomSheetObservable: Observable<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)> {
     showBottomSheetSubject.asObservable()
   }

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -160,6 +160,10 @@ extension BoardDetailViewModel {
       .filter { [weak self] _ in
         return self?.pagingManager.isLast ?? false
       }
+      .do(onNext: { [weak self] _ in  // API 호출을 위해 작업한 targetID와 commentOption을 기본값으로 초기화
+        self?.targetIDSubject.onNext(nil)
+        self?.commentOptionSubject.onNext(.commentOrReply)
+      })
       .subscribe(with: self) { owner, comment in
         // 일반 댓글은 단순 append
         if comment.type == .normal {
@@ -211,6 +215,10 @@ extension BoardDetailViewModel {
       .flatMap { [deleteCommentUseCase] commentID in
         deleteCommentUseCase.execute(plubbingID: plubbingID, feedID: content.feedID, commentID: commentID)
       }
+      .do(onNext: { [weak self] _ in // API 호출을 위해 작업한 targetID와 commentOption을 기본값으로 초기화
+        self?.targetIDSubject.onNext(nil)
+        self?.commentOptionSubject.onNext(.commentOrReply)
+      })
       .withLatestFrom(targetIDSubject)
       .subscribe(with: self) { owner, commentID in
         guard let content = owner.comments.first(where: { $0.commentID == commentID }) else { return }
@@ -262,6 +270,10 @@ extension BoardDetailViewModel {
       .flatMap { [editCommentUseCase] in
         editCommentUseCase.execute(plubbingID: plubbingID, feedID: content.feedID, commentID: $0.targetID, content: $0.comment)
       }
+      .do(onNext: { [weak self] _ in
+        self?.targetIDSubject.onNext(nil)
+        self?.commentOptionSubject.onNext(.commentOrReply)
+      })
       .subscribe(with: self) { owner, comment in
         guard let index = owner.comments.firstIndex(where: { $0.commentID == comment.commentID })
         else {

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -37,7 +37,7 @@ protocol BoardDetailViewModelType {
   /// decoratorView에 들어갈 적절한 text를 처리합니다.
   var decoratorNameObserable: Observable<(labelText: String, buttonText: String)> { get }
   
-  var showBottomSheetObservable: Observable<CommentOptionBottomSheetViewController.UserAccessType> { get }
+  var showBottomSheetObservable: Observable<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)> { get }
 }
 
 protocol BoardDetailDataStore {
@@ -80,7 +80,7 @@ final class BoardDetailViewModel: BoardDetailDataStore {
   private let replyIDSubject                  = BehaviorSubject<Int?>(value: nil)
   private let decoratorNameSubject            = PublishSubject<(labelText: String, buttonText: String)>()
   private let bottomCellSubject               = PublishSubject<(collectionViewHeight: CGFloat, offset: CGFloat)>()
-  private let showBottomSheetSubject          = PublishSubject<CommentOptionBottomSheetViewController.UserAccessType>()
+  private let showBottomSheetSubject          = PublishSubject<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)>()
   private let recentSelectedCommentIDSubject  = ReplaySubject<Int>.create(bufferSize: 1)
   private let deleteOptionSubject             = PublishSubject<Void>()
   private let editOptionSubject               = PublishSubject<Void>()
@@ -238,7 +238,7 @@ extension BoardDetailViewModel: BoardDetailViewModelType {
   var decoratorNameObserable: Observable<(labelText: String, buttonText: String)> {
     decoratorNameSubject.asObservable()
   }
-  var showBottomSheetObservable: Observable<CommentOptionBottomSheetViewController.UserAccessType> {
+  var showBottomSheetObservable: Observable<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)> {
     showBottomSheetSubject.asObservable()
   }
   var deleteOptionObserver: AnyObserver<Void> {
@@ -368,7 +368,7 @@ extension BoardDetailViewModel: BoardDetailCollectionViewCellDelegate {
       accessType = .normal
     }
     
-    showBottomSheetSubject.onNext(accessType)
+    showBottomSheetSubject.onNext((commentID, accessType))
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -26,7 +26,11 @@ protocol BoardDetailViewModelType {
   /// 답장할 대상자의 ID를 emit합니다.
   var replyIDObserver: AnyObserver<Int?> { get }
   
+  /// 삭제 버튼을 누른 경우 해당 옵저버를 이용하여 emit합니다.
   var deleteOptionObserver: AnyObserver<Void> { get }
+  
+  /// 수정 버튼을 누른 경우 해당 옵저버를 이용하여 emit합니다.
+  var editOptionObserver: AnyObserver<Void> { get }
   
   //Output
   
@@ -79,6 +83,7 @@ final class BoardDetailViewModel: BoardDetailDataStore {
   private let showBottomSheetSubject          = PublishSubject<CommentOptionBottomSheetViewController.UserAccessType>()
   private let recentSelectedCommentIDSubject  = ReplaySubject<Int>.create(bufferSize: 1)
   private let deleteOptionSubject             = PublishSubject<Void>()
+  private let editOptionSubject               = PublishSubject<Void>()
   
   // MARK: - Initializations
   
@@ -238,6 +243,9 @@ extension BoardDetailViewModel: BoardDetailViewModelType {
   }
   var deleteOptionObserver: AnyObserver<Void> {
     deleteOptionSubject.asObserver()
+  }
+  var editOptionObserver: AnyObserver<Void> {
+    editOptionSubject.asObserver()
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -72,6 +72,7 @@ final class BoardDetailViewModel: BoardDetailDataStore {
   private let getCommentsUseCase: GetCommentsUseCase
   private let postCommentUseCase: PostCommentUseCase
   private let deleteCommentUseCase: DeleteCommentUseCase
+  private let editCommentUseCase: EditCommentUseCase
   
   // MARK: Subjects
   
@@ -91,12 +92,14 @@ final class BoardDetailViewModel: BoardDetailDataStore {
     content: BoardModel,
     getCommentsUseCase: GetCommentsUseCase,
     postCommentUseCase: PostCommentUseCase,
-    deleteCommentUseCase: DeleteCommentUseCase
+    deleteCommentUseCase: DeleteCommentUseCase,
+    editCommentUseCase: EditCommentUseCase
   ) {
     self.content = content
     self.getCommentsUseCase   = getCommentsUseCase
     self.postCommentUseCase   = postCommentUseCase
     self.deleteCommentUseCase = deleteCommentUseCase
+    self.editCommentUseCase   = editCommentUseCase
     
     fetchComments(plubbingID: plubbingID, content: content)
     createComments(plubbingID: plubbingID, content: content)

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -215,11 +215,11 @@ extension BoardDetailViewModel {
       .flatMap { [deleteCommentUseCase] commentID in
         deleteCommentUseCase.execute(plubbingID: plubbingID, feedID: content.feedID, commentID: commentID)
       }
+      .withLatestFrom(targetIDSubject)
       .do(onNext: { [weak self] _ in // API 호출을 위해 작업한 targetID와 commentOption을 기본값으로 초기화
         self?.targetIDSubject.onNext(nil)
         self?.commentOptionSubject.onNext(.commentOrReply)
       })
-      .withLatestFrom(targetIDSubject)
       .subscribe(with: self) { owner, commentID in
         guard let content = owner.comments.first(where: { $0.commentID == commentID }) else { return }
         if content.type == .normal {

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -34,8 +34,8 @@ protocol BoardDetailViewModelType {
   
   //Output
   
-  /// 답장할 대상자의 닉네임을 받습니다.
-  var replyNicknameObserable: Observable<String> { get }
+  /// decoratorView에 들어갈 적절한 text를 처리합니다.
+  var decoratorNameObserable: Observable<(labelText: String, buttonText: String)> { get }
   
   var showBottomSheetObservable: Observable<CommentOptionBottomSheetViewController.UserAccessType> { get }
 }
@@ -78,7 +78,7 @@ final class BoardDetailViewModel: BoardDetailDataStore {
   private let collectionViewSubject           = PublishSubject<UICollectionView>()
   private let commentInputSubject             = PublishSubject<String>()
   private let replyIDSubject                  = BehaviorSubject<Int?>(value: nil)
-  private let replyNicknameSubject            = PublishSubject<String>()
+  private let decoratorNameSubject            = PublishSubject<(labelText: String, buttonText: String)>()
   private let bottomCellSubject               = PublishSubject<(collectionViewHeight: CGFloat, offset: CGFloat)>()
   private let showBottomSheetSubject          = PublishSubject<CommentOptionBottomSheetViewController.UserAccessType>()
   private let recentSelectedCommentIDSubject  = ReplaySubject<Int>.create(bufferSize: 1)
@@ -235,8 +235,8 @@ extension BoardDetailViewModel: BoardDetailViewModelType {
   var replyIDObserver: AnyObserver<Int?> {
     replyIDSubject.asObserver()
   }
-  var replyNicknameObserable: Observable<String> {
-    replyNicknameSubject.asObservable()
+  var decoratorNameObserable: Observable<(labelText: String, buttonText: String)> {
+    decoratorNameSubject.asObservable()
   }
   var showBottomSheetObservable: Observable<CommentOptionBottomSheetViewController.UserAccessType> {
     showBottomSheetSubject.asObservable()
@@ -345,8 +345,7 @@ extension BoardDetailViewModel: BoardDetailCollectionViewCellDelegate {
     else {
       return
     }
-    
-    replyNicknameSubject.onNext(commentValue.nickname)
+    decoratorNameSubject.onNext((labelText: "\(commentValue.nickname)에게 답글 쓰는 중...", buttonText: "답글 작성 취소"))
     replyIDSubject.onNext(commentID)
   }
   

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -247,7 +247,8 @@ extension MainPageViewController: BoardViewControllerDelegate {
         content: content,
         getCommentsUseCase: DefaultGetCommentsUseCase(),
         postCommentUseCase: DefaultPostCommentUseCase(),
-        deleteCommentUseCase: DefaultDeleteCommentUseCase()
+        deleteCommentUseCase: DefaultDeleteCommentUseCase(),
+        editCommentUseCase: DefaultEditCommentUseCase()
       )
     )
     vc.navigationItem.largeTitleDisplayMode = .never


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 댓글 수정 기능을 구현했습니다
- 답글 또는 수정이 완료되었을 때 댓글 작성란 윗 부분(aka. DecoratorView)가 보이지 않도록 처리했습니다. (#302)
- 기존 코드를 재사용하려고 하니 무지성으로 구현해둔 게 있어서, 일부 리팩토링을 진행했습니다. 아래 설명 참고

🌱 PR 포인트

#### ReplyView를 DecoratorView로 변경했습니다.

답장 뿐 아니라 댓글 수정할 때도 ReplyView가 사용되기 때문입니다.

#### 댓글 수정, 댓글 작성, 답글 작성, 댓글 삭제를 각각 분리하여 구현하되, 비슷한 성격을 가진 Item들을 묶어 관리하였습니다.

`CommentOptionSubject`:  현재 댓글 정보를 처리하기 위한 옵션을 처리합니다. (댓(답)글인지, 삭제인지, 수정인지)
`TargetIDSubject`: `replyID`와 `recentSelectedCommentID`를 묶었습니다. 답글이든, 삭제이든, 수정이든 결국에는 타겟팅 되어있는 ID를 가지고 처리하는 녀석들이기 때문에, 하나의 Subject로 관리했습니다.

#### BottomSheet를 띄울 때 commentID도 initializer에 넣어 처리하도록 구현했습니다.

기존에는 `BottomSheet`를 요청한 `Cell`의 `commentID`를 미리 갖고있었으나, 나중에 `다른 Cell`의 `BottomSheet`요청 버튼을 누른 뒤 나가버리게 되면 commentID가 재갱신되어버리는 상황이 발생되기 때문에 시나리오상 버그가 발생할 우려가 존재했습니다. 따라서, 확실하게 BottomSheet로부터 `댓글 수정 버튼`, `댓글 삭제 버튼`이 눌려졌다면 delegate에서 commentID와 함께 호출하는 방식을 사용하도록 하여 사용자로부터 의도치 않는 현상을 방지할 수 있도록 수정하였습니다.


## 📸 스크린샷
|스크린샷|
|:--:|
|![댓글 수정 시나리오](https://user-images.githubusercontent.com/57972338/233027582-838782f0-8988-47bb-86c3-6667f3e474a9.gif)|

## 📮 관련 이슈
- Resolved: #211

