### PR TITLE
[FEAT] 아카이브 업로드 기능 구현

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		BA2173B729F53685000D72B1 /* UploadImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2173B629F53685000D72B1 /* UploadImageUseCase.swift */; };
 		BA2173B929F57A97000D72B1 /* DeleteImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2173B829F57A97000D72B1 /* DeleteImageUseCase.swift */; };
 		BA2173BB29F61955000D72B1 /* UploadArchiveUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2173BA29F61955000D72B1 /* UploadArchiveUseCase.swift */; };
+		BA2173BD29F61A36000D72B1 /* EditArchiveUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2173BC29F61A36000D72B1 /* EditArchiveUseCase.swift */; };
 		BA340E1629782207002BAF2C /* IntroduceTagCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA340E1529782207002BAF2C /* IntroduceTagCollectionViewCell.swift */; };
 		BA340E1C297822CC002BAF2C /* IntroduceCategoryInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA340E1B297822CC002BAF2C /* IntroduceCategoryInfoView.swift */; };
 		BA340E1E297822ED002BAF2C /* IntroduceCategoryTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA340E1D297822ED002BAF2C /* IntroduceCategoryTitleView.swift */; };
@@ -512,6 +513,7 @@
 		BA2173B629F53685000D72B1 /* UploadImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadImageUseCase.swift; sourceTree = "<group>"; };
 		BA2173B829F57A97000D72B1 /* DeleteImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteImageUseCase.swift; sourceTree = "<group>"; };
 		BA2173BA29F61955000D72B1 /* UploadArchiveUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadArchiveUseCase.swift; sourceTree = "<group>"; };
+		BA2173BC29F61A36000D72B1 /* EditArchiveUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditArchiveUseCase.swift; sourceTree = "<group>"; };
 		BA340E1529782207002BAF2C /* IntroduceTagCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceTagCollectionViewCell.swift; sourceTree = "<group>"; };
 		BA340E1B297822CC002BAF2C /* IntroduceCategoryInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceCategoryInfoView.swift; sourceTree = "<group>"; };
 		BA340E1D297822ED002BAF2C /* IntroduceCategoryTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceCategoryTitleView.swift; sourceTree = "<group>"; };
@@ -1294,6 +1296,7 @@
 		BA4CCDF529EAB93D0040D0D7 /* Archive */ = {
 			isa = PBXGroup;
 			children = (
+				BA2173BC29F61A36000D72B1 /* EditArchiveUseCase.swift */,
 				BA590E7929EBC6320017FAF1 /* GetArchiveDetailUseCase.swift */,
 				BA4CCDF629EAB9540040D0D7 /* GetArchiveUseCase.swift */,
 				BA2173BA29F61955000D72B1 /* UploadArchiveUseCase.swift */,
@@ -2385,6 +2388,7 @@
 				BAE0AC7629B5D67D00F46F3D /* BoardDetailViewController.swift in Sources */,
 				C34F048429C715A800E5B67E /* SettingSubview.swift in Sources */,
 				BA46CC9F28EC9B05004953B1 /* Ex+UIColor.swift in Sources */,
+				BA2173BD29F61A36000D72B1 /* EditArchiveUseCase.swift in Sources */,
 				BAB2E56C29E30A13006B7BDC /* PostCommentUseCase.swift in Sources */,
 				C39E09B629C604DE00ECAD11 /* RecruitingFooterView.swift in Sources */,
 				BA340E1629782207002BAF2C /* IntroduceTagCollectionViewCell.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		BA1FC12B29A62E3600AB3F91 /* FeedsClipboardResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1FC12A29A62E3600AB3F91 /* FeedsClipboardResponse.swift */; };
 		BA2173B729F53685000D72B1 /* UploadImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2173B629F53685000D72B1 /* UploadImageUseCase.swift */; };
 		BA2173B929F57A97000D72B1 /* DeleteImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2173B829F57A97000D72B1 /* DeleteImageUseCase.swift */; };
+		BA2173BB29F61955000D72B1 /* UploadArchiveUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2173BA29F61955000D72B1 /* UploadArchiveUseCase.swift */; };
 		BA340E1629782207002BAF2C /* IntroduceTagCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA340E1529782207002BAF2C /* IntroduceTagCollectionViewCell.swift */; };
 		BA340E1C297822CC002BAF2C /* IntroduceCategoryInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA340E1B297822CC002BAF2C /* IntroduceCategoryInfoView.swift */; };
 		BA340E1E297822ED002BAF2C /* IntroduceCategoryTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA340E1D297822ED002BAF2C /* IntroduceCategoryTitleView.swift */; };
@@ -510,6 +511,7 @@
 		BA1FC12A29A62E3600AB3F91 /* FeedsClipboardResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedsClipboardResponse.swift; sourceTree = "<group>"; };
 		BA2173B629F53685000D72B1 /* UploadImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadImageUseCase.swift; sourceTree = "<group>"; };
 		BA2173B829F57A97000D72B1 /* DeleteImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteImageUseCase.swift; sourceTree = "<group>"; };
+		BA2173BA29F61955000D72B1 /* UploadArchiveUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadArchiveUseCase.swift; sourceTree = "<group>"; };
 		BA340E1529782207002BAF2C /* IntroduceTagCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceTagCollectionViewCell.swift; sourceTree = "<group>"; };
 		BA340E1B297822CC002BAF2C /* IntroduceCategoryInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceCategoryInfoView.swift; sourceTree = "<group>"; };
 		BA340E1D297822ED002BAF2C /* IntroduceCategoryTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceCategoryTitleView.swift; sourceTree = "<group>"; };
@@ -1294,6 +1296,7 @@
 			children = (
 				BA590E7929EBC6320017FAF1 /* GetArchiveDetailUseCase.swift */,
 				BA4CCDF629EAB9540040D0D7 /* GetArchiveUseCase.swift */,
