### PR TITLE
댓글 페이지 - 개선사항 구현 및 버그 수정

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -158,11 +158,11 @@
 		BA52778B28EECDC50036B825 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA52778228EECDC50036B825 /* Pretendard-Regular.otf */; };
 		BA52778C28EECDC50036B825 /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA52778328EECDC50036B825 /* Pretendard-Light.otf */; };
 		BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52778F28EECEB40036B825 /* Ex+UIFont.swift */; };
+		BA57F3F629ED30D200A9F790 /* DeleteCommentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3F529ED30D200A9F790 /* DeleteCommentUseCase.swift */; };
 		BA57F3F929ED4EEC00A9F790 /* ArchiveUploadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3F729ED4EEC00A9F790 /* ArchiveUploadViewController.swift */; };
 		BA57F3FA29ED4EEC00A9F790 /* ArchiveUploadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3F829ED4EEC00A9F790 /* ArchiveUploadViewModel.swift */; };
 		BA57F3FD29ED5D6600A9F790 /* ArchiveUploadHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3FC29ED5D6600A9F790 /* ArchiveUploadHeaderView.swift */; };
 		BA57F3FF29ED814500A9F790 /* ArchiveUploadCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3FE29ED814500A9F790 /* ArchiveUploadCollectionViewCell.swift */; };
-		BA57F3F629ED30D200A9F790 /* DeleteCommentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57F3F529ED30D200A9F790 /* DeleteCommentUseCase.swift */; };
 		BA590E7A29EBC6320017FAF1 /* GetArchiveDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA590E7929EBC6320017FAF1 /* GetArchiveDetailUseCase.swift */; };
 		BA590E7D29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA590E7C29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift */; };
 		BA5D9ECF29E3E9A300F06AB5 /* ArchiveRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5D9ECD29E3E9A300F06AB5 /* ArchiveRouter.swift */; };
@@ -174,6 +174,7 @@
 		BA5DEB302974D8E200650788 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5DEB2F2974D8E200650788 /* NetworkResult.swift */; };
 		BA5DEB3329751E5F00650788 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = BA5DEB3229751E5F00650788 /* GoogleSignIn */; };
 		BA5EC6C629EFD4E5000A68B7 /* EditCommentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5EC6C529EFD4E5000A68B7 /* EditCommentUseCase.swift */; };
+		BA5EC6CD29F167D7000A68B7 /* BoardDetailViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5EC6CC29F167D7000A68B7 /* BoardDetailViewModelFactory.swift */; };
 		BA6D7C5329A7D46900D8E928 /* CommentsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6D7C5229A7D46900D8E928 /* CommentsRequest.swift */; };
 		BA7255C12992445600A3E8F5 /* PLUBTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7255C02992445600A3E8F5 /* PLUBTabBarController.swift */; };
 		BA72BCF029BB03FF007165E5 /* BaseNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA72BCEF29BB03FF007165E5 /* BaseNavigationController.swift */; };
@@ -529,11 +530,11 @@
 		BA52778228EECDC50036B825 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		BA52778328EECDC50036B825 /* Pretendard-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.otf"; sourceTree = "<group>"; };
 		BA52778F28EECEB40036B825 /* Ex+UIFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+UIFont.swift"; sourceTree = "<group>"; };
+		BA57F3F529ED30D200A9F790 /* DeleteCommentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteCommentUseCase.swift; sourceTree = "<group>"; };
 		BA57F3F729ED4EEC00A9F790 /* ArchiveUploadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveUploadViewController.swift; sourceTree = "<group>"; };
 		BA57F3F829ED4EEC00A9F790 /* ArchiveUploadViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveUploadViewModel.swift; sourceTree = "<group>"; };
 		BA57F3FC29ED5D6600A9F790 /* ArchiveUploadHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveUploadHeaderView.swift; sourceTree = "<group>"; };
 		BA57F3FE29ED814500A9F790 /* ArchiveUploadCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveUploadCollectionViewCell.swift; sourceTree = "<group>"; };
-		BA57F3F529ED30D200A9F790 /* DeleteCommentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteCommentUseCase.swift; sourceTree = "<group>"; };
 		BA590E7929EBC6320017FAF1 /* GetArchiveDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetArchiveDetailUseCase.swift; sourceTree = "<group>"; };
 		BA590E7C29EBF2940017FAF1 /* ArchiveDetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailCollectionViewCell.swift; sourceTree = "<group>"; };
 		BA5D9ECD29E3E9A300F06AB5 /* ArchiveRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveRouter.swift; sourceTree = "<group>"; };
@@ -544,6 +545,7 @@
 		BA5D9EDA29E406AD00F06AB5 /* Day.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Day.swift; sourceTree = "<group>"; };
 		BA5DEB2F2974D8E200650788 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
 		BA5EC6C529EFD4E5000A68B7 /* EditCommentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EditCommentUseCase.swift; path = PLUB/Sources/UseCases/Feeds/EditCommentUseCase.swift; sourceTree = SOURCE_ROOT; };
+		BA5EC6CC29F167D7000A68B7 /* BoardDetailViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailViewModelFactory.swift; sourceTree = "<group>"; };
 		BA6D7C5229A7D46900D8E928 /* CommentsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentsRequest.swift; sourceTree = "<group>"; };
 		BA7255C02992445600A3E8F5 /* PLUBTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLUBTabBarController.swift; sourceTree = "<group>"; };
 		BA72BCEF29BB03FF007165E5 /* BaseNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNavigationController.swift; sourceTree = "<group>"; };
@@ -1569,6 +1571,7 @@
 			isa = PBXGroup;
 			children = (
 				BAE0AC7529B5D67D00F46F3D /* BoardDetailViewModel.swift */,
