### PR TITLE
댓글 작성란 - 프로필 이미지 UI 구현

### DIFF
--- a/PLUB/Sources/Views/Home/Clipboard/Component/CommentInputView.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/CommentInputView.swift
@@ -126,7 +126,7 @@ final class CommentInputView: UIView {
   }
   
   private func bind() {
-    
+    // 프로필 이미지 설정
     AccountService.shared.inquireMyInfo()
       .compactMap { result -> String? in
         guard case let .success(response) = result else { return nil }
@@ -137,7 +137,7 @@ final class CommentInputView: UIView {
       }
       .disposed(by: disposeBag)
     
-    
+    // 댓글 작성 버튼 탭
     uploadButton.rx.tap
       .asDriver()
       .drive(with: self) { owner, _ in

--- a/PLUB/Sources/Views/Home/Clipboard/Component/CommentInputView.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/CommentInputView.swift
@@ -100,26 +100,26 @@ final class CommentInputView: UIView {
   private func setupConstraints() {
     
     commentStackView.snp.makeConstraints {
-      $0.directionalVerticalEdges.equalToSuperview().inset(8)
-      $0.directionalHorizontalEdges.equalToSuperview().inset(24)
+      $0.directionalVerticalEdges.equalToSuperview().inset(Margin.vertical)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(Margin.horizontal)
     }
     
     profileImageView.snp.makeConstraints {
-      $0.size.equalTo(32)
+      $0.size.equalTo(Size.initialStateHeight)
     }
     
     textView.snp.makeConstraints {
-      $0.height.greaterThanOrEqualTo(32)
+      $0.height.greaterThanOrEqualTo(Size.initialStateHeight)
     }
     
     uploadButton.snp.makeConstraints {
-      $0.size.equalTo(32)
+      $0.size.equalTo(Size.initialStateHeight)
     }
     
     commentSeparatorLineView.snp.makeConstraints {
       $0.top.equalToSuperview()
       $0.directionalHorizontalEdges.equalToSuperview()
-      $0.height.equalTo(1)
+      $0.height.equalTo(Size.barHeight)
     }
   }
   
@@ -157,13 +157,15 @@ final class CommentInputView: UIView {
         let size = CGSize(width: owner.textView.frame.width, height: .infinity)
         let estimatedSize = owner.textView.sizeThatFits(size)
         owner.textView.snp.remakeConstraints {
-          $0.height.greaterThanOrEqualTo(32).priority(.required)
+          $0.height.greaterThanOrEqualTo(Size.initialStateHeight).priority(.required)
           $0.height.equalTo(estimatedSize.height).priority(.high)
         }
       }
       .disposed(by: disposeBag)
   }
 }
+
+// MARK: - UITextViewDelegate
 
 extension CommentInputView: UITextViewDelegate {
   func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
@@ -176,8 +178,20 @@ extension CommentInputView: UITextViewDelegate {
   }
 }
 
-extension CommentInputView {
+// MARK: - Constants
+
+private extension CommentInputView {
   enum Constants {
     static let placeholder = "댓글을 입력하세요"
+  }
+  
+  enum Size {
+    static let initialStateHeight = 32
+    static let barHeight          = 1
+  }
+  
+  enum Margin {
+    static let vertical   = 8
+    static let horizontal = 16
   }
 }

--- a/PLUB/Sources/Views/Home/Clipboard/Component/CommentInputView.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/CommentInputView.swift
@@ -124,6 +124,18 @@ final class CommentInputView: UIView {
   }
   
   private func bind() {
+    
+    AccountService.shared.inquireMyInfo()
+      .compactMap { result -> String? in
+        guard case let .success(response) = result else { return nil }
+        return response.data?.profileImage
+      }
+      .subscribe(with: self) { owner, profileImage in
+        owner.profileImageView.kf.setImage(with: URL(string: profileImage))
+      }
+      .disposed(by: disposeBag)
+    
+    
     uploadButton.rx.tap
       .asDriver()
       .drive(with: self) { owner, _ in

--- a/PLUB/Sources/Views/Home/Clipboard/Component/CommentInputView.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/CommentInputView.swift
@@ -50,6 +50,8 @@ final class CommentInputView: UIView {
   
   private let profileImageView = UIImageView(image: .init(named: "userDefaultImage")).then {
     $0.contentMode = .scaleAspectFit
+    $0.clipsToBounds = true
+    $0.layer.cornerRadius = CGFloat(Size.initialStateHeight) * 0.5
   }
   
   private let textViewContainerView = UIStackView().then {


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 댓글작성란 왼쪽에 사용자의 프로필 이미지가 보이도록 설정
- 댓글 작성란 뷰(CommentInputView)에서 직접 AccountService를 호출해서 적용시켰습니다. UseCase로 빼는 것이 오히려 복잡도가 높아지고 가독성에 좋지 않아 오버엔지니어링이 되는 것 같았습니다.

## 📸 스크린샷

|사용자 A| 사용자 B|
|:--:|:-:|
|![Simulator Screenshot - iPhone 14 Pro - 2023-04-24 at 14 48 14](https://user-images.githubusercontent.com/57972338/233910065-b359f111-5cfc-4c55-99ea-b85ad76b9bca.png)|![IMG_B34E5670323D-1](https://user-images.githubusercontent.com/57972338/233910716-195e59f5-fd6b-4c13-9269-da9406de121c.jpeg)|


## 📮 관련 이슈
- #302