+				BA2173BA29F61955000D72B1 /* UploadArchiveUseCase.swift */,
 			);
 			path = Archive;
 			sourceTree = "<group>";
@@ -2585,6 +2588,7 @@
 				BA4BD1AE29D6C4A800334C04 /* PagingManager.swift in Sources */,
 				7028770929AA6B3D00E57509 /* CategoryMeetingRequest.swift in Sources */,
 				BAC5EF2F298AA23700F3955E /* SplashViewModel.swift in Sources */,
+				BA2173BB29F61955000D72B1 /* UploadArchiveUseCase.swift in Sources */,
 				C38A5B95297AD5B000485355 /* KakaoLocationRouter.swift in Sources */,
 				C383967A29A25A16005998A5 /* ScheduleService.swift in Sources */,
 				70A420B629914B4F0026E9F9 /* CategoryMeetingResponse.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		BA1FC12729A5E1D900AB3F91 /* FeedsContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1FC12629A5E1D900AB3F91 /* FeedsContent.swift */; };
 		BA1FC12929A5FD3C00AB3F91 /* PaginatedDataResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1FC12829A5FD3C00AB3F91 /* PaginatedDataResponse.swift */; };
 		BA1FC12B29A62E3600AB3F91 /* FeedsClipboardResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1FC12A29A62E3600AB3F91 /* FeedsClipboardResponse.swift */; };
+		BA2173B729F53685000D72B1 /* UploadImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2173B629F53685000D72B1 /* UploadImageUseCase.swift */; };
 		BA340E1629782207002BAF2C /* IntroduceTagCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA340E1529782207002BAF2C /* IntroduceTagCollectionViewCell.swift */; };
 		BA340E1C297822CC002BAF2C /* IntroduceCategoryInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA340E1B297822CC002BAF2C /* IntroduceCategoryInfoView.swift */; };
 		BA340E1E297822ED002BAF2C /* IntroduceCategoryTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA340E1D297822ED002BAF2C /* IntroduceCategoryTitleView.swift */; };
@@ -506,6 +507,7 @@
 		BA1FC12629A5E1D900AB3F91 /* FeedsContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedsContent.swift; sourceTree = "<group>"; };
 		BA1FC12829A5FD3C00AB3F91 /* PaginatedDataResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedDataResponse.swift; sourceTree = "<group>"; };
 		BA1FC12A29A62E3600AB3F91 /* FeedsClipboardResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedsClipboardResponse.swift; sourceTree = "<group>"; };
+		BA2173B629F53685000D72B1 /* UploadImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadImageUseCase.swift; sourceTree = "<group>"; };
 		BA340E1529782207002BAF2C /* IntroduceTagCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceTagCollectionViewCell.swift; sourceTree = "<group>"; };
 		BA340E1B297822CC002BAF2C /* IntroduceCategoryInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceCategoryInfoView.swift; sourceTree = "<group>"; };
 		BA340E1D297822ED002BAF2C /* IntroduceCategoryTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceCategoryTitleView.swift; sourceTree = "<group>"; };
@@ -1133,6 +1135,14 @@
 			path = Response;
 			sourceTree = "<group>";
 		};
+		BA2173B329F53657000D72B1 /* Image */ = {
+			isa = PBXGroup;
+			children = (
+				BA2173B629F53685000D72B1 /* UploadImageUseCase.swift */,
+			);
+			path = Image;
+			sourceTree = "<group>";
+		};
 		BA340E14297821C8002BAF2C /* DetailRecruitment */ = {
 			isa = PBXGroup;
 			children = (
@@ -1492,6 +1502,7 @@
 		BAB2E56A29E30053006B7BDC /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
+				BA2173B329F53657000D72B1 /* Image */,
 				C36E64CD29F1AECD00C6C3CF /* Recruitment */,
 				BA4CCDF529EAB93D0040D0D7 /* Archive */,
 				BA4CCDF429EAB91D0040D0D7 /* Feeds */,
@@ -2310,6 +2321,7 @@
 				C38D6566298852F80052013F /* PaddingLabel.swift in Sources */,
 				70197B7B29549B6A000503F6 /* SelectedCategoryChartCollectionViewCell.swift in Sources */,
 				70A4209C2988B1DC0026E9F9 /* SortControl.swift in Sources */,
+				BA2173B729F53685000D72B1 /* UploadImageUseCase.swift in Sources */,
 				BA5D9EDB29E406AD00F06AB5 /* Day.swift in Sources */,
 				70A420A7298D0F140026E9F9 /* RecentSearchListCollectionViewCell.swift in Sources */,
 				BA034D3229E864CA003B7192 /* CommentOptionDecoratorView.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		BA1FC12929A5FD3C00AB3F91 /* PaginatedDataResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1FC12829A5FD3C00AB3F91 /* PaginatedDataResponse.swift */; };
 		BA1FC12B29A62E3600AB3F91 /* FeedsClipboardResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1FC12A29A62E3600AB3F91 /* FeedsClipboardResponse.swift */; };
 		BA2173B729F53685000D72B1 /* UploadImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2173B629F53685000D72B1 /* UploadImageUseCase.swift */; };
