### PR TITLE
[REFACTOR] 댓글 내부 로직 리팩토링 + 버그 픽스

### DIFF
--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -25,8 +25,6 @@ final class BoardDetailViewController: BaseViewController {
   // MARK: - UI Components
   
   private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()).then {
-    $0.register(BoardDetailCollectionHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: BoardDetailCollectionHeaderView.identifier)
-    $0.register(BoardDetailCollectionViewCell.self, forCellWithReuseIdentifier: BoardDetailCollectionViewCell.identifier)
     $0.backgroundColor = .background
   }
   

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -1,4 +1,4 @@
-// 
+//
 //  BoardDetailViewController.swift
 //  PLUB
 //
@@ -16,7 +16,7 @@ final class BoardDetailViewController: BaseViewController {
   
   // MARK: - Properties
   
-  private let viewModel: BoardDetailViewModelType & BoardDetailDataStore
+  private let viewModel: BoardDetailViewModelType
   
   /// 터치 및 아래로 스와이프를 인식하기 위한 gesture recognizer
   private let panGesture = UIPanGestureRecognizer(target: BoardDetailViewController.self, action: nil)
@@ -42,7 +42,7 @@ final class BoardDetailViewController: BaseViewController {
   
   // MARK: - Initializations
   
-  init(viewModel: BoardDetailViewModelType & BoardDetailDataStore) {
+  init(viewModel: BoardDetailViewModelType) {
     self.viewModel = viewModel
     super.init(nibName: nil, bundle: nil)
   }
@@ -97,6 +97,7 @@ final class BoardDetailViewController: BaseViewController {
     panGesture.delegate = self
     collectionView.addGestureRecognizer(tapGesture)
     collectionView.addGestureRecognizer(panGesture)
+    collectionView.collectionViewLayout = createLayouts()
     
     // == comment posting delegate ==
     commentInputView.delegate = self
@@ -105,7 +106,6 @@ final class BoardDetailViewController: BaseViewController {
   
   override func bind() {
     super.bind()
-    collectionView.rx.setDelegate(self).disposed(by: disposeBag)
     
     viewModel.decoratorNameObserable
       .subscribe(with: self) { owner, tuple in
@@ -198,34 +198,31 @@ extension BoardDetailViewController: CommentOptionBottomSheetDelegate {
   }
 }
 
-// MARK: - UICollectionViewDelegateFlowLayout
+// MARK: - UICollectionViewLayout
 
-extension BoardDetailViewController: UICollectionViewDelegateFlowLayout {
-  
-  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-    // * section은 1부터 시작, section 순서는 groupID 순과 동일함
-    // * viewModel의 `comments`는 section, item과 상관없이 일차원 배열로 나열되어있음
-    // * 위 배열에서 section과 item의 맞는 모델을 찾아 사이즈를 구해야함
-    // * 따라서 section값에 따른 groupID를 먼저 구하고, groupID가 동일한 배열만을 빼냄
-    // * 빼낸 배열은 item을 인덱스로하여 모델을 가져오도록 구현
-    let groupID = Set(viewModel.comments.map(\.groupID)).sorted()[indexPath.section - 1]
-    let commentsModelsForSection = viewModel.comments
-      .filter { $0.groupID == groupID }
-      .sorted { $0.commentID < $1.commentID }
-    let size = BoardDetailCollectionViewCell.estimatedCommentCellSize(CGSize(width: view.bounds.width, height: 0), commentContent: commentsModelsForSection[indexPath.item])
-    return size
-  }
-  
-  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-    // 첫 번째 section에만 게시글이 보이도록 설정
-    guard section == 0 else { return .zero }
-    // 동적 높이 처리
-    let headerRegistration = BoardDetailViewModel.HeaderRegistration(elementKind: UICollectionView.elementKindSectionHeader) { [viewModel] supplementaryView, elementKind, indexPath in
-      supplementaryView.configure(with: viewModel.content)
+extension BoardDetailViewController {
+  func createLayouts() -> UICollectionViewLayout {
+    return UICollectionViewCompositionalLayout { sectionNumber, _ in
+
+      let item = NSCollectionLayoutItem(layoutSize: .init(widthDimension: .fractionalWidth(1), heightDimension: .estimated(80)))
+      
+      let group = NSCollectionLayoutGroup.vertical(layoutSize: .init(widthDimension: .fractionalWidth(1), heightDimension: .estimated(80)), subitems: [item])
+      
+      let section = NSCollectionLayoutSection(group: group)
+      
+      if sectionNumber == 0 {
+        section.boundarySupplementaryItems = [.init(
+          layoutSize: .init(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .estimated(100)
+          ),
+          elementKind: UICollectionView.elementKindSectionHeader,
+          alignment: .top
+        )]
+      }
+      
+      return section
     }
-    let indexPath = IndexPath(row: 0, section: section)
-    let headerView = collectionView.dequeueConfiguredReusableSupplementary(using: headerRegistration, for: indexPath)
-    return headerView.systemLayoutSizeFitting(CGSize(width: collectionView.frame.width, height: UIView.layoutFittingCompressedSize.height), withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel)
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/Cell/BoardDetailCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Cell/BoardDetailCollectionViewCell.swift
@@ -237,19 +237,3 @@ final class BoardDetailCollectionViewCell: UICollectionViewCell {
     datetimeLabel.text = "\(DateFormatterFactory.commentDate.string(from: date))"
   }
 }
-
-// MARK: - Dynamic Height Sizing
-
-extension BoardDetailCollectionViewCell {
-  
-  /// 댓글을 포함한 셀의 대략적인 높이를 포함한 view의 크기를 리턴합니다.
-  /// - Parameters:
-  ///   - targetSize: 원하는 view의 크기,
-  ///   - comment: 댓글 내용
-  /// - Returns: 댓글 내용이 전부 보일 정도의 대략적인 view의 크기
-  static func estimatedCommentCellSize(_ targetSize: CGSize, commentContent: CommentContent) -> CGSize {
-    let view = BoardDetailCollectionViewCell()
-    view.configure(with: commentContent)
-    return view.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel)
-  }
-}

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -43,12 +43,7 @@ protocol BoardDetailViewModelType: BoardDetailViewModel {
   var showBottomSheetObservable: Observable<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)> { get }
 }
 
-protocol BoardDetailDataStore {
-  var content: BoardModel { get }
-  var comments: Set<CommentContent> { get }
-}
-
-final class BoardDetailViewModel: BoardDetailDataStore {
+final class BoardDetailViewModel {
   
   // MARK: - Properties
   

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -198,8 +198,8 @@ extension BoardDetailViewModel {
         
         var commentsToDelete = Set<CommentContent>() // 삭제할 댓글 집합
         
-        func deleteComments(commentID: Int) {
-          guard let commentToDelete = owner.comments.first(where: { $0.commentID == commentID })
+        func deleteComments(targetID: Int) {
+          guard let commentToDelete = owner.comments.first(where: { $0.commentID == targetID })
           else {
             return
           }
@@ -208,15 +208,15 @@ extension BoardDetailViewModel {
           commentsToDelete.insert(commentToDelete)
           
           // 자식 댓글 삭제
-          let childCommentsToDelete = owner.comments.filter { $0.parentCommentID == commentID }
+          let childCommentsToDelete = owner.comments.filter { $0.parentCommentID == targetID }
           childCommentsToDelete.forEach {
-            deleteComments(commentID: $0.commentID)
+            deleteComments(targetID: $0.commentID)
           }
         }
         
-        deleteComments(commentID: commentID)
+        deleteComments(targetID: commentID)
         
-        // 차집합으로 자신과 자식 댓글까지 제거
+        // 차집합으로 자신과 하위 댓글까지 제거
         owner.comments.subtract(commentsToDelete)
       }
       .disposed(by: disposeBag)


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용

- 댓글 레이아웃을 FlowLayout에서 CompositionalLayout으로 변경했습니다. ([변경한 이유](https://whitehyun.vercel.app/iOS-compositional-layout-1))
- 하위 손자 댓글 부터 삭제되지 않는 버그 수정 ([변경 과정](https://whitehyun.vercel.app/iOS-BFS))
- DiffableDataSource의 Section 타입을 Int에서 Section(enum 타입)으로 변경했습니다.

## 📸 스크린샷
|답답글 삭제 버그 픽스|
|:--:|
|![Simulator Screen Recording - iPhone 14 Pro - 2023-04-30 at 15 42 40](https://user-images.githubusercontent.com/57972338/235340772-798f7510-833a-48f9-b362-928a5af99594.gif)|

## 📮 관련 이슈

- #302
- Resolved: #325

