### PR TITLE
[FEAT] 강퇴하기 기능 구현

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -270,6 +270,8 @@
 		C31D577429E16DBD00E056BA /* MyInfoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31D577329E16DBD00E056BA /* MyInfoRequest.swift */; };
 		C32AB19029DDB9000045B919 /* ProfileEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32AB18F29DDB9000045B919 /* ProfileEditViewModel.swift */; };
 		C332DFD52976E5440023B70B /* PhotoBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C332DFD42976E5440023B70B /* PhotoBottomSheetViewController.swift */; };
+		C333EEB929F45A7E00B3F84E /* ExportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333EEB829F45A7E00B3F84E /* ExportViewController.swift */; };
+		C333EEBB29F45AB900B3F84E /* ExportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333EEBA29F45AB900B3F84E /* ExportViewModel.swift */; };
 		C3394CB929E177D2005EECD7 /* UpdateImageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3394CB829E177D2005EECD7 /* UpdateImageRequest.swift */; };
 		C33952EF29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33952EE29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift */; };
 		C33EF37D29A1DFD100D7A5CA /* ScheduleAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33EF37C29A1DFD100D7A5CA /* ScheduleAlarmView.swift */; };
@@ -639,6 +641,8 @@
 		C31D577329E16DBD00E056BA /* MyInfoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoRequest.swift; sourceTree = "<group>"; };
 		C32AB18F29DDB9000045B919 /* ProfileEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditViewModel.swift; sourceTree = "<group>"; };
 		C332DFD42976E5440023B70B /* PhotoBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoBottomSheetViewController.swift; sourceTree = "<group>"; };
+		C333EEB829F45A7E00B3F84E /* ExportViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportViewController.swift; sourceTree = "<group>"; };
+		C333EEBA29F45AB900B3F84E /* ExportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportViewModel.swift; sourceTree = "<group>"; };
 		C3394CB829E177D2005EECD7 /* UpdateImageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateImageRequest.swift; sourceTree = "<group>"; };
 		C33952EE29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleParticipantCollectionViewCell.swift; sourceTree = "<group>"; };
 		C33EF37C29A1DFD100D7A5CA /* ScheduleAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleAlarmView.swift; sourceTree = "<group>"; };
@@ -1240,6 +1244,7 @@
 				C3AB743A296B1EC3003DD5E2 /* CreateMeeting */,
 				C33FB0702993F81800BEB15B /* EditMeeting */,
 				C359FEA4299FDE6400B2F561 /* Schedule */,
+				C333EEB729F45A5400B3F84E /* Export */,
 			);
 			path = Meeting;
 			sourceTree = "<group>";
@@ -1663,6 +1668,15 @@
 				C316051A2997936200D27488 /* GuestQuestionViewModel.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		C333EEB729F45A5400B3F84E /* Export */ = {
+			isa = PBXGroup;
+			children = (
+				C333EEB829F45A7E00B3F84E /* ExportViewController.swift */,
+				C333EEBA29F45AB900B3F84E /* ExportViewModel.swift */,
+			);
+			path = Export;
 			sourceTree = "<group>";
 		};
 		C33952ED29B64F760029FF7F /* Cell */ = {
@@ -2334,6 +2348,7 @@
 				C3B3435429BE3A1400935B73 /* MyPageRouter.swift in Sources */,
 				BA780E0F297138F10032C178 /* HeaderType.swift in Sources */,
 				C385D10F29894BF200EF88EC /* CreateMeetingViewModel.swift in Sources */,
+				C333EEB929F45A7E00B3F84E /* ExportViewController.swift in Sources */,
 				70F1DFEF297D9E1C00F9BC83 /* DetailRecruitmentViewModel.swift in Sources */,
 				BA8AA42A29863ABC004E9403 /* Interceptor.swift in Sources */,
 				C307826829CF5D9700E1D44B /* Ex+UIImage.swift in Sources */,
@@ -2595,6 +2610,7 @@
 				70727A3329D2C635003DE956 /* TodoCollectionViewCell.swift in Sources */,
 				BABB011A297ED415004178EC /* InterestViewController.swift in Sources */,
 				70CF3335299920CD0077FF47 /* RecruitmentFilterCollectionViewCell.swift in Sources */,
+				C333EEBB29F45AB900B3F84E /* ExportViewModel.swift in Sources */,
 				BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */,
 				C307826629CF5B6E00E1D44B /* MeetingTypeControl.swift in Sources */,
 				C31605172997934100D27488 /* RecruitPostViewModel.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -273,6 +273,8 @@
 		C333EEB929F45A7E00B3F84E /* ExportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333EEB829F45A7E00B3F84E /* ExportViewController.swift */; };
 		C333EEBB29F45AB900B3F84E /* ExportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333EEBA29F45AB900B3F84E /* ExportViewModel.swift */; };
 		C333EEBE29F4660800B3F84E /* ExportTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333EEBD29F4660800B3F84E /* ExportTableViewCell.swift */; };
