### PR TITLE
아카이브 화면 - 바텀시트 구현

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 		BAC923DF29546BF500385841 /* BirthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC923DE29546BF500385841 /* BirthViewController.swift */; };
 		BAC9794529CF0E9E00A5DF1B /* CommentInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC9794429CF0E9E00A5DF1B /* CommentInputView.swift */; };
 		BACEE33329E6F393009FAB98 /* CropViewController in Frameworks */ = {isa = PBXBuildFile; productRef = BACEE33229E6F393009FAB98 /* CropViewController */; };
+		BADD8B4629F907F700C93C4A /* ArchiveBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADD8B4529F907F700C93C4A /* ArchiveBottomSheetViewController.swift */; };
 		BAE0AC7129B5D61800F46F3D /* BoardDetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE0AC7029B5D61800F46F3D /* BoardDetailCollectionViewCell.swift */; };
 		BAE0AC7629B5D67D00F46F3D /* BoardDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE0AC7429B5D67D00F46F3D /* BoardDetailViewController.swift */; };
 		BAE0AC7729B5D67D00F46F3D /* BoardDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE0AC7529B5D67D00F46F3D /* BoardDetailViewModel.swift */; };
@@ -621,6 +622,7 @@
 		BAC8930829755B87000D44E2 /* SignUpRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequest.swift; sourceTree = "<group>"; };
 		BAC923DE29546BF500385841 /* BirthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthViewController.swift; sourceTree = "<group>"; };
 		BAC9794429CF0E9E00A5DF1B /* CommentInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentInputView.swift; sourceTree = "<group>"; };
+		BADD8B4529F907F700C93C4A /* ArchiveBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveBottomSheetViewController.swift; sourceTree = "<group>"; };
 		BAE058E528EC7CEC00F09BD8 /* PLUB.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PLUB.entitlements; sourceTree = "<group>"; };
 		BAE0AC7029B5D61800F46F3D /* BoardDetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailCollectionViewCell.swift; sourceTree = "<group>"; };
 		BAE0AC7429B5D67D00F46F3D /* BoardDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailViewController.swift; sourceTree = "<group>"; };
@@ -1347,6 +1349,7 @@
 			isa = PBXGroup;
 			children = (
 				BA57F3FC29ED5D6600A9F790 /* ArchiveUploadHeaderView.swift */,
+				BADD8B4529F907F700C93C4A /* ArchiveBottomSheetViewController.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -2630,6 +2633,7 @@
 				C3E98EAD2974759800E36C45 /* MeetingNameViewModel.swift in Sources */,
 				C3ED8FB72989B87E002F689B /* CreateMeetingResponse.swift in Sources */,
 				BA88125028E48A2F00BD832A /* SceneDelegate.swift in Sources */,
+				BADD8B4629F907F700C93C4A /* ArchiveBottomSheetViewController.swift in Sources */,
 				C344E5412986B9D7009F73A9 /* MeetingCategoryViewModel.swift in Sources */,
 				BA4BD1AE29D6C4A800334C04 /* PagingManager.swift in Sources */,
 				7028770929AA6B3D00E57509 /* CategoryMeetingRequest.swift in Sources */,

--- a/PLUB/Sources/Views/Home/Archive/ArchiveViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveViewController.swift
@@ -44,6 +44,7 @@ final class ArchiveViewController: BaseViewController {
   )
   
   private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()).then {
+    $0.showsVerticalScrollIndicator = false
     $0.backgroundColor = .background
     $0.register(ArchiveCollectionViewCell.self, forCellWithReuseIdentifier: ArchiveCollectionViewCell.identifier)
   }
@@ -148,6 +149,13 @@ final class ArchiveViewController: BaseViewController {
           viewModel: ArchiveUploadViewModelWithUploadFactory.make(plubbingID: tuple.plubbingID)
         )
         owner.navigationController?.pushViewController(uploadVC, animated: true)
+      }
+      .disposed(by: disposeBag)
+    
+    // 바텀시트를 보여줘야 하는 경우
+    viewModel.presentBottomSheetObservable
+      .subscribe(with: self) { owner, accessType in
+        
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/Archive/ArchiveViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/ArchiveViewController.swift
@@ -155,9 +155,19 @@ final class ArchiveViewController: BaseViewController {
     // 바텀시트를 보여줘야 하는 경우
     viewModel.presentBottomSheetObservable
       .subscribe(with: self) { owner, accessType in
-        
+        let bottomSheetVC = ArchiveBottomSheetViewController(accessType: accessType)
+        bottomSheetVC.delegate = owner
+        owner.present(bottomSheetVC, animated: true)
       }
       .disposed(by: disposeBag)
+  }
+}
+
+// MARK: - ArchiveBottomSheetDelegate
+
+extension ArchiveViewController: ArchiveBottomSheetDelegate {
+  func buttonTapped(type: ArchiveBottomSheetViewController.SelectedType) {
+    viewModel.bottomSheetTypeObserver.onNext(type)
   }
 }
 

