### PR TITLE
[FIX] 지원질문에 대한 오류 해결

### DIFF
--- a/PLUB/Sources/Models/Recruitment/Request/ApplyForRecruitmentRequest.swift
+++ b/PLUB/Sources/Models/Recruitment/Request/ApplyForRecruitmentRequest.swift
@@ -28,7 +28,7 @@ struct ApplyAnswer: Codable, Equatable {
     case answer
   }
   
-  public static func ==(lhs: ApplyAnswer, rhs: ApplyAnswer) -> Bool{
+  static func ==(lhs: ApplyAnswer, rhs: ApplyAnswer) -> Bool{
     return lhs.questionID == rhs.questionID
   }
 }

--- a/PLUB/Sources/Models/Recruitment/Request/ApplyForRecruitmentRequest.swift
+++ b/PLUB/Sources/Models/Recruitment/Request/ApplyForRecruitmentRequest.swift
@@ -28,4 +28,7 @@ struct ApplyAnswer: Codable, Equatable {
     case answer
   }
   
+  public static func ==(lhs: ApplyAnswer, rhs: ApplyAnswer) -> Bool{
+    return lhs.questionID == rhs.questionID
+  }
 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- questionID가 동일한 질문을 질문리스트에 추가되는 오류를 해결하였습니다
- 동일한 questionID를 가진 질문에 대한 정보를 가지지않기위해 ApplyAnswer에 ==함수를 정의하였습니다.

## 📸 수정된 코드
``` swift
struct ApplyAnswer: Codable, Equatable {
  
  /// 질문 고유 Identifier
  let questionID: Int
  
  /// 질문에 맞춰  작성한 응답값
  let answer: String
  
  enum CodingKeys: String, CodingKey {
    case questionID = "questionId"
    case answer
  }
  
  public static func ==(lhs: ApplyAnswer, rhs: ApplyAnswer) -> Bool{
    return lhs.questionID == rhs.questionID
  }
}
```

## 📮 관련 이슈
- Resolved: #306 