+		C333EEC129F48EF400B3F84E /* InquireMeetingMemberUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333EEC029F48EF400B3F84E /* InquireMeetingMemberUseCase.swift */; };
+		C333EEC329F48FDC00B3F84E /* ExportMeetingMemberUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333EEC229F48FDC00B3F84E /* ExportMeetingMemberUseCase.swift */; };
 		C3394CB929E177D2005EECD7 /* UpdateImageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3394CB829E177D2005EECD7 /* UpdateImageRequest.swift */; };
 		C33952EF29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33952EE29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift */; };
 		C33EF37D29A1DFD100D7A5CA /* ScheduleAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33EF37C29A1DFD100D7A5CA /* ScheduleAlarmView.swift */; };
@@ -645,6 +647,8 @@
 		C333EEB829F45A7E00B3F84E /* ExportViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportViewController.swift; sourceTree = "<group>"; };
 		C333EEBA29F45AB900B3F84E /* ExportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportViewModel.swift; sourceTree = "<group>"; };
 		C333EEBD29F4660800B3F84E /* ExportTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTableViewCell.swift; sourceTree = "<group>"; };
+		C333EEC029F48EF400B3F84E /* InquireMeetingMemberUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquireMeetingMemberUseCase.swift; sourceTree = "<group>"; };
+		C333EEC229F48FDC00B3F84E /* ExportMeetingMemberUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportMeetingMemberUseCase.swift; sourceTree = "<group>"; };
 		C3394CB829E177D2005EECD7 /* UpdateImageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateImageRequest.swift; sourceTree = "<group>"; };
 		C33952EE29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleParticipantCollectionViewCell.swift; sourceTree = "<group>"; };
 		C33EF37C29A1DFD100D7A5CA /* ScheduleAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleAlarmView.swift; sourceTree = "<group>"; };
@@ -1493,6 +1497,7 @@
 		BAB2E56A29E30053006B7BDC /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
+				C333EEBF29F48EB800B3F84E /* Meeting */,
 				C36E64CD29F1AECD00C6C3CF /* Recruitment */,
 				BA4CCDF529EAB93D0040D0D7 /* Archive */,
 				BA4CCDF429EAB91D0040D0D7 /* Feeds */,
@@ -1688,6 +1693,15 @@
 				C333EEBD29F4660800B3F84E /* ExportTableViewCell.swift */,
 			);
 			path = Cell;
+			sourceTree = "<group>";
+		};
+		C333EEBF29F48EB800B3F84E /* Meeting */ = {
+			isa = PBXGroup;
+			children = (
+				C333EEC029F48EF400B3F84E /* InquireMeetingMemberUseCase.swift */,
+				C333EEC229F48FDC00B3F84E /* ExportMeetingMemberUseCase.swift */,
+			);
+			path = Meeting;
 			sourceTree = "<group>";
 		};
 		C33952ED29B64F760029FF7F /* Cell */ = {
@@ -2364,6 +2378,7 @@
 				BA8AA42A29863ABC004E9403 /* Interceptor.swift in Sources */,
 				C307826829CF5D9700E1D44B /* Ex+UIImage.swift in Sources */,
 				70727A1F29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift in Sources */,
+				C333EEC129F48EF400B3F84E /* InquireMeetingMemberUseCase.swift in Sources */,
 				701A9C9E29BB2178006F53C2 /* BoardClipboardHeaderView.swift in Sources */,
 				70CF333929992FA60077FF47 /* RecruitmentFilterSlider.swift in Sources */,
 				BA42D1F328EDE10F00C20061 /* LoginViewController.swift in Sources */,
@@ -2534,6 +2549,7 @@
 				BA117A3B297440B500B37E03 /* UserDefaultsWrapper.swift in Sources */,
 				BA46CCA028EC9B05004953B1 /* Ex+UIButton.swift in Sources */,
 				BAE2B362297C1D6C0000D5B9 /* AccountRouter.swift in Sources */,
+				C333EEC329F48FDC00B3F84E /* ExportMeetingMemberUseCase.swift in Sources */,
 				C3622B4A29A7CFF0005EF09C /* AddScheduleControl.swift in Sources */,
 				702876B7299E429C00E57509 /* BookmarkViewController.swift in Sources */,
 				C3E0390829C208B700C4744C /* RecruitingViewController.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -272,6 +272,7 @@
 		C332DFD52976E5440023B70B /* PhotoBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C332DFD42976E5440023B70B /* PhotoBottomSheetViewController.swift */; };
 		C333EEB929F45A7E00B3F84E /* ExportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333EEB829F45A7E00B3F84E /* ExportViewController.swift */; };
 		C333EEBB29F45AB900B3F84E /* ExportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333EEBA29F45AB900B3F84E /* ExportViewModel.swift */; };
