### PR TITLE
[FEAT] 메인페이지에서 아카이브로 이동하는 코드 추가

### DIFF
--- a/PLUB/Sources/Views/Home/MainPage/Component/MainPageHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/MainPageHeaderView.swift
@@ -14,6 +14,7 @@ import Then
 
 protocol MainPageHeaderViewDelegate: AnyObject {
   func didTappedMainPageBackButton()
+  func didTappedArchiveButton()
 }
 
 class MainPageHeaderView: UIView {
@@ -36,8 +37,9 @@ class MainPageHeaderView: UIView {
     $0.setImage(UIImage(named: "speakerWhite"), for: .normal)
   }
   
-  private let photoStackButton = UIButton().then {
+  private let archiveButton = UIButton().then {
     $0.setImage(UIImage(named: "photoStackWhite"), for: .normal)
+    $0.addTarget(self, action: #selector(didTappedArchiveButton), for: .touchUpInside)
   }
   
   private let moreButton = UIButton().then {
@@ -70,7 +72,7 @@ class MainPageHeaderView: UIView {
       $0.height.equalTo(32)
     }
     
-    [speakerButton, photoStackButton, moreButton].forEach { view in
+    [speakerButton, archiveButton, moreButton].forEach { view in
       horizontalStackView.addArrangedSubview(view)
       view.snp.makeConstraints {
         $0.size.equalTo(32)
@@ -84,5 +86,9 @@ class MainPageHeaderView: UIView {
         owner.delegate?.didTappedMainPageBackButton()
       }
       .disposed(by: disposeBag)
+  }
+  
+  @objc private func didTappedArchiveButton() {
+    delegate?.didTappedArchiveButton()
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Component/MainPageNavigationView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/MainPageNavigationView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class MainPageNavigationView: UIStackView {
+final class MainPageNavigationView: UIStackView {
   
   private let speakerBlack = UIButton().then {
     $0.setImage(UIImage(named: "speakerBlack"), for: .normal)

--- a/PLUB/Sources/Views/Home/MainPage/Component/MainPageNavigationView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/MainPageNavigationView.swift
@@ -10,6 +10,10 @@ import UIKit
 import SnapKit
 import Then
 
+protocol MainPageNavigationViewDelegate: AnyObject {
+  func didTappedArchiveButton()
+}
+
 final class MainPageNavigationView: UIStackView {
   
   private let speakerBlack = UIButton().then {

--- a/PLUB/Sources/Views/Home/MainPage/Component/MainPageNavigationView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/MainPageNavigationView.swift
@@ -16,12 +16,15 @@ protocol MainPageNavigationViewDelegate: AnyObject {
 
 final class MainPageNavigationView: UIStackView {
   
+  weak var delegate: MainPageNavigationViewDelegate?
+  
   private let speakerBlack = UIButton().then {
     $0.setImage(UIImage(named: "speakerBlack"), for: .normal)
   }
   
   private let archiveButton = UIButton().then {
     $0.setImage(UIImage(named: "photoStackBlack"), for: .normal)
+    $0.addTarget(MainPageNavigationView.self, action: #selector(didTappedArchiveButton), for: .touchUpInside)
   }
   
   private let verticalEllipsisBlack = UIButton().then {
@@ -39,5 +42,9 @@ final class MainPageNavigationView: UIStackView {
   
   private func configureUI() {
     [speakerBlack, archiveButton, verticalEllipsisBlack].forEach { addArrangedSubview($0) }
+  }
+  
+  @objc private func didTappedArchiveButton() {
+    delegate?.didTappedArchiveButton()
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Component/MainPageNavigationView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/MainPageNavigationView.swift
@@ -20,7 +20,7 @@ final class MainPageNavigationView: UIStackView {
     $0.setImage(UIImage(named: "speakerBlack"), for: .normal)
   }
   
-  private let photoStackBlack = UIButton().then {
+  private let archiveButton = UIButton().then {
     $0.setImage(UIImage(named: "photoStackBlack"), for: .normal)
   }
   
@@ -38,6 +38,6 @@ final class MainPageNavigationView: UIStackView {
   }
   
   private func configureUI() {
-    [speakerBlack, photoStackBlack, verticalEllipsisBlack].forEach { addArrangedSubview($0) }
+    [speakerBlack, archiveButton, verticalEllipsisBlack].forEach { addArrangedSubview($0) }
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Component/MainPageNavigationView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/MainPageNavigationView.swift
@@ -24,7 +24,7 @@ final class MainPageNavigationView: UIStackView {
   
   private let archiveButton = UIButton().then {
     $0.setImage(UIImage(named: "photoStackBlack"), for: .normal)
-    $0.addTarget(MainPageNavigationView.self, action: #selector(didTappedArchiveButton), for: .touchUpInside)
+    $0.addTarget(self, action: #selector(didTappedArchiveButton), for: .touchUpInside)
   }
   
   private let verticalEllipsisBlack = UIButton().then {

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -95,6 +95,7 @@ final class MainPageViewController: BaseViewController {
   private lazy var mainpageNavigationView = MainPageNavigationView().then {
     $0.axis = .horizontal
     $0.spacing = 4
+    $0.delegate = self
   }
   
   init(plubbingID: Int) {
@@ -274,5 +275,14 @@ extension MainPageViewController: BoardViewControllerDelegate {
 extension MainPageViewController: MainPageHeaderViewDelegate {
   func didTappedMainPageBackButton() {
     self.navigationController?.popViewController(animated: true)
+  }
+}
+
+extension MainPageViewController: MainPageNavigationViewDelegate {
+  func didTappedArchiveButton() {
+    let vc = ArchiveViewController(viewModel: ArchiveViewModel(plubbingID: plubbingID, getArchiveUseCase: DefaultGetArchiveUseCase()))
+    vc.title = "" // 추후에 메인페이지헤더뷰에 대한 데이터를 올바르게 받아올 경우 코드 추가
+    vc.navigationItem.largeTitleDisplayMode = .never
+    navigationController?.pushViewController(vc, animated: true)
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -109,7 +109,12 @@ final class MainPageViewController: BaseViewController {
   
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
-    navigationController?.navigationBar.isHidden = true
+    if headerView.isHidden {
+      navigationController?.navigationBar.isHidden = false
+    } else {
+      navigationController?.navigationBar.isHidden = true
+    }
+    
   }
   
   override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 메인페이지에서 아카이브화면으로 이동할 수 있는 2가지 모두 이동코드 추가하였습니다.
- 아카이브화면에서 다시 메인페이지로 돌아올때 네비게이션바가 보이지않는 부분을 해결했습니다.

🌱 PR 포인트
- @WhiteHyun 홍 아카이브화면에서 title값이 필요한데 이 부분 예전에 말씀드린것처럼 추후에 메인페이지 헤더뷰가 완벽히 구현될때 데이터연동하면서 전달하도록 하겠습니다

## 📸 동작영상
https://user-images.githubusercontent.com/39263235/233300070-2510a4cc-1e1c-4d6f-8887-73d404ddbe22.mp4

## 📮 관련 이슈
- Resolved: #305 

