### PR TITLE
[FIX] 모집상세글 화면재진입시 프로필 중복

### DIFF
--- a/PLUB/Sources/Views/Home/Component/IntroduceCategoryInfoView.swift
+++ b/PLUB/Sources/Views/Home/Component/IntroduceCategoryInfoView.swift
@@ -20,16 +20,19 @@ struct IntroduceCategoryInfoViewModel {
 final class IntroduceCategoryInfoView: UIView {
   
   private let meetingRecommendedLabel = UILabel().then {
-    $0.font = .systemFont(ofSize: 32)
+    $0.font = .appFont(family: .nanum, size: 32)
     $0.textColor = .main
     $0.textAlignment = .center
     $0.sizeToFit()
   }
   
-  private let categoryInfoListView = CategoryInfoListView(categoryAlignment: .horizontal, categoryListType: .noLocation)
+  private let categoryInfoListView = CategoryInfoListView(
+    categoryAlignment: .horizontal,
+    categoryListType: .noLocation
+  )
   
   private let meetingImageView = UIImageView().then {
-    $0.contentMode = .scaleAspectFit
+    $0.contentMode = .scaleAspectFill
     $0.layer.cornerRadius = 10
     $0.layer.masksToBounds = true
   }
@@ -46,7 +49,7 @@ final class IntroduceCategoryInfoView: UIView {
   private func configureUI() {
     [meetingRecommendedLabel, categoryInfoListView, meetingImageView].forEach { addSubview($0) }
     meetingRecommendedLabel.snp.makeConstraints {
-      $0.leading.trailing.top.equalToSuperview()
+      $0.directionalHorizontalEdges.top.equalToSuperview()
       $0.height.equalTo(40)
     }
     
@@ -58,8 +61,9 @@ final class IntroduceCategoryInfoView: UIView {
     }
     
     meetingImageView.snp.makeConstraints {
-      $0.top.equalTo(categoryInfoListView.snp.bottom).offset(24)
-      $0.leading.trailing.bottom.equalToSuperview()
+      $0.top.equalTo(categoryInfoListView.snp.bottom).offset(8)
+      $0.directionalHorizontalEdges.bottom.equalToSuperview()
+      $0.height.equalTo(246)
     }
   }
   

--- a/PLUB/Sources/Views/Home/Component/MeetingIntroduceView.swift
+++ b/PLUB/Sources/Views/Home/Component/MeetingIntroduceView.swift
@@ -19,6 +19,7 @@ final class MeetingIntroduceView: UIView {
   
   private let meetingIntroduceLabel = UILabel().then {
     $0.font = .systemFont(ofSize: 18)
+    $0.textAlignment = .justified
     $0.textColor = .black
     $0.sizeToFit()
   }
@@ -44,12 +45,13 @@ final class MeetingIntroduceView: UIView {
     [meetingIntroduceLabel, meetingDescriptionLabel].forEach { addSubview($0) }
     meetingIntroduceLabel.snp.makeConstraints {
       $0.top.leading.equalToSuperview()
+      $0.trailing.lessThanOrEqualToSuperview()
     }
     
     meetingDescriptionLabel.snp.makeConstraints {
       $0.top.equalTo(meetingIntroduceLabel.snp.bottom).offset(16)
-      $0.leading.trailing.bottom.equalToSuperview()
-      $0.width.equalTo(Device.width)
+      $0.directionalHorizontalEdges.equalToSuperview()
+      $0.bottom.lessThanOrEqualToSuperview()
     }
   }
   

--- a/PLUB/Sources/Views/Home/Component/ParticipantListView.swift
+++ b/PLUB/Sources/Views/Home/Component/ParticipantListView.swift
@@ -123,14 +123,10 @@ final class ParticipantImageView: UIImageView {
     fatalError("init(coder:) has not been implemented")
   }
   
-  override func layoutSubviews() {
-    super.layoutSubviews()
-    let imageSize = self.bounds.size
-    layer.cornerRadius = imageSize.width / 2.0
-  }
-  
   private func configureUI() {
     layer.masksToBounds = true
+    layer.cornerRadius = 17
+    image = UIImage(named: "userDefaultImage")
     contentMode = .scaleAspectFill
     snp.makeConstraints {
       $0.size.equalTo(34)

--- a/PLUB/Sources/Views/Home/Component/ParticipantListView.swift
+++ b/PLUB/Sources/Views/Home/Component/ParticipantListView.swift
@@ -81,6 +81,7 @@ final class ParticipantListView: UIView {
   }
   
   func configureUI(with model: [AccountInfo]) {
+    participantListStackView.subviews.forEach { $0.removeFromSuperview() }
     accountInfos = model
     let model = model.compactMap { $0 }
     let joinedCount = model.count

--- a/PLUB/Sources/Views/Home/Component/ParticipantListView.swift
+++ b/PLUB/Sources/Views/Home/Component/ParticipantListView.swift
@@ -40,6 +40,7 @@ final class ParticipantListView: UIView {
     $0.titleLabel?.font = .overLine
     $0.titleLabel?.textAlignment = .center
     $0.layer.masksToBounds = true
+    $0.layer.cornerRadius = 17
     $0.clipsToBounds = true
     $0.isHidden = true
   }
@@ -51,12 +52,6 @@ final class ParticipantListView: UIView {
   
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-  
-  override func layoutSubviews() {
-    super.layoutSubviews()
-    let moreButtonSize = moreButton.bounds.size
-    moreButton.layer.cornerRadius = moreButtonSize.height / 2.0
   }
   
   private func configureUI() {

--- a/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
+++ b/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
@@ -131,15 +131,16 @@ final class DetailRecruitmentViewController: BaseViewController {
     super.setupConstraints()
     
     scrollView.snp.makeConstraints {
-      $0.directionalEdges.width.equalToSuperview() // 타이틀에 대한 너비까지 잡아줌으로써 Vertical Enabled한 UI를 구성
+      $0.directionalEdges.equalToSuperview()
     }
     
     introduceTypeStackView.snp.makeConstraints {
-      $0.directionalEdges.width.equalToSuperview()
+      $0.directionalVerticalEdges.width.equalToSuperview()
     }
     
+    introduceTypeStackView.setCustomSpacing(16, after: introduceCategoryInfoView)
+    
     introduceTagCollectionView.snp.makeConstraints {
-      $0.leading.trailing.equalToSuperview().inset(16)
       $0.height.greaterThanOrEqualTo(48)
     }
     
@@ -150,7 +151,6 @@ final class DetailRecruitmentViewController: BaseViewController {
     }
     
     bottomStackView.snp.makeConstraints {
-      $0.trailing.equalToSuperview().offset(-16.5)
       $0.height.equalTo(46)
     }
   }

--- a/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
+++ b/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
@@ -58,11 +58,10 @@ final class DetailRecruitmentViewController: BaseViewController {
     introduceCategoryTitleView, introduceCategoryInfoView, meetingIntroduceView, introduceTagCollectionView, participantListView, bottomStackView
   ]).then {
     $0.axis = .vertical
-    $0.alignment = .center
-    $0.distribution = .fill
+    $0.distribution = .equalSpacing
     $0.isLayoutMarginsRelativeArrangement = true
     $0.spacing = 24
-    $0.layoutMargins = UIEdgeInsets(top: Device.navigationBarHeight, left: 16.5, bottom: .zero, right: 16.5)
+    $0.layoutMargins = UIEdgeInsets(top: Device.navigationBarHeight, left: 16.5, bottom: 35 + Device.tabBarHeight, right: 16.5)
   }
   
   private lazy var bottomStackView = UIStackView(arrangedSubviews: [surroundMeetingButton, applyButton]).then {

--- a/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
+++ b/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
@@ -207,6 +207,10 @@ final class DetailRecruitmentViewController: BaseViewController {
       })
       .disposed(by: disposeBag)
     
+    viewModel.categories
+      .drive(rx.model)
+      .disposed(by: disposeBag)
+    
     applyButton.rx.tap
       .subscribe(with: self) { owner, _ in
         if !owner.isApplied && !owner.isHost {

--- a/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
+++ b/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
@@ -42,7 +42,7 @@ final class DetailRecruitmentViewController: BaseViewController {
     }
   }
   
-  private var model: DetailRecruitmentModel? {
+  private var model: [String] = [] {
     didSet {
       self.introduceTagCollectionView.reloadData()
     }
@@ -279,22 +279,19 @@ extension DetailRecruitmentViewController: UICollectionViewDelegate, UICollectio
   }
   
   func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    guard let model = model else { return 0 }
-    return model.categories.count
+    return model.count
   }
   
   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    guard let model = model else { return UICollectionViewCell() }
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: IntroduceTagCollectionViewCell.identifier, for: indexPath) as? IntroduceTagCollectionViewCell ?? IntroduceTagCollectionViewCell()
-    cell.configureUI(with: model.categories[indexPath.row])
+    cell.configureUI(with: model[indexPath.row])
     return cell
   }
   
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-    guard let model = model else { return .zero }
     let label = UILabel().then {
       $0.font = .caption
-      $0.text = model.categories[indexPath.row]
+      $0.text = model[indexPath.row]
       $0.sizeToFit()
     }
     let size = label.frame.size

--- a/PLUB/Sources/Views/Home/ViewModel/DetailRecruitmentViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/DetailRecruitmentViewModel.swift
@@ -50,9 +50,9 @@ final class DetailRecruitmentViewModel: DetailRecruitmentViewModelType {
     let selectingCancelApplication = PublishSubject<Void>()
     let selectingEndRecruitment = PublishSubject<Void>()
     
-    self.selectPlubbingID = selectingPlubbingID.asObserver()
-    self.selectCancelApplication = selectingCancelApplication.asObserver()
-    self.selectEndRecruitment = selectingEndRecruitment.asObserver()
+    selectPlubbingID = selectingPlubbingID.asObserver()
+    selectCancelApplication = selectingCancelApplication.asObserver()
+    selectEndRecruitment = selectingEndRecruitment.asObserver()
     
     let fetchingDetail = selectingPlubbingID
       .flatMapLatest(RecruitmentService.shared.inquireDetailRecruitment(plubbingID:))

--- a/PLUB/Sources/Views/Home/ViewModel/DetailRecruitmentViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/DetailRecruitmentViewModel.swift
@@ -122,10 +122,9 @@ final class DetailRecruitmentViewModel: DetailRecruitmentViewModelType {
     }
     .asDriver(onErrorDriveWith: .empty())
     
-    categories = successFetchingDetail.map { response -> [String] in
-      return response.categories
-    }
-    .asDriver(onErrorDriveWith: .empty())
+    categories = successFetchingDetail
+      .map(\.categories)
+      .asDriver(onErrorDriveWith: .empty())
     
     successCancelApplication = requestCancelApplication
       .compactMap { result -> Void? in

--- a/PLUB/Sources/Views/Home/ViewModel/DetailRecruitmentViewModel.swift
+++ b/PLUB/Sources/Views/Home/ViewModel/DetailRecruitmentViewModel.swift
@@ -93,7 +93,7 @@ final class DetailRecruitmentViewModel: DetailRecruitmentViewModelType {
     introduceCategoryInfoViewModel = successFetchingDetail.map { response -> IntroduceCategoryInfoViewModel in
       return IntroduceCategoryInfoViewModel(
         recommendedText: response.goal,
-        meetingImageURL: "",
+        meetingImageURL: response.mainImage,
         meetingImage: nil,
         categoryInfoListModel: .init(
           placeName: response.placeName,


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 모집 상세글 화면 재진입할때마다 참여자 프로필이 중복되어 보여지는 문제를 해결
- Figma상 UI에 대한 레이아웃 변경에 따른 코드 수정
- 모집글에 대한 mainImage에 대한 데이터 뿌려주기
- 프로필이 존재하지않는 유저에 대한 디폴트 이미지 보여주기
- 모집글 추천멘트 폰트 변경

🌱 PR 포인트
- 참여자 더보기버튼 클릭 시 바텀시트보여주는 부분에서 승현님 코드로 변경된 이후에 레이아웃이 꽉 채워지는 부분은 추후에 따로 pr로 빼서 수정하도록 하겠습니다

## 📸 동작영상
https://user-images.githubusercontent.com/39263235/235079784-0cb7bcdd-46a6-4d22-8ea2-1e24015bae2a.mp4


## 📮 관련 이슈
- Resolved: #307 