+				BA5EC6CC29F167D7000A68B7 /* BoardDetailViewModelFactory.swift */,
 				BA1D4A7429A9D9EA00CBBCC6 /* ClipboardViewModel.swift */,
 			);
 			path = ViewModel;
@@ -2290,6 +2293,7 @@
 				BA72BCF029BB03FF007165E5 /* BaseNavigationController.swift in Sources */,
 				70197B722953698F000503F6 /* SelectedCategoryViewController.swift in Sources */,
 				70727A2529C4C21A003DE956 /* CreateBoardViewModel.swift in Sources */,
+				BA5EC6CD29F167D7000A68B7 /* BoardDetailViewModelFactory.swift in Sources */,
 				70727A4729D6D507003DE956 /* TodoInfoView.swift in Sources */,
 				C3775E2429C61B9C003A812F /* CustomAlertView.swift in Sources */,
 				701A9C9C29B72656006F53C2 /* MainPageClipboardView.swift in Sources */,

--- a/PLUB/Sources/Models/Feeds/CommentContent.swift
+++ b/PLUB/Sources/Models/Feeds/CommentContent.swift
@@ -24,7 +24,7 @@ struct CommentContent: Codable {
   let commentID: Int
   
   /// 댓글 내용
-  var content: String
+  let content: String
   
   /// 프로필 이미지 URL
   let profileImageURL: String?

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -186,9 +186,7 @@ extension BoardDetailViewController: CommentOptionViewDelegate {
 
 extension BoardDetailViewController: CommentOptionBottomSheetDelegate {
   func deleteButtonTapped(commentID: Int) {
-    // 순서 중요
-    viewModel.targetIDObserver.onNext(commentID)
-    viewModel.commentOptionObserver.onNext(.delete)
+    viewModel.deleteIDObserver.onNext(commentID)
   }
   
   func editButtonTapped(commentID: Int) {

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -212,8 +212,10 @@ extension BoardDetailViewController: UICollectionViewDelegateFlowLayout {
     // * 위 배열에서 section과 item의 맞는 모델을 찾아 사이즈를 구해야함
     // * 따라서 section값에 따른 groupID를 먼저 구하고, groupID가 동일한 배열만을 빼냄
     // * 빼낸 배열은 item을 인덱스로하여 모델을 가져오도록 구현
-    let groupID = Array(Set(viewModel.comments.map { $0.groupID })).sorted()[indexPath.section - 1]
-    let commentsModelsForSection = viewModel.comments.filter { $0.groupID == groupID }
+    let groupID = Set(viewModel.comments.map(\.groupID)).sorted()[indexPath.section - 1]
+    let commentsModelsForSection = viewModel.comments
+      .filter { $0.groupID == groupID }
+      .sorted { $0.commentID < $1.commentID }
     let size = BoardDetailCollectionViewCell.estimatedCommentCellSize(CGSize(width: view.bounds.width, height: 0), commentContent: commentsModelsForSection[indexPath.item])
     return size
   }

--- a/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
@@ -100,14 +100,7 @@ final class ClipboardViewController: BaseViewController {
       .subscribe(with: self) { owner, model in
         owner.navigationController?.pushViewController(
           BoardDetailViewController(
-            viewModel: BoardDetailViewModel(
-              plubbingID: model.plubbingID!,
-              content: model.toBoardModel,
-              getCommentsUseCase: DefaultGetCommentsUseCase(),
-              postCommentUseCase: DefaultPostCommentUseCase(),
-              deleteCommentUseCase: DefaultDeleteCommentUseCase(),
-              editCommentUseCase: DefaultEditCommentUseCase()
-            )
+            viewModel: BoardDetailViewModelWithFeedsFactory.make(plubbingID: model.plubbingID!, boardModel: model.toBoardModel)
           ),
           animated: true
         )

--- a/PLUB/Sources/Views/Home/Clipboard/Component/CommentInputView.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/CommentInputView.swift
@@ -131,6 +131,8 @@ final class CommentInputView: UIView {
       }
       .disposed(by: disposeBag)
     
+    textView.delegate = self
+    
     textView.rx.text
       .orEmpty
       .distinctUntilChanged()
@@ -148,6 +150,17 @@ final class CommentInputView: UIView {
         }
       }
       .disposed(by: disposeBag)
+  }
+}
+
+extension CommentInputView: UITextViewDelegate {
+  func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+    let currentText = textView.text ?? ""
+    guard let stringRange = Range(range, in: currentText) else { return false }
+
+    let updatedText = currentText.replacingCharacters(in: stringRange, with: text)
+
+    return updatedText.count <= 300 // 300자 이내로만 작성 가능함
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -222,15 +222,7 @@ extension BoardDetailViewModel {
       })
       .subscribe(with: self) { owner, commentID in
         guard let content = owner.comments.first(where: { $0.commentID == commentID }) else { return }
-        if content.type == .normal {
-          owner.comments.removeAll {
-            $0.groupID == content.groupID
-          }
-        } else {
-          owner.comments.removeAll {
-            $0.commentID == content.commentID
-          }
-        }
+        owner.comments.removeAll { $0.parentCommentID == content.commentID || $0 == content }
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -182,7 +182,6 @@ extension BoardDetailViewModel {
   /// - Parameters:
   ///   - plubbingID: 플러빙 ID
   ///   - content: 게시글 컨텐츠 모델
-  ///   - indexPathObservable: 컬렉션 뷰에서 하단 셀의 인덱스 경로를 전달받는 `Observable`
   private func pagingSetup(plubbingID: Int, content: BoardModel) {
     bottomCellSubject
       .filter { [pagingManager] in // pagingManager에게 fetching 가능한지 요청

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModelFactory.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModelFactory.swift
@@ -1,0 +1,29 @@
+//
+//  BoardDetailViewModelFactory.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/20.
+//
+
+import Foundation
+
+
+protocol BoardDetailViewModelFactory {
+  static func make(plubbingID: Int, boardModel: BoardModel) -> BoardDetailViewModel
+}
+
+final class BoardDetailViewModelWithFeedsFactory: BoardDetailViewModelFactory {
+  
+  private init() { }
+  
+  static func make(plubbingID: Int, boardModel: BoardModel) -> BoardDetailViewModel {
+    return BoardDetailViewModel(
+      plubbingID: plubbingID,
+      content: boardModel,
+      getCommentsUseCase: DefaultGetCommentsUseCase(),
+      postCommentUseCase: DefaultPostCommentUseCase(),
+      deleteCommentUseCase: DefaultDeleteCommentUseCase(),
+      editCommentUseCase: DefaultEditCommentUseCase()
+    )
+  }
+}

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -242,14 +242,7 @@ extension MainPageViewController: BoardViewControllerDelegate {
   
   func didTappedBoardCollectionViewCell(plubbingID: Int, content: BoardModel) {
     let vc = BoardDetailViewController(
-      viewModel: BoardDetailViewModel(
-        plubbingID: plubbingID,
-        content: content,
-        getCommentsUseCase: DefaultGetCommentsUseCase(),
-        postCommentUseCase: DefaultPostCommentUseCase(),
-        deleteCommentUseCase: DefaultDeleteCommentUseCase(),
-        editCommentUseCase: DefaultEditCommentUseCase()
-      )
+      viewModel: BoardDetailViewModelWithFeedsFactory.make(plubbingID: plubbingID, boardModel: content)
     )
     vc.navigationItem.largeTitleDisplayMode = .never
     navigationController?.pushViewController(vc, animated: true)


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 300자 이내로만 댓글이 써질 수 있도록 구현 (delegate로 처리)
- 댓글 수정 중 다른 댓글을 삭제한 뒤 수정 버튼을 누르면 댓글로 처리되는 버그 수정(`DeleteIDObserver`을 별도로 추가해서 처리)

- 개선사항
   - comments를 `Set`으로 변경, 집합연산을 수행하기 위함
   - BoardDetailViewModelFactory를 구현, 공지에서도 같은 ViewModel을 차용할 예정 + 계속 추가되는 usecase


## 📸 스크린샷
|댓글 삭제 후 답글이 써지지 않는 현상을 고침|
|:--:|
|![수정 후](https://user-images.githubusercontent.com/57972338/233387777-6e127bdb-52b1-4a3c-82b1-2586f9c40b53.gif)|

## 📮 관련 이슈
- #302