+		BA2173B929F57A97000D72B1 /* DeleteImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2173B829F57A97000D72B1 /* DeleteImageUseCase.swift */; };
 		BA340E1629782207002BAF2C /* IntroduceTagCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA340E1529782207002BAF2C /* IntroduceTagCollectionViewCell.swift */; };
 		BA340E1C297822CC002BAF2C /* IntroduceCategoryInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA340E1B297822CC002BAF2C /* IntroduceCategoryInfoView.swift */; };
 		BA340E1E297822ED002BAF2C /* IntroduceCategoryTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA340E1D297822ED002BAF2C /* IntroduceCategoryTitleView.swift */; };
@@ -508,6 +509,7 @@
 		BA1FC12829A5FD3C00AB3F91 /* PaginatedDataResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedDataResponse.swift; sourceTree = "<group>"; };
 		BA1FC12A29A62E3600AB3F91 /* FeedsClipboardResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedsClipboardResponse.swift; sourceTree = "<group>"; };
 		BA2173B629F53685000D72B1 /* UploadImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadImageUseCase.swift; sourceTree = "<group>"; };
+		BA2173B829F57A97000D72B1 /* DeleteImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteImageUseCase.swift; sourceTree = "<group>"; };
 		BA340E1529782207002BAF2C /* IntroduceTagCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceTagCollectionViewCell.swift; sourceTree = "<group>"; };
 		BA340E1B297822CC002BAF2C /* IntroduceCategoryInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceCategoryInfoView.swift; sourceTree = "<group>"; };
 		BA340E1D297822ED002BAF2C /* IntroduceCategoryTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceCategoryTitleView.swift; sourceTree = "<group>"; };
@@ -1138,6 +1140,7 @@
 		BA2173B329F53657000D72B1 /* Image */ = {
 			isa = PBXGroup;
 			children = (
+				BA2173B829F57A97000D72B1 /* DeleteImageUseCase.swift */,
 				BA2173B629F53685000D72B1 /* UploadImageUseCase.swift */,
 			);
 			path = Image;
@@ -2345,6 +2348,7 @@
 				C3E0390F29C230F700C4744C /* RecruitingHeaderView.swift in Sources */,
 				BA814A3429890AB1003570D3 /* OnboardingViewModel.swift in Sources */,
 				C3B3435B29BE3E5100935B73 /* MyPlubbingResponse.swift in Sources */,
+				BA2173B929F57A97000D72B1 /* DeleteImageUseCase.swift in Sources */,
 				BA8E2B40297461E6009DDF32 /* SignInRequest.swift in Sources */,
 				70F1DFD6297950DD00F9BC83 /* CategoryRouter.swift in Sources */,
 				BA5D9ED529E3EE7400F06AB5 /* ArchiveRequest.swift in Sources */,

--- a/PLUB/Sources/Models/Image/Request/UploadImageRequest.swift
+++ b/PLUB/Sources/Models/Image/Request/UploadImageRequest.swift
@@ -22,4 +22,7 @@ enum ImageType: String, Codable {
   
   /// 게시판 이미지
   case feed
+  
+  /// 아카이브 이미지
+  case archive
 }

--- a/PLUB/Sources/Network/Routers/ImageRouter.swift
+++ b/PLUB/Sources/Network/Routers/ImageRouter.swift
@@ -10,7 +10,7 @@ import Alamofire
 enum ImageRouter {
   case uploadImage
   case updateImage
-  case deleteImage
+  case deleteImage(String, ImageType)
 }
 
 extension ImageRouter: Router {
@@ -37,8 +37,10 @@ extension ImageRouter: Router {
   
   var parameters: ParameterType {
     switch self {
-    case .uploadImage, .updateImage, .deleteImage:
+    case .uploadImage, .updateImage:
       return .plain
+    case let .deleteImage(fileURL, imageType):
+      return .query(["fileUrl": fileURL, "type": imageType.rawValue])
     }
   }
   

--- a/PLUB/Sources/Network/Services/ImageService.swift
+++ b/PLUB/Sources/Network/Services/ImageService.swift
@@ -26,7 +26,7 @@ extension ImageService {
   func uploadImage(
     images: [UIImage],
     params: UploadImageRequest
-) -> PLUBResult<UploadImageResponse> {
+  ) -> PLUBResult<UploadImageResponse> {
     return sendRequestWithImage(
       setUpImageData(
         images: images,
@@ -40,7 +40,7 @@ extension ImageService {
   func updateImage(
     images: [UIImage],
     params: UpdateImageRequest
-) -> PLUBResult<UploadImageResponse> {
+  ) -> PLUBResult<UploadImageResponse> {
     return sendRequestWithImage(
       setUpImageData(
         images: images,
@@ -52,13 +52,17 @@ extension ImageService {
     )
   }
   
+  func deleteImage(fileURL: String, imageType: ImageType) -> Observable<EmptyModel> {
+    sendObservableRequest(ImageRouter.deleteImage(fileURL, imageType))
+  }
+  
   private func setUpImageData(
     images: [UIImage],
     params: [String: Any],
     type: ImageServiceType = .upload
   ) -> MultipartFormData {
     let formData = MultipartFormData()
-
+    
     for image in images {
       guard let imageData = image.jpegData(compressionQuality: 0.1) else { continue }
       formData.append(

--- a/PLUB/Sources/UseCases/Archive/EditArchiveUseCase.swift
+++ b/PLUB/Sources/UseCases/Archive/EditArchiveUseCase.swift
@@ -1,0 +1,32 @@
+// 
+//  EditArchiveUseCase.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/24.
+//
+
+import RxSwift
+
+protocol EditArchiveUseCase {
+  func execute(title: String, images: [String]) -> Observable<BaseService.EmptyModel>
+}
+
+final class DefaultEditArchiveUseCase: EditArchiveUseCase {
+  
+  private let plubbingID: Int
+  private let archiveID: Int
+  
+  init(plubbingID: Int, archiveID: Int) {
+    self.plubbingID = plubbingID
+    self.archiveID  = archiveID
+  }
+  
+  func execute(title: String, images: [String]) -> Observable<BaseService.EmptyModel> {
+    ArchiveService.shared.updateArchive(
+      plubbingID: plubbingID,
+      archiveID: archiveID,
+      model: ArchiveRequest(title: title, images: images)
+    )
+    .map { _ in .init() }
+  }
+}

--- a/PLUB/Sources/UseCases/Archive/GetArchiveDetailUseCase.swift
+++ b/PLUB/Sources/UseCases/Archive/GetArchiveDetailUseCase.swift
@@ -14,14 +14,15 @@ protocol GetArchiveDetailUseCase {
 final class DefaultGetArchiveDetailUseCase: GetArchiveDetailUseCase {
   
   private let plubbingID: Int
-  private let archiveID: Int
+  private let archiveID: Int?
   
-  init(plubbingID: Int, archiveID: Int) {
+  init(plubbingID: Int, archiveID: Int?) {
     self.plubbingID = plubbingID
     self.archiveID  = archiveID
   }
   
   func execute() -> Observable<ArchiveContent> {
-    ArchiveService.shared.fetchArchiveDetails(plubbingID: plubbingID, archiveID: archiveID)
+    guard let archiveID else { return .error(PLUBError<GeneralResponse<ArchiveContent>>.unknownedError) }
+    return ArchiveService.shared.fetchArchiveDetails(plubbingID: plubbingID, archiveID: archiveID)
   }
 }

--- a/PLUB/Sources/UseCases/Archive/UploadArchiveUseCase.swift
+++ b/PLUB/Sources/UseCases/Archive/UploadArchiveUseCase.swift
@@ -1,0 +1,29 @@
+// 
+//  UploadArchiveUseCase.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/24.
+//
+
+import RxSwift
+
+protocol UploadArchiveUseCase {
+  func execute(title: String, images: [String]) -> Observable<BaseService.EmptyModel>
+}
+
+final class DefaultUploadArchiveUseCase: UploadArchiveUseCase {
+  
+  private let plubbingID: Int
+  
+  init(plubbingID: Int) {
+    self.plubbingID = plubbingID
+  }
+  
+  func execute(title: String, images: [String]) -> Observable<BaseService.EmptyModel> {
+    ArchiveService.shared.createArchive(
+      plubbingID: plubbingID,
+      model: ArchiveRequest(title: title, images: images)
+    )
+    .map { _ in .init() }
+  }
+}

--- a/PLUB/Sources/UseCases/Image/DeleteImageUseCase.swift
+++ b/PLUB/Sources/UseCases/Image/DeleteImageUseCase.swift
@@ -1,0 +1,19 @@
+// 
+//  DeleteImageUseCase.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/23.
+//
+
+import RxSwift
+
+protocol DeleteImageUseCase {
+  func execute(fileURL: String, type: ImageType) -> Observable<BaseService.EmptyModel>
+}
+
+final class DefaultDeleteImageUseCase: DeleteImageUseCase {
+  
+  func execute(fileURL: String, type: ImageType) -> Observable<BaseService.EmptyModel> {
+    ImageService.shared.deleteImage(fileURL: fileURL, imageType: type)
+  }
+}

--- a/PLUB/Sources/UseCases/Image/UploadImageUseCase.swift
+++ b/PLUB/Sources/UseCases/Image/UploadImageUseCase.swift
@@ -1,0 +1,27 @@
+// 
+//  UploadImageUseCase.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/23.
+//
+
+import UIKit
+
+import RxSwift
+
+protocol UploadImageUseCase {
+  func execute(images: [UIImage], uploadType: ImageType) -> Observable<UploadImageResponse>
+}
+
+final class DefaultUploadImageUseCase: UploadImageUseCase {
+  
+  func execute(images: [UIImage], uploadType: ImageType) -> Observable<UploadImageResponse> {
+    ImageService.shared.uploadImage(images: images, params: UploadImageRequest(type: uploadType))
+      .compactMap { result in
+        guard case let .success(response) = result else {
+          return nil
+        }
+        return response.data
+      }
+  }
+}

--- a/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
@@ -123,6 +123,10 @@ final class ArchiveUploadViewController: BaseViewController {
         owner.present(photoBottomSheetVC, animated: true)
       }
       .disposed(by: disposeBag)
+    
+    viewModel.buttonEnabledObservable
+      .bind(to: completeButton.rx.isEnabled)
+      .disposed(by: disposeBag)
   }
 }
 

--- a/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
@@ -127,6 +127,16 @@ final class ArchiveUploadViewController: BaseViewController {
     viewModel.buttonEnabledObservable
       .bind(to: completeButton.rx.isEnabled)
       .disposed(by: disposeBag)
+    
+    completeButton.rx.tap
+      .bind(to: viewModel.completeButtonTappedObserver)
+      .disposed(by: disposeBag)
+    
+    viewModel.popViewControllerObservable
+      .subscribe(with: self) { owner, _ in
+        owner.navigationController?.popViewController(animated: true)
+      }
+      .disposed(by: disposeBag)
   }
 }
 

--- a/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
@@ -162,7 +162,7 @@ extension ArchiveUploadViewController: UICollectionViewDelegate {
 
 extension ArchiveUploadViewController: PhotoBottomSheetDelegate {
   func selectImage(image: UIImage) {
-    
+    viewModel.selectedImageObserver.onNext(image)
   }
 }
 

--- a/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveUploadViewController.swift
@@ -115,6 +115,14 @@ final class ArchiveUploadViewController: BaseViewController {
     collectionView.delegate = self
     
     viewModel.collectionViewObserver.onNext(collectionView)
+    
+    viewModel.presentPhotoBottomSheetObservable
+      .subscribe(with: self) { owner, _ in
+        let photoBottomSheetVC = PhotoBottomSheetViewController()
+        photoBottomSheetVC.delegate = owner
+        owner.present(photoBottomSheetVC, animated: true)
+      }
+      .disposed(by: disposeBag)
   }
 }
 
@@ -147,6 +155,14 @@ extension ArchiveUploadViewController: UICollectionViewDelegate {
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     viewModel.selectedCellIndexPathObserver.onNext(indexPath)
     collectionView.deselectItem(at: indexPath, animated: true)
+  }
+}
+
+// MARK: - PhotoBottomSheetDelegate
+
+extension ArchiveUploadViewController: PhotoBottomSheetDelegate {
+  func selectImage(image: UIImage) {
+    
   }
 }
 

--- a/PLUB/Sources/Views/Home/Archive/Cell/ArchiveUploadedPictureCell.swift
+++ b/PLUB/Sources/Views/Home/Archive/Cell/ArchiveUploadedPictureCell.swift
@@ -7,14 +7,28 @@
 
 import UIKit
 
+import Kingfisher
+import RxSwift
+import RxCocoa
 import SnapKit
 import Then
+
+protocol ArchiveUploadedPictureCellDelegate: AnyObject {
+  func cancelButtonTapped(imageURL: String)
+}
 
 final class ArchiveUploadedPictureCell: UICollectionViewCell {
   
   // MARK: - Properties
   
   static let identifier = "\(ArchiveUploadedPictureCell.self)"
+  
+  /// 셀에 등록된 이미지 url 주소값, 제거 버튼 클릭 시 해당 값을 내보냅니다.
+  private var imageURL = ""
+  
+  private let disposeBag = DisposeBag()
+  
+  weak var delegate: ArchiveUploadedPictureCellDelegate?
   
   // MARK: - UI Components
   
@@ -38,7 +52,7 @@ final class ArchiveUploadedPictureCell: UICollectionViewCell {
     super.init(frame: frame)
     setupLayouts()
     setupConstraints()
-    setupStyles()
+    bind()
   }
   
   required init?(coder: NSCoder) {
@@ -68,11 +82,16 @@ final class ArchiveUploadedPictureCell: UICollectionViewCell {
     }
   }
   
-  private func setupStyles() {
-    
+  private func bind() {
+    cancelButton.rx.tap
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.cancelButtonTapped(imageURL: owner.imageURL)
+      }
+      .disposed(by: disposeBag)
   }
   
   func configure(with imageLink: String) {
     archiveImageView.kf.setImage(with: URL(string: imageLink))
+    imageURL = imageLink
   }
 }

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
@@ -135,6 +135,7 @@ private extension ArchiveUploadViewModel {
       .disposed(by: disposeBag)
   }
   
+  /// 아카이브 업로드를 시도하고, 성공했을 경우 ViewController를 Pop하는 로직을 처리합니다.
   func uploadAndDismissView() {
     completeButtonTappedSubject
       .withLatestFrom(archiveTitleSubject)

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
@@ -62,15 +62,18 @@ final class ArchiveUploadViewModel {
   private let getArchiveDetailUseCase: GetArchiveDetailUseCase
   private let uploadImageUseCase: UploadImageUseCase
   private let deleteImageUseCase: DeleteImageUseCase
+  private let uploadArchiveUseCase: UploadArchiveUseCase
   
   init(
     getArchiveDetailUseCase: GetArchiveDetailUseCase,
     uploadImageUseCase: UploadImageUseCase,
-    deleteImageUseCase: DeleteImageUseCase
+    deleteImageUseCase: DeleteImageUseCase,
+    uploadArchiveUseCase: UploadArchiveUseCase
   ) {
     self.getArchiveDetailUseCase = getArchiveDetailUseCase
     self.uploadImageUseCase = uploadImageUseCase
     self.deleteImageUseCase = deleteImageUseCase
+    self.uploadArchiveUseCase = uploadArchiveUseCase
     
     fetchArchives()
     uploadImageAndUpdateView()

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
@@ -54,13 +54,28 @@ final class ArchiveUploadViewModel {
   
   // MARK: Subjects
   
+  /// diffable datasource를 위한 collectionView 세팅 서브젝트
   private let setCollectionViewSubject          = PublishSubject<UICollectionView>()
+  
+  /// 선택된 CollectionViewCell의 IndexPath를 받고 처리하는 서브젝트
   private let selectedCellIndexPathSubject      = PublishSubject<IndexPath>()
+  
+  /// PhotoBottomSheet로부터 받은 이미지를 받고 처리하는 서브젝트
   private let selectedImageSubject              = PublishSubject<UIImage>()
+  
+  /// HeaderView의 제목 textfield를 Input으로 받아 가공하는 서브젝트
   private let archiveTitleSubject               = BehaviorSubject<String>(value: "")
+  
+  /// 이미지 CollectionViewCell의 cancelButton이 눌렸을 때 해당 이미지를 받아 처리하는 서브젝트
   private let deleteImageURLSubject             = PublishSubject<String>()
+  
+  /// 현재 저장되어있는 이미지의 상태를 받고 처리하는 서브젝트
   private let imagesStateSubject                = PublishSubject<[String]>()
+  
+  /// 업로드 또는 수정 버튼이 눌렸을 때를 받고, 파이프라인을 구성할 서브젝트
   private let completeButtonTappedSubject       = PublishSubject<Void>()
+  
+  /// 해당 ViewModel을 갖고있는 ViewController가 pop되어야할 때를 알려주기 위한 서브젝트
   private let popViewControllerSubject          = PublishSubject<Void>()
   
   // MARK: Use Cases

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
@@ -20,6 +20,9 @@ protocol ArchiveUploadViewModelType {
   var selectedCellIndexPathObserver: AnyObserver<IndexPath> { get }
   
   // Output
+  
+  /// 사진 업로드를 위해 바텀시트를 보여주어야할 때 사용됩니다.
+  var presentPhotoBottomSheetObservable: Observable<Void> { get }
 }
 
 final class ArchiveUploadViewModel {
@@ -81,6 +84,16 @@ extension ArchiveUploadViewModel: ArchiveUploadViewModelType {
   
   var selectedCellIndexPathObserver: AnyObserver<IndexPath> {
     selectedCellIndexPathSubject.asObserver()
+  }
+  
+  // MARK: Output
+  
+  var presentPhotoBottomSheetObservable: Observable<Void> {
+    selectedCellIndexPathSubject
+      .filter { [weak self] indexPath in
+        self?.archivesContents.count == indexPath.item // `사진 추가`셀은 항상 마지막에 존재
+      }
+      .map { _ in Void() }
   }
 }
 

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
@@ -283,7 +283,10 @@ private extension ArchiveUploadViewModel {
       return
     }
     
-    
+    // 함수가 끝나면 snapshot apply 적용
+    defer {
+      dataSource?.apply(snapshot)
+    }
     
     var uploadedItems = Set(snapshot.itemIdentifiers
       .compactMap { item -> String? in
@@ -300,10 +303,12 @@ private extension ArchiveUploadViewModel {
     let itemsToAdd = Set(archivesContents).subtracting(uploadedItems).map { Item.picture($0) }
     snapshot.appendItems(itemsToAdd)
     
-    snapshot.moveItem(addPictureItem, afterItem: snapshot.itemIdentifiers.last!)
+    guard let lastItem = snapshot.itemIdentifiers.last
+    else {
+      return
+    }
     
-    
-    dataSource?.apply(snapshot)
+    snapshot.moveItem(addPictureItem, afterItem: lastItem)
   }
 }
 

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
@@ -26,6 +26,9 @@ protocol ArchiveUploadViewModelType {
   
   /// 사진 업로드를 위해 바텀시트를 보여주어야할 때 사용됩니다.
   var presentPhotoBottomSheetObservable: Observable<Void> { get }
+  
+  /// 수정 및 업로드 버튼의 활성화 유무를 판단합니다.
+  var buttonEnabledObservable: Observable<Bool> { get }
 }
 
 final class ArchiveUploadViewModel {
@@ -41,6 +44,7 @@ final class ArchiveUploadViewModel {
   private var archivesContents = [String]() {
     didSet {
       updateSnapshots()
+      imagesStateSubject.onNext(archivesContents)
     }
   }
   
@@ -51,6 +55,7 @@ final class ArchiveUploadViewModel {
   private let selectedImageSubject         = PublishSubject<UIImage>()
   private let archiveTitleSubject          = BehaviorSubject<String>(value: "")
   private let deleteImageURLSubject        = PublishSubject<String>()
+  private let imagesStateSubject           = PublishSubject<[String]>()
   
   // MARK: Use Cases
   
@@ -144,6 +149,12 @@ extension ArchiveUploadViewModel: ArchiveUploadViewModelType {
         self?.archivesContents.count == indexPath.item // `사진 추가`셀은 항상 마지막에 존재
       }
       .map { _ in Void() }
+  }
+  
+  var buttonEnabledObservable: Observable<Bool> {
+    .combineLatest(imagesStateSubject, archiveTitleSubject) {
+      !$0.isEmpty && !$1.isEmpty
+    }
   }
 }
 

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModel.swift
@@ -55,10 +55,16 @@ final class ArchiveUploadViewModel {
   
   private let getArchiveDetailUseCase: GetArchiveDetailUseCase
   private let uploadImageUseCase: UploadImageUseCase
+  private let deleteImageUseCase: DeleteImageUseCase
   
-  init(getArchiveDetailUseCase: GetArchiveDetailUseCase, uploadImageUseCase: UploadImageUseCase) {
+  init(
+    getArchiveDetailUseCase: GetArchiveDetailUseCase,
+    uploadImageUseCase: UploadImageUseCase,
+    deleteImageUseCase: DeleteImageUseCase
+  ) {
     self.getArchiveDetailUseCase = getArchiveDetailUseCase
     self.uploadImageUseCase = uploadImageUseCase
+    self.deleteImageUseCase = deleteImageUseCase
     
     fetchArchives()
     uploadImageAndUpdateView()

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModelFactory.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModelFactory.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 
 protocol ArchiveUploadViewModelFactory {
-  static func make(plubbingID: Int, archiveID: Int) -> ArchiveUploadViewModel
+  static func make(plubbingID: Int, archiveID: Int?) -> ArchiveUploadViewModel
 }
 
 /// 아카이브 수정 시 필요한 ViewModel을 생성하는 Factory
@@ -18,7 +18,7 @@ final class ArchiveUploadViewModelWithEditFactory: ArchiveUploadViewModelFactory
   
   private init() { }
   
-  static func make(plubbingID: Int, archiveID: Int) -> ArchiveUploadViewModel {
+  static func make(plubbingID: Int, archiveID: Int?) -> ArchiveUploadViewModel {
     return ArchiveUploadViewModel(
       getArchiveDetailUseCase: DefaultGetArchiveDetailUseCase(plubbingID: plubbingID, archiveID: archiveID),
       uploadImageUseCase: DefaultUploadImageUseCase(),
@@ -31,15 +31,16 @@ final class ArchiveUploadViewModelWithEditFactory: ArchiveUploadViewModelFactory
   private class EditArchiveUseCaseAdapter: UploadArchiveUseCase {
     
     private let plubbingID: Int
-    private let archiveID: Int
+    private let archiveID: Int?
     
-    init(plubbingID: Int, archiveID: Int) {
+    init(plubbingID: Int, archiveID: Int?) {
       self.plubbingID = plubbingID
       self.archiveID = archiveID
     }
     
     func execute(title: String, images: [String]) -> Observable<BaseService.EmptyModel> {
-      DefaultEditArchiveUseCase(plubbingID: plubbingID, archiveID: archiveID).execute(title: title, images: images)
+      guard let archiveID else { return .error(PLUBError<GeneralResponse<BaseService.EmptyModel>>.unknownedError) }
+      return DefaultEditArchiveUseCase(plubbingID: plubbingID, archiveID: archiveID).execute(title: title, images: images)
     }
   }
 }
@@ -49,7 +50,7 @@ final class ArchiveUploadViewModelWithUploadFactory: ArchiveUploadViewModelFacto
   
   private init() { }
   
-  static func make(plubbingID: Int, archiveID: Int = -1) -> ArchiveUploadViewModel {
+  static func make(plubbingID: Int, archiveID: Int? = nil) -> ArchiveUploadViewModel {
     return ArchiveUploadViewModel(
       getArchiveDetailUseCase: GetArchiveDetailUseCaseAdapter(),
       uploadImageUseCase: DefaultUploadImageUseCase(),
@@ -61,7 +62,7 @@ final class ArchiveUploadViewModelWithUploadFactory: ArchiveUploadViewModelFacto
   /// GetArchiveDetailUseCase 어댑터
   private class GetArchiveDetailUseCaseAdapter: GetArchiveDetailUseCase {
     func execute() -> Observable<ArchiveContent> {
-      .just(ArchiveContent(archiveID: -1, title: "", images: [], imageCount: 0, sequence: 0, postDate: "", accessType: .normal))
+      .just(ArchiveContent(archiveID: nil, title: "", images: [], imageCount: 0, sequence: 0, postDate: "", accessType: .normal))
     }
   }
 }

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModelFactory.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModelFactory.swift
@@ -20,7 +20,8 @@ final class ArchiveUploadViewModelWithEditFactory: ArchiveUploadViewModelFactory
   
   static func make(plubbingID: Int, archiveID: Int) -> ArchiveUploadViewModel {
     return ArchiveUploadViewModel(
-      getArchiveDetailUseCase: DefaultGetArchiveDetailUseCase(plubbingID: plubbingID, archiveID: archiveID)
+      getArchiveDetailUseCase: DefaultGetArchiveDetailUseCase(plubbingID: plubbingID, archiveID: archiveID),
+      uploadImageUseCase: DefaultUploadImageUseCase()
     )
   }
 }
@@ -32,7 +33,8 @@ final class ArchiveUploadViewModelWithUploadFactory: ArchiveUploadViewModelFacto
   
   static func make(plubbingID: Int, archiveID: Int = -1) -> ArchiveUploadViewModel {
     return ArchiveUploadViewModel(
-      getArchiveDetailUseCase: GetArchiveDetailUseCaseAdapter()
+      getArchiveDetailUseCase: GetArchiveDetailUseCaseAdapter(),
+      uploadImageUseCase: DefaultUploadImageUseCase()
     )
   }
   

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModelFactory.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModelFactory.swift
@@ -21,7 +21,8 @@ final class ArchiveUploadViewModelWithEditFactory: ArchiveUploadViewModelFactory
   static func make(plubbingID: Int, archiveID: Int) -> ArchiveUploadViewModel {
     return ArchiveUploadViewModel(
       getArchiveDetailUseCase: DefaultGetArchiveDetailUseCase(plubbingID: plubbingID, archiveID: archiveID),
-      uploadImageUseCase: DefaultUploadImageUseCase()
+      uploadImageUseCase: DefaultUploadImageUseCase(),
+      deleteImageUseCase: DefaultDeleteImageUseCase()
     )
   }
 }
@@ -34,7 +35,8 @@ final class ArchiveUploadViewModelWithUploadFactory: ArchiveUploadViewModelFacto
   static func make(plubbingID: Int, archiveID: Int = -1) -> ArchiveUploadViewModel {
     return ArchiveUploadViewModel(
       getArchiveDetailUseCase: GetArchiveDetailUseCaseAdapter(),
-      uploadImageUseCase: DefaultUploadImageUseCase()
+      uploadImageUseCase: DefaultUploadImageUseCase(),
+      deleteImageUseCase: DefaultDeleteImageUseCase()
     )
   }
   

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModelFactory.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveUploadViewModelFactory.swift
@@ -22,8 +22,25 @@ final class ArchiveUploadViewModelWithEditFactory: ArchiveUploadViewModelFactory
     return ArchiveUploadViewModel(
       getArchiveDetailUseCase: DefaultGetArchiveDetailUseCase(plubbingID: plubbingID, archiveID: archiveID),
       uploadImageUseCase: DefaultUploadImageUseCase(),
-      deleteImageUseCase: DefaultDeleteImageUseCase()
+      deleteImageUseCase: DefaultDeleteImageUseCase(),
+      uploadArchiveUseCase: EditArchiveUseCaseAdapter(plubbingID: plubbingID, archiveID: archiveID)
     )
+  }
+  
+  /// Edit use case를 UploadUseCase와 연결하기 위한 Adapter
+  private class EditArchiveUseCaseAdapter: UploadArchiveUseCase {
+    
+    private let plubbingID: Int
+    private let archiveID: Int
+    
+    init(plubbingID: Int, archiveID: Int) {
+      self.plubbingID = plubbingID
+      self.archiveID = archiveID
+    }
+    
+    func execute(title: String, images: [String]) -> Observable<BaseService.EmptyModel> {
+      DefaultEditArchiveUseCase(plubbingID: plubbingID, archiveID: archiveID).execute(title: title, images: images)
+    }
   }
 }
 
@@ -36,7 +53,8 @@ final class ArchiveUploadViewModelWithUploadFactory: ArchiveUploadViewModelFacto
     return ArchiveUploadViewModel(
       getArchiveDetailUseCase: GetArchiveDetailUseCaseAdapter(),
       uploadImageUseCase: DefaultUploadImageUseCase(),
-      deleteImageUseCase: DefaultDeleteImageUseCase()
+      deleteImageUseCase: DefaultDeleteImageUseCase(),
+      uploadArchiveUseCase: DefaultUploadArchiveUseCase(plubbingID: plubbingID)
     )
   }
   


### PR DESCRIPTION
## 📌 PR 요약

### 🌱 작업한 내용

- 업로드를 구현하기 위해 Network Service 일부 구현
   - ImageService의 deleteImage 구현

- UseCase 추가
   - UploadImageUseCase: 이미지 업로드
   - DeleteImageUseCase: 이미지 삭제
   - UploadArchiveUseCase: 아카이브 업로드
   - EditArchiveUseCase: 아카이브 수정

- 그 외 ArchiveUploadViewModel과 ArchiveUploadViewController간 파이프라인 연동
- 이미지 사진 제거 기능도 구현하였으나, 서버에서 이미지 제거 API에 문제가 생겨 스크린샷으로는 보여드리지 못하는 점 양해 바랍니다.


### 🌱 PR 포인트

#### 사진 추가 플로우

- `사진 추가 셀 선택` -> `ViewController에게 알려줌` -> `BottomSheet present` -> `사진 선택` -> `선택된 사진을 ViewModel에게 전달` -> `ViewModel이 사진 업로드 API 호출` -> `응답으로 받은 이미지 주소를 archiveContents에 저장` -> `snapshot update` -> `Cell Registration에서 이미지 주소를 가지고 configure 호출` -> `Cell View Update`

#### 사진 제거 플로우

- `셀의 삭제 버튼 인식` -> `셀은 갖고있는 이미지 주소를 ViewModel에게 전달` -> `ViewModel의 이미지 삭제 API 호출(UseCase 사용)` -> `ViewModel이 갖고있는 archiveContents 중에 이미지 주소와 겹치는 값 삭제` -> `snapshot update` -> `cell 제거`

#### 업로드(또는 수정)버튼 활성화 플로우

1. `HeaderView가 갖고있는 textField가 변경됨` -> `ViewModel에게 알림(delegate)`
2. `업로드된 사진을 갖는 archiveContents가 업데이트 될 때마다 Subject로 계속 값을 emit`
3. `1번`과 `2번`을 묶어 전부 비어있지 않으면 버튼 활성화가 될 수 있도록 처리(combineLatest 사용)



## 📸 스크린샷

|영상|영상 이후 적용된 아카이브|
|:--:|:-:|
|![아카이브 업로드 시나리오](https://user-images.githubusercontent.com/57972338/233888126-472dd49d-15e8-4a3d-bd6b-727742ccdaf3.gif)|![](https://user-images.githubusercontent.com/57972338/233888870-8fee07af-33f2-4d2d-a0d0-784a71dfcbaa.png)|

## 📮 관련 이슈
- Resolved: #299