+		C333EEBE29F4660800B3F84E /* ExportTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333EEBD29F4660800B3F84E /* ExportTableViewCell.swift */; };
 		C3394CB929E177D2005EECD7 /* UpdateImageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3394CB829E177D2005EECD7 /* UpdateImageRequest.swift */; };
 		C33952EF29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33952EE29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift */; };
 		C33EF37D29A1DFD100D7A5CA /* ScheduleAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33EF37C29A1DFD100D7A5CA /* ScheduleAlarmView.swift */; };
@@ -643,6 +644,7 @@
 		C332DFD42976E5440023B70B /* PhotoBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoBottomSheetViewController.swift; sourceTree = "<group>"; };
 		C333EEB829F45A7E00B3F84E /* ExportViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportViewController.swift; sourceTree = "<group>"; };
 		C333EEBA29F45AB900B3F84E /* ExportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportViewModel.swift; sourceTree = "<group>"; };
+		C333EEBD29F4660800B3F84E /* ExportTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTableViewCell.swift; sourceTree = "<group>"; };
 		C3394CB829E177D2005EECD7 /* UpdateImageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateImageRequest.swift; sourceTree = "<group>"; };
 		C33952EE29B6577B0029FF7F /* ScheduleParticipantCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleParticipantCollectionViewCell.swift; sourceTree = "<group>"; };
 		C33EF37C29A1DFD100D7A5CA /* ScheduleAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleAlarmView.swift; sourceTree = "<group>"; };
@@ -1675,8 +1677,17 @@
 			children = (
 				C333EEB829F45A7E00B3F84E /* ExportViewController.swift */,
 				C333EEBA29F45AB900B3F84E /* ExportViewModel.swift */,
+				C333EEBC29F465E200B3F84E /* Cell */,
 			);
 			path = Export;
