### PR TITLE
[FIX] 업로드 시 리퀘스트 여러개 보내는 문제 해결

### DIFF
--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/CreateBoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/CreateBoardViewModel.swift
@@ -75,8 +75,6 @@ final class CreateBoardViewModel: CreateBoardViewModelType {
     let contentNotEmpty = contentExceptPlaceholder
       .map { !$0.isEmpty }
     
-    let postType = selectingPostType.share()
-    
     let uploadImage = whichUploadingImage
       .compactMap { $0 }
       .flatMapLatest { image in
@@ -95,7 +93,7 @@ final class CreateBoardViewModel: CreateBoardViewModelType {
       }
     
     tappedUploadingButton
-      .withLatestFrom(postType)
+      .withLatestFrom(selectingPostType)
       .flatMap { type in
         switch type {
         case .photo:
@@ -145,7 +143,7 @@ final class CreateBoardViewModel: CreateBoardViewModelType {
     isSuccessCreateBoard = isSuccessCreatingBoard
       .asSignal(onErrorSignalWith: .empty())
     
-    uploadButtonIsActivated = postType
+    uploadButtonIsActivated = selectingPostType
       .flatMap { type in
         switch type {
         case .photo:


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 아무런 postType버튼을 누르지않을 시 사진Only에 따른 버튼 활성화 상태 유지
- 업로드 버튼 클릭 시 의도한 리퀘스트 하나만 보내기 

🌱 PR 포인트
- 동작영상을 찍고싶은데 너무 커서 올리지못한점 이해부탁드립니다😭😭

## 📮 관련 이슈
- Resolved: #323 