--- a/PLUB/Sources/Views/Home/Archive/Cell/ArchiveCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Archive/Cell/ArchiveCollectionViewCell.swift
@@ -13,11 +13,21 @@ import RxCocoa
 import SnapKit
 import Then
 
+protocol ArchiveCollectionViewCellDelegate: AnyObject {
+  func settingButtonTapped(archiveID: Int?)
+}
+
 final class ArchiveCollectionViewCell: UICollectionViewCell {
   
   // MARK: - Properties
   
   static let identifier = "\(ArchiveCollectionViewCell.self)"
+  
+  private var archiveID: Int?
+  
+  weak var delegate: ArchiveCollectionViewCellDelegate?
+  
+  private let disposeBag = DisposeBag()
   
   // MARK: - UI Components
   
@@ -109,7 +119,7 @@ final class ArchiveCollectionViewCell: UICollectionViewCell {
     super.init(frame: frame)
     setupLayouts()
     setupConstraints()
-    setupStyles()
+    bind()
   }
   
   required init?(coder: NSCoder) {
@@ -205,8 +215,12 @@ final class ArchiveCollectionViewCell: UICollectionViewCell {
     }
   }
   
-  private func setupStyles() {
-    
+  private func bind() {
+    settingButton.rx.tap
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.settingButtonTapped(archiveID: owner.archiveID)
+      }
+      .disposed(by: disposeBag)
   }
   
   func configure(with model: ArchiveContent) {
@@ -224,6 +238,9 @@ final class ArchiveCollectionViewCell: UICollectionViewCell {
       imageView.isHidden = false
       imageView.kf.setImage(with: URL(string: urlString))
     }
+    
+    // inject archiveID
+    archiveID = model.archiveID
   }
   
   

--- a/PLUB/Sources/Views/Home/Archive/Component/ArchiveBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/Component/ArchiveBottomSheetViewController.swift
@@ -1,0 +1,137 @@
+//
+//  ArchiveBottomSheetViewController.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/04/26.
+//
+
+import UIKit
+
+import RxSwift
+import RxCocoa
+import SnapKit
+import Then
+
+
+protocol ArchiveBottomSheetDelegate: AnyObject {
+  func buttonTapped(type: ArchiveBottomSheetViewController.SelectedType)
+}
+
+final class ArchiveBottomSheetViewController: BottomSheetViewController {
+  
+  // MARK: - Properties
+  
+  private let accessType: ArchiveContent.AccessType
+  
+  weak var delegate: ArchiveBottomSheetDelegate?
+  
+  // MARK: - UI Components
+  
+  private let contentStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 8
+  }
+  
+  private lazy var editArchiveView    = BottomSheetListView(text: "아카이브 수정", image: "editBlack")
+  private lazy var reportArchiveView  = BottomSheetListView(text: "아카이브 신고", image: "lightBeaconMain")
+  private lazy var deleteArchiveView  = BottomSheetListView(text: "아카이브 삭제", image: "trashRed", textColor: .error)
+  
+  // MARK: - Initializations
+  
+  init(accessType: ArchiveContent.AccessType) {
+    self.accessType = accessType
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Configurations
+  
+  override func setupLayouts() {
+    super.setupLayouts()
+    contentView.addSubview(contentStackView)
+    
+    // 신고 UI
+    if accessType != .author {
+      contentStackView.addArrangedSubview(reportArchiveView)
+    } else {
+      // 수정 UI
+      contentStackView.addArrangedSubview(editArchiveView)
+    }
+    
+    if accessType != .normal {
+      contentStackView.addArrangedSubview(deleteArchiveView)
+    }
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    
+    let heightConstraints: (ConstraintMaker) -> Void = {
+      $0.height.equalTo(Metrics.Size.height)
+    }
+    
+    contentStackView.snp.makeConstraints {
+      $0.top.equalToSuperview().inset(Metrics.Margin.top)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(Metrics.Margin.horizontal)
+      $0.bottom.equalToSuperview().inset(Metrics.Margin.bottom)
+    }
+    
+    // 신고 UI Constraints
+    if accessType != .author {
+      reportArchiveView.snp.makeConstraints(heightConstraints)
+    } else {  // 수정 UI Constraints
+      editArchiveView.snp.makeConstraints(heightConstraints)
+    }
+    
+    // 삭제 UI Constraints
+    if accessType != .normal {
+      deleteArchiveView.snp.makeConstraints(heightConstraints)
+    }
+  }
+  
+  override func bind() {
+    super.bind()
+    
+    if accessType != .author {
+      reportArchiveView.button.rx.tap
+        .subscribe(with: self) { owner, _ in
+          owner.delegate?.buttonTapped(type: .report)
+          owner.dismiss(animated: true)
+        }
+        .disposed(by: disposeBag)
+    } else {
+      editArchiveView.button.rx.tap
+        .subscribe(with: self) { owner, _ in
+          owner.delegate?.buttonTapped(type: .edit)
+          owner.dismiss(animated: true)
+        }
+        .disposed(by: disposeBag)
+    }
+    if accessType != .normal {
+      deleteArchiveView.button.rx.tap
+        .subscribe(with: self) { owner, _ in
+          owner.delegate?.buttonTapped(type: .delete)
+          owner.dismiss(animated: true)
+        }
+        .disposed(by: disposeBag)
+    }
+  }
+}
+
+// MARK: - Bottom Sheet Selected Type
+
+extension ArchiveBottomSheetViewController {
+  enum SelectedType {
+    /// 아카이브 수정
+    case edit
+    
+    /// 아카이브 삭제
+    case delete
+    
+    /// 아카이브 신고
+    case report
+  }
+}

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveViewModel.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveViewModel.swift
@@ -32,6 +32,9 @@ protocol ArchiveViewModelType {
   
   /// ArchiveUploadVC를 띄우기 위해 필요한 인자를 받습니다.
   var presentArchiveUploadObservable: Observable<(plubbingID: Int, archiveID: Int)> { get }
+  
+  /// ArchiveBottomSheetVC를 띄웁니다.
+  var presentBottomSheetObservable: Observable<(ArchiveContent.AccessType)> { get }
 }
 
 final class ArchiveViewModel {
@@ -61,6 +64,8 @@ final class ArchiveViewModel {
   private let selectedArchiveCellSubject  = PublishSubject<IndexPath>()
   private let offsetSubject               = PublishSubject<(viewHeight: CGFloat, offset: CGFloat)>()
   private let uploadButtonTappedSubject   = PublishSubject<Void>()
+  private let recentTappedArchiveSubject  = PublishSubject<Int>()
+  private let presentBottomSheetSubject   = PublishSubject<ArchiveContent.AccessType>()
   
   // MARK: - Initialization
   
@@ -158,6 +163,10 @@ extension ArchiveViewModel: ArchiveViewModelType {
       (plubbingID, 0) // 업로드 버튼은 archiveID를 쓰지 않으므로 임의의 값 0을 주입
     }
   }
+  
+  var presentBottomSheetObservable: Observable<(ArchiveContent.AccessType)> {
+    presentBottomSheetSubject.asObservable()
+  }
 }
 
 // MARK: - Diffable DataSources
@@ -217,6 +226,12 @@ extension ArchiveViewModel: ArchiveCollectionViewCellDelegate {
       Log.error("아카이브 설정 버튼이 눌렸는데, archiveID값을 전달받지 못했습니다.")
       return
     }
+    recentTappedArchiveSubject.onNext(archiveID)
     
+    guard let accessType = archiveContents.first(where: { $0.archiveID == archiveID })?.accessType
+    else {
+      return
+    }
+    presentBottomSheetSubject.onNext(accessType)
   }
 }

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveViewModel.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveViewModel.swift
@@ -175,7 +175,8 @@ extension ArchiveViewModel {
   func setCollectionView(_ collectionView: UICollectionView) {
     
     // 단어 그대로 `등록`처리 코드, 셀 후처리할 때 사용됨
-    let registration = CellRegistration { cell, _, item in
+    let registration = CellRegistration { [weak self] cell, _, item in
+      cell.delegate = self
       cell.configure(with: item)
     }
     
@@ -205,5 +206,17 @@ extension ArchiveViewModel {
     snapshot.appendItems(Array(archiveContents[index...]))
     
     dataSource?.apply(snapshot)
+  }
+}
+
+// MARK: - ArchiveCollectionViewCellDelegate
+
+extension ArchiveViewModel: ArchiveCollectionViewCellDelegate {
+  func settingButtonTapped(archiveID: Int?) {
+    guard let archiveID else {
+      Log.error("아카이브 설정 버튼이 눌렸는데, archiveID값을 전달받지 못했습니다.")
+      return
+    }
+    
   }
 }

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveViewModel.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveViewModel.swift
@@ -63,13 +63,13 @@ final class ArchiveViewModel {
   
   // MARK: Subjects
   
-  private let setCollectionViewSubject    = PublishSubject<UICollectionView>()
-  private let selectedArchiveCellSubject  = PublishSubject<IndexPath>()
-  private let offsetSubject               = PublishSubject<(viewHeight: CGFloat, offset: CGFloat)>()
-  private let uploadButtonTappedSubject   = PublishSubject<Void>()
-  private let recentTappedArchiveSubject  = PublishSubject<Int>()
-  private let presentBottomSheetSubject   = PublishSubject<ArchiveContent.AccessType>()
-  private let bottomSheetTypeSubject      = PublishSubject<ArchiveBottomSheetViewController.SelectedType>()
+  private let setCollectionViewSubject      = PublishSubject<UICollectionView>()
+  private let selectedArchiveCellSubject    = PublishSubject<IndexPath>()
+  private let offsetSubject                 = PublishSubject<(viewHeight: CGFloat, offset: CGFloat)>()
+  private let uploadButtonTappedSubject     = PublishSubject<Void>()
+  private let recentTappedArchiveIDSubject  = PublishSubject<Int>()
+  private let presentBottomSheetSubject     = PublishSubject<ArchiveContent.AccessType>()
+  private let bottomSheetTypeSubject        = PublishSubject<ArchiveBottomSheetViewController.SelectedType>()
   
   // MARK: - Initialization
   
@@ -234,7 +234,7 @@ extension ArchiveViewModel: ArchiveCollectionViewCellDelegate {
       Log.error("아카이브 설정 버튼이 눌렸는데, archiveID값을 전달받지 못했습니다.")
       return
     }
-    recentTappedArchiveSubject.onNext(archiveID)
+    recentTappedArchiveIDSubject.onNext(archiveID)
     
     guard let accessType = archiveContents.first(where: { $0.archiveID == archiveID })?.accessType
     else {

--- a/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveViewModel.swift
+++ b/PLUB/Sources/Views/Home/Archive/ViewModel/ArchiveViewModel.swift
@@ -25,6 +25,9 @@ protocol ArchiveViewModelType {
   /// 업로드 버튼이 눌렸을 때를 인지하기 위한 Observer입니다.
   var uploadButtonObserver: AnyObserver<Void> { get }
   
+  /// Bottom Sheet로부터 선택된 버튼 타입을 방출하는 Observer입니다.
+  var bottomSheetTypeObserver: AnyObserver<ArchiveBottomSheetViewController.SelectedType> { get }
+  
   // Output
   
   /// ArchivePopUpVC를 처리하는데 필요한 인자를 받습니다.
@@ -66,6 +69,7 @@ final class ArchiveViewModel {
   private let uploadButtonTappedSubject   = PublishSubject<Void>()
   private let recentTappedArchiveSubject  = PublishSubject<Int>()
   private let presentBottomSheetSubject   = PublishSubject<ArchiveContent.AccessType>()
+  private let bottomSheetTypeSubject      = PublishSubject<ArchiveBottomSheetViewController.SelectedType>()
   
   // MARK: - Initialization
   
@@ -149,6 +153,10 @@ extension ArchiveViewModel: ArchiveViewModelType {
   
   var uploadButtonObserver: AnyObserver<Void> {
     uploadButtonTappedSubject.asObserver()
+  }
+  
+  var bottomSheetTypeObserver: AnyObserver<ArchiveBottomSheetViewController.SelectedType> {
+    bottomSheetTypeSubject.asObserver()
   }
   
   // MARK: Output


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- API 연동은 다음 PR 때 진행 예정
- 사용자 타입에 따라 바텀시트가 다르게 보입니다.
   - 아카이브 저자, 모임 호스트: 아카이브 삭제 가능
   - 일반 사용자, 모임 호스트: 아카이브 신고 가능
   - 아카이브 저자: 아카이브 수정 가능


## 📸 스크린샷
|토스트는 녹화를 위해 넣었습니다. 실제로는 들어가 있지 않습니다.|
|:--:|
|![Simulator Screen Recording - iPhone 14 Pro - 2023-04-26 at 16 54 47](https://user-images.githubusercontent.com/57972338/234509083-799e9bab-ff74-487d-847b-aea78e8cbc43.gif)|

## 📮 관련 이슈
- #321