+			sourceTree = "<group>";
+		};
+		C333EEBC29F465E200B3F84E /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				C333EEBD29F4660800B3F84E /* ExportTableViewCell.swift */,
+			);
+			path = Cell;
 			sourceTree = "<group>";
 		};
 		C33952ED29B64F760029FF7F /* Cell */ = {
@@ -2609,6 +2620,7 @@
 				70A420AD299002490026E9F9 /* NoResultSearchView.swift in Sources */,
 				70727A3329D2C635003DE956 /* TodoCollectionViewCell.swift in Sources */,
 				BABB011A297ED415004178EC /* InterestViewController.swift in Sources */,
+				C333EEBE29F4660800B3F84E /* ExportTableViewCell.swift in Sources */,
 				70CF3335299920CD0077FF47 /* RecruitmentFilterCollectionViewCell.swift in Sources */,
 				C333EEBB29F45AB900B3F84E /* ExportViewModel.swift in Sources */,
 				BA52779028EECEB40036B825 /* Ex+UIFont.swift in Sources */,

--- a/PLUB/Sources/Network/Routers/MeetingRouter.swift
+++ b/PLUB/Sources/Network/Routers/MeetingRouter.swift
@@ -49,7 +49,7 @@ extension MeetingRouter: Router {
     case .exitMeeting(let plubbingID):
       return "/plubbings/\(plubbingID)/leave"
     case .exportMeetingMember(let plubbingID, let accountID):
-      return "/plubbings/\(plubbingID)/acoounts/\(accountID)"
+      return "/plubbings/\(plubbingID)/accounts/\(accountID)"
     case .inquireMeetingMember(let plubbingID):
       return "/plubbings/\(plubbingID)/members"
     case .endMeeting(let plubbingID):

--- a/PLUB/Sources/UseCases/Meeting/ExportMeetingMemberUseCase.swift
+++ b/PLUB/Sources/UseCases/Meeting/ExportMeetingMemberUseCase.swift
@@ -1,0 +1,21 @@
+//
+//  ExportMeetingMemberUseCase.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/04/23.
+//
+
+import RxSwift
+
+protocol ExportMeetingMemberUseCase {
+  func execute(plubbingID: Int, accountID: Int)
+  -> Observable<Void>
+}
+
+final class DefaultExportMeetingMemberUseCase: ExportMeetingMemberUseCase {
+  func execute(plubbingID: Int, accountID: Int)
+  -> Observable<Void> {
+    MeetingService.shared.exportMeetingMember(plubbingID: plubbingID, accountID: accountID)
+      .map { _ in () }
+  }
+}

--- a/PLUB/Sources/UseCases/Meeting/InquireMeetingMemberUseCase.swift
+++ b/PLUB/Sources/UseCases/Meeting/InquireMeetingMemberUseCase.swift
@@ -1,0 +1,21 @@
+//
+//  InquireMeetingMemberUseCase.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/04/23.
+//
+
+import RxSwift
+
+protocol InquireMeetingMemberUseCase {
+  func execute(plubbingID: Int)
+  -> Observable<[AccountInfo]>
+}
+
+final class DefaultInquireMeetingMemberUseCase: InquireMeetingMemberUseCase {
+  func execute(plubbingID: Int)
+  -> Observable<[AccountInfo]> {
+    MeetingService.shared.inquireMeetingMember(plubbingID: plubbingID)
+      .map { $0.accounts }
+  }
+}

--- a/PLUB/Sources/Views/Meeting/Export/Cell/ExportTableViewCell.swift
+++ b/PLUB/Sources/Views/Meeting/Export/Cell/ExportTableViewCell.swift
@@ -1,0 +1,114 @@
+//
+//  ExportTableViewCell.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/04/23.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+import RxSwift
+
+protocol ExportTableViewCellDelegate: AnyObject {
+  func didTappedExportButton(indexPathRow: Int)
+}
+
+final class ExportTableViewCell: UITableViewCell {
+  static let identifier = "ExportTableViewCell"
+  private var indexPathRow: Int?
+  private let disposeBag = DisposeBag()
+  weak var delegate: ExportTableViewCellDelegate?
+  
+  private let contentStackView = UIStackView().then {
+    $0.axis = .horizontal
+    $0.alignment = .center
+    $0.spacing = 16
+    $0.isLayoutMarginsRelativeArrangement = true
+    $0.layoutMargins = .init(top: 16, left: 16, bottom: 16, right: 16)
+    $0.layer.cornerRadius = 10
+    $0.layer.borderColor = UIColor.lightGray.cgColor
+    $0.layer.borderWidth = 1
+    $0.backgroundColor = .white
+  }
+  
+  private let profileImageView = UIImageView().then {
+    $0.clipsToBounds = true
+    $0.layer.cornerRadius = 20
+  }
+  
+  private let nicknameLabel = UILabel().then {
+    $0.font = .subtitle
+    $0.textColor = .black
+  }
+  
+  private let exportButton = UIButton().then {
+    $0.setTitle("강퇴", for: .normal)
+    $0.setTitleColor(.deepGray, for: .normal)
+    $0.titleLabel?.font = .button
+    $0.layer.cornerRadius = 8
+    $0.backgroundColor = .lightGray
+  }
+  
+  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+    setupLayouts()
+    setupConstraints()
+    setupStyles()
+    bind()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupLayouts() {
+    contentView.addSubview(contentStackView)
+    [profileImageView, nicknameLabel, exportButton].forEach {
+      contentStackView.addArrangedSubview($0)
+    }
+  }
+  
+  private func setupConstraints() {
+    contentStackView.snp.makeConstraints {
+      $0.directionalHorizontalEdges.equalToSuperview().inset(16)
+      $0.directionalVerticalEdges.equalToSuperview().inset(6)
+    }
+    
+    profileImageView.snp.makeConstraints {
+      $0.size.equalTo(40)
+    }
+    
+    exportButton.snp.makeConstraints {
+      $0.width.equalTo(56)
+      $0.height.equalTo(29)
+    }
+  }
+  
+  private func setupStyles() {
+    selectionStyle = .none
+    backgroundColor = .background
+  }
+  
+  private func bind() {
+    exportButton.rx.tap
+      .subscribe(with: self) { owner, _ in
+        guard let indexPathRow = owner.indexPathRow else { return }
+        owner.delegate?.didTappedExportButton(indexPathRow: indexPathRow)
+      }
+      .disposed(by: disposeBag)
+  }
+  
+  func setupData(with data: AccountInfo, indexPathRow: Int) {
+    self.indexPathRow = indexPathRow
+    nicknameLabel.text = data.nickname
+    
+    if let profileImage = data.profileImage,
+       let profileImageURL = URL(string: profileImage) {
+      profileImageView.kf.setImage(with: profileImageURL)
+    } else {
+      profileImageView.image = UIImage(named: "userDefaultImage")
+    }
+  }
+}

--- a/PLUB/Sources/Views/Meeting/Export/Cell/ExportTableViewCell.swift
+++ b/PLUB/Sources/Views/Meeting/Export/Cell/ExportTableViewCell.swift
@@ -12,7 +12,7 @@ import Then
 import RxSwift
 
 protocol ExportTableViewCellDelegate: AnyObject {
-  func didTappedExportButton(indexPathRow: Int)
+  func didTappedExportButton(nickname: String, indexPathRow: Int)
 }
 
 final class ExportTableViewCell: UITableViewCell {
@@ -94,8 +94,9 @@ final class ExportTableViewCell: UITableViewCell {
   private func bind() {
     exportButton.rx.tap
       .subscribe(with: self) { owner, _ in
-        guard let indexPathRow = owner.indexPathRow else { return }
-        owner.delegate?.didTappedExportButton(indexPathRow: indexPathRow)
+        guard let indexPathRow = owner.indexPathRow,
+        let nickname = owner.nicknameLabel.text else { return }
+        owner.delegate?.didTappedExportButton(nickname: nickname, indexPathRow: indexPathRow)
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Meeting/Export/ExportViewController.swift
+++ b/PLUB/Sources/Views/Meeting/Export/ExportViewController.swift
@@ -64,7 +64,7 @@ final class ExportViewController: BaseViewController {
   override func bind() {
     super.bind()
     viewModel.accountList
-      .drive(tableView.rx.items) { tableView, row, item -> UITableViewCell in
+      .drive(tableView.rx.items) { [weak self] tableView, row, item -> UITableViewCell in
         guard let cell = tableView.dequeueReusableCell(
           withIdentifier: ExportTableViewCell.identifier,
           for: IndexPath(row: row, section: 0)

--- a/PLUB/Sources/Views/Meeting/Export/ExportViewController.swift
+++ b/PLUB/Sources/Views/Meeting/Export/ExportViewController.swift
@@ -17,7 +17,7 @@ final class ExportViewController: BaseViewController {
     $0.separatorStyle = .none
     $0.showsVerticalScrollIndicator = false
     $0.backgroundColor = .background
-    $0.register(MyPageTableViewCell.self, forCellReuseIdentifier: MyPageTableViewCell.identifier)
+    $0.register(ExportTableViewCell.self, forCellReuseIdentifier: ExportTableViewCell.identifier)
   }
   
   init(viewModel: ExportViewModel) {
@@ -31,10 +31,16 @@ final class ExportViewController: BaseViewController {
   
   override func setupLayouts() {
     super.setupLayouts()
+    [tableView].forEach {
+      view.addSubview($0)
+    }
   }
   
   override func setupConstraints() {
     super.setupConstraints()
+    tableView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
   }
   
   override func setupStyles() {
@@ -47,22 +53,12 @@ final class ExportViewController: BaseViewController {
     viewModel.accountList
       .drive(tableView.rx.items) { tableView, row, item -> UITableViewCell in
         guard let cell = tableView.dequeueReusableCell(
-          withIdentifier: "LocationTableViewCell",
+          withIdentifier: ExportTableViewCell.identifier,
           for: IndexPath(row: row, section: 0)
-        ) as? LocationTableViewCell else { return UITableViewCell() }
-//        cell.setupData(
-//          with: LocationTableViewCellModel(
-//            title: item.placeName ?? "",
-//            subTitle: item.address ?? ""
-//          )
-//        )
+        ) as? ExportTableViewCell else { return UITableViewCell() }
+        cell.setupData(with: item, indexPathRow: row)
+        cell.delegate = self
         return cell
-      }
-      .disposed(by: disposeBag)
-    
-    tableView.rx.didScroll
-      .subscribe { [weak self] _ in
-
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Meeting/Export/ExportViewController.swift
+++ b/PLUB/Sources/Views/Meeting/Export/ExportViewController.swift
@@ -1,0 +1,85 @@
+//
+//  ExportViewController.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/04/23.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ExportViewController: BaseViewController {
+  private let viewModel: ExportViewModel
+  
+  private lazy var tableView = UITableView(frame: .zero, style: .grouped).then {
+    $0.separatorStyle = .none
+    $0.showsVerticalScrollIndicator = false
+    $0.backgroundColor = .background
+    $0.register(MyPageTableViewCell.self, forCellReuseIdentifier: MyPageTableViewCell.identifier)
+  }
+  
+  init(viewModel: ExportViewModel) {
+    self.viewModel = viewModel
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func setupLayouts() {
+    super.setupLayouts()
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+  }
+  
+  override func setupStyles() {
+    super.setupStyles()
+    setupNavigationBar()
+  }
+  
+  override func bind() {
+    super.bind()
+    viewModel.accountList
+      .drive(tableView.rx.items) { tableView, row, item -> UITableViewCell in
+        guard let cell = tableView.dequeueReusableCell(
+          withIdentifier: "LocationTableViewCell",
+          for: IndexPath(row: row, section: 0)
+        ) as? LocationTableViewCell else { return UITableViewCell() }
+//        cell.setupData(
+//          with: LocationTableViewCellModel(
+//            title: item.placeName ?? "",
+//            subTitle: item.address ?? ""
+//          )
+//        )
+        return cell
+      }
+      .disposed(by: disposeBag)
+    
+    tableView.rx.didScroll
+      .subscribe { [weak self] _ in
+
+      }
+      .disposed(by: disposeBag)
+  }
+}
+
+extension ExportViewController {
+  private func setupNavigationBar() {
+    navigationItem.leftBarButtonItem = UIBarButtonItem(
+      image: UIImage(named: "backButton"),
+      style: .plain,
+      target: self,
+      action: #selector(didTappedBackButton)
+    )
+  }
+  
+  @objc
+  private func didTappedBackButton() {
+    navigationController?.popViewController(animated: true)
+  }
+}

--- a/PLUB/Sources/Views/Meeting/Export/ExportViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/Export/ExportViewModel.swift
@@ -12,6 +12,9 @@ final class ExportViewModel {
   private let disposeBag = DisposeBag()
   private let plubbingID: Int
   
+  private let inquireMeetingMemberUseCase: InquireMeetingMemberUseCase
+  private let exportMeetingMemberUseCase: ExportMeetingMemberUseCase
+  
   // Output
   let accountList: Driver<[AccountInfo]>
   let successExport: Driver<String>
@@ -19,8 +22,15 @@ final class ExportViewModel {
   private let accountListRelay = BehaviorRelay<[AccountInfo]>.init(value: Array.init())
   private let successExportSubject = PublishSubject<String>()
   
-  init(plubbingID: Int) {
+  init(
+    plubbingID: Int,
+    inquireMeetingMemberUseCase: InquireMeetingMemberUseCase,
+    exportMeetingMemberUseCase: ExportMeetingMemberUseCase
+  ) {
     self.plubbingID = plubbingID
+    self.inquireMeetingMemberUseCase = inquireMeetingMemberUseCase
+    self.exportMeetingMemberUseCase = exportMeetingMemberUseCase
+    
     accountList = accountListRelay.asDriver()
     successExport = successExportSubject.asDriver(onErrorDriveWith: .empty())
     
@@ -28,10 +38,11 @@ final class ExportViewModel {
   }
   
   private func fetchMeetingMember() {
-    MeetingService.shared.inquireMeetingMember(plubbingID: plubbingID)
+    inquireMeetingMemberUseCase
+      .execute(plubbingID: plubbingID)
       .withUnretained(self)
-      .subscribe(onNext: { owner, model in
-        owner.accountListRelay.accept(model.accounts)
+      .subscribe(onNext: { owner, accounts in
+        owner.accountListRelay.accept(accounts)
       })
       .disposed(by: disposeBag)
   }
@@ -39,7 +50,8 @@ final class ExportViewModel {
   func exportMember(indexPathRow: Int) {
     let account = accountListRelay.value[indexPathRow]
     let accountID = account.accountId
-    MeetingService.shared.exportMeetingMember(plubbingID: plubbingID, accountID: accountID)
+    exportMeetingMemberUseCase
+      .execute(plubbingID: plubbingID, accountID: accountID)
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
         let oldValue = owner.accountListRelay.value

--- a/PLUB/Sources/Views/Meeting/Export/ExportViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/Export/ExportViewModel.swift
@@ -1,0 +1,37 @@
+//
+//  ExportViewModel.swift
+//  PLUB
+//
+//  Created by 김수빈 on 2023/04/23.
+//
+
+import RxSwift
+import RxCocoa
+
+final class ExportViewModel {
+  //  exportMeetingMember
+
+  private let disposeBag = DisposeBag()
+  private let plubbingID: Int
+  
+  // Output
+  let accountList: Driver<[AccountInfo]>
+  
+  private let accountListRelay = BehaviorRelay<[AccountInfo]>.init(value: Array.init())
+  
+  init(plubbingID: Int) {
+    self.plubbingID = plubbingID
+    accountList = accountListRelay.asDriver()
+    
+    fetchMeetingMember()
+  }
+  
+  private func fetchMeetingMember() {
+    MeetingService.shared.inquireMeetingMember(plubbingID: plubbingID)
+      .withUnretained(self)
+      .subscribe(onNext: { owner, model in
+        owner.accountListRelay.accept(model.accounts)
+      })
+      .disposed(by: disposeBag)
+  }
+}

--- a/PLUB/Sources/Views/Meeting/Export/ExportViewModel.swift
+++ b/PLUB/Sources/Views/Meeting/Export/ExportViewModel.swift
@@ -9,19 +9,20 @@ import RxSwift
 import RxCocoa
 
 final class ExportViewModel {
-  //  exportMeetingMember
-
   private let disposeBag = DisposeBag()
   private let plubbingID: Int
   
   // Output
   let accountList: Driver<[AccountInfo]>
+  let successExport: Driver<String>
   
   private let accountListRelay = BehaviorRelay<[AccountInfo]>.init(value: Array.init())
+  private let successExportSubject = PublishSubject<String>()
   
   init(plubbingID: Int) {
     self.plubbingID = plubbingID
     accountList = accountListRelay.asDriver()
+    successExport = successExportSubject.asDriver(onErrorDriveWith: .empty())
     
     fetchMeetingMember()
   }
@@ -31,6 +32,26 @@ final class ExportViewModel {
       .withUnretained(self)
       .subscribe(onNext: { owner, model in
         owner.accountListRelay.accept(model.accounts)
+      })
+      .disposed(by: disposeBag)
+  }
+  
+  func exportMember(indexPathRow: Int) {
+    let account = accountListRelay.value[indexPathRow]
+    let accountID = account.accountId
+    MeetingService.shared.exportMeetingMember(plubbingID: plubbingID, accountID: accountID)
+      .withUnretained(self)
+      .subscribe(onNext: { owner, _ in
+        let oldValue = owner.accountListRelay.value
+          .filter { $0.accountId != accountID }
+        
+        owner.accountListRelay.accept(oldValue)
+        
+        if oldValue.isEmpty {
+          //TODO: - 수빈 noneView 화면으로 전환
+        }
+        
+        owner.successExportSubject.onNext(account.nickname)
       })
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Meeting/MeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewController.swift
@@ -242,7 +242,12 @@ extension MeetingViewController: MeetingCollectionViewCellDelegate {
   }
   
   func didTappedExportButton(plubbingID: Int) {
-    let vc = ExportViewController(viewModel: ExportViewModel(plubbingID: plubbingID))
+    let vc = ExportViewController(
+      viewModel: ExportViewModel(
+        plubbingID: plubbingID,
+        inquireMeetingMemberUseCase: DefaultInquireMeetingMemberUseCase(),
+        exportMeetingMemberUseCase: DefaultExportMeetingMemberUseCase())
+    )
     vc.hidesBottomBarWhenPushed = true
     navigationController?.pushViewController(vc, animated: true)
   }

--- a/PLUB/Sources/Views/Meeting/MeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewController.swift
@@ -242,6 +242,9 @@ extension MeetingViewController: MeetingCollectionViewCellDelegate {
   }
   
   func didTappedExportButton(plubbingID: Int) {
+    let vc = ExportViewController(viewModel: ExportViewModel(plubbingID: plubbingID))
+    vc.hidesBottomBarWhenPushed = true
+    navigationController?.pushViewController(vc, animated: true)
   }
   
   func didTappedEndButton(plubbingID: Int) {

--- a/PLUB/Sources/Views/MyPage/Recruiting/Component/CustomAlertView.swift
+++ b/PLUB/Sources/Views/MyPage/Recruiting/Component/CustomAlertView.swift
@@ -15,7 +15,7 @@ struct AlertModel {
   let title: String // 알림창 제목
   let message: String? // 알림창 내용
   let cancelButton: String? // 취소 버튼 이름
-  let confirmButton: String // 확인 버튼 이름
+  let confirmButton: String? // 확인 버튼 이름
   let height: Int? // 알림창 높이
 }
 
@@ -73,7 +73,7 @@ final class CustomAlertView: UIView {
   }
   
   private lazy var confirmButton =  UIButton(configuration: .plain()).then {
-    $0.configurationUpdateHandler = $0.configuration?.plubButton(label: model.confirmButton)
+    $0.configurationUpdateHandler = $0.configuration?.plubButton(label: model.confirmButton ?? "")
   }
   
   init(
@@ -104,7 +104,7 @@ final class CustomAlertView: UIView {
     
     [
       model.cancelButton == nil ? nil : cancelButton,
-      confirmButton
+      model.confirmButton == nil ? nil : confirmButton
     ].compactMap { $0 }.forEach {
       buttonStackView.addArrangedSubview($0)
     }

--- a/PLUB/Sources/Views/MyPage/Recruiting/Component/CustomAlertView.swift
+++ b/PLUB/Sources/Views/MyPage/Recruiting/Component/CustomAlertView.swift
@@ -15,7 +15,7 @@ struct AlertModel {
   let title: String // 알림창 제목
   let message: String? // 알림창 내용
   let cancelButton: String? // 취소 버튼 이름
-  let confirmButton: String // 확인 버튼 이름
+  let confirmButton: String? // 확인 버튼 이름
   let height: Int? // 알림창 높이
 }
 
@@ -73,7 +73,7 @@ final class CustomAlertView: UIView {
   }
   
   private lazy var confirmButton =  UIButton(configuration: .plain()).then {
-    $0.configurationUpdateHandler = $0.configuration?.plubButton(label: model.confirmButton)
+    $0.configurationUpdateHandler = $0.configuration?.plubButton(label: model.confirmButton ?? "")
   }
   
   init(
@@ -104,7 +104,7 @@ final class CustomAlertView: UIView {
     
     [
       model.cancelButton == nil ? nil : cancelButton,
-      confirmButton
+      model.confirmButton == nil ? nil : confirmButton
     ].compactMap { $0 }.forEach {
       buttonStackView.addArrangedSubview($0)
     }
@@ -124,7 +124,12 @@ final class CustomAlertView: UIView {
     }
     
     buttonStackView.snp.makeConstraints {
-      $0.height.equalTo(46)
+      if let _ = model.cancelButton,
+         let _ = model.confirmButton {
+        $0.height.equalTo(46)
+      } else {
+        $0.height.equalTo(0)
+      }
     }
     
     if model.message != nil {


### PR DESCRIPTION
## 📌 PR 요약
내모임(호스트일때) > 강퇴하기 기능을 구현하였습니다.

🌱 작업한 내용
- 플러버 리스트 ui 작업
- 플러버 리스트 api 연동
- 강퇴하기 api 연동

🌱 PR 포인트
- 플러버 리스트가 없을때 화면은 아직 전달받지 못하여 작업전입니다.
- `customAlertView`에 확인, 취소가 모두 없을때 case를 추가하였습니다.(임시작업)
-> UI가 조금 틀어지는 경향이 있어서 따로 pr 파서 작업하겠습니다..!

## 📸 스크린샷

Uploading RPReplay_Final1682199660.MP4…



## 📮 관련 이슈
-  #268 
