### PR TITLE
게시글 좋아요 기능 구현

### DIFF
--- a/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
@@ -98,9 +98,10 @@ final class ClipboardViewController: BaseViewController {
     // BoardDetailViewController의 ViewModel에 전달하면서 navigation push 진행
     collectionView.rx.modelSelected(FeedsContent.self)
       .subscribe(with: self) { owner, model in
+        guard let plubbingID = model.plubbingID else { return }
         owner.navigationController?.pushViewController(
           BoardDetailViewController(
-            viewModel: BoardDetailViewModelWithFeedsFactory.make(plubbingID: model.plubbingID!, feedID: model.feedID)
+            viewModel: BoardDetailViewModelWithFeedsFactory.make(plubbingID: plubbingID, feedID: model.feedID)
           ),
           animated: true
         )

--- a/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ClipboardViewController.swift
@@ -100,7 +100,7 @@ final class ClipboardViewController: BaseViewController {
       .subscribe(with: self) { owner, model in
         owner.navigationController?.pushViewController(
           BoardDetailViewController(
-            viewModel: BoardDetailViewModelWithFeedsFactory.make(plubbingID: model.plubbingID!, boardModel: model.toBoardModel)
+            viewModel: BoardDetailViewModelWithFeedsFactory.make(plubbingID: model.plubbingID!, feedID: model.feedID)
           ),
           animated: true
         )

--- a/PLUB/Sources/Views/Home/Clipboard/Component/BoardDetailCollectionHeaderView.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/BoardDetailCollectionHeaderView.swift
@@ -242,8 +242,10 @@ final class BoardDetailCollectionHeaderView: UICollectionReusableView {
     contentLabel.text = model.content
     
     contentImageView.isHidden = model.imageLink == nil
-    if let contentImageLink = model.imageLink, contentImageLink.isEmpty == false {
-      contentImageView.kf.setImage(with: URL(string: contentImageLink)!)
+    if let contentImageLink = model.imageLink,
+       contentImageLink.isEmpty == false,
+       let source = URL(string: contentImageLink) {
+      contentImageView.kf.setImage(with: source)
     }
     commentLabel.text = "달린 댓글 \(model.commentCount)"
     

--- a/PLUB/Sources/Views/Home/Clipboard/Component/BoardDetailCollectionHeaderView.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/BoardDetailCollectionHeaderView.swift
@@ -246,6 +246,28 @@ final class BoardDetailCollectionHeaderView: UICollectionReusableView {
       contentImageView.kf.setImage(with: URL(string: contentImageLink)!)
     }
     commentLabel.text = "달린 댓글 \(model.commentCount)"
+    
+    // 좋아요 버튼 색상 변경
+    guard let isLike = model.isLike else { return }
+    let buttonImage = isLike ? UIImage(named: "heartFilled") : UIImage(named: "heart")
+    heartButton.setImage(buttonImage, for: .normal)
+  }
+}
+
+extension BoardDetailCollectionHeaderView: FeedLikeDelegate {
+  func likeChanged(_ boardLike: Bool) {
+    // heart image
+    let buttonImage = boardLike ? UIImage(named: "heartFilled") : UIImage(named: "heart")
+    heartButton.setImage(buttonImage, for: .normal)
+    
+    // heart count
+    guard let heartCountText = heartCountLabel.text,
+          let heartCount = Int(heartCountText)
+    else {
+      return
+    }
+    
+    heartCountLabel.text = "\(heartCount + (boardLike ? 1 : -1))"
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/Component/BoardDetailCollectionHeaderView.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/BoardDetailCollectionHeaderView.swift
@@ -8,14 +8,25 @@
 import UIKit
 
 import Kingfisher
+import RxSwift
+import RxCocoa
 import SnapKit
 import Then
+
+protocol BoardDetailCollectionHeaderViewDelegate: AnyObject {
+  func didTappedHeartButton()
+  func didTappedSettingButton()
+}
 
 final class BoardDetailCollectionHeaderView: UICollectionReusableView {
   
   // MARK: - Properties
   
   static let identifier = "\(BoardDetailCollectionHeaderView.self)"
+  
+  private let disposeBag = DisposeBag()
+  
+  weak var delegate: BoardDetailCollectionHeaderViewDelegate?
   
   // MARK: - UI Components
   
@@ -135,6 +146,7 @@ final class BoardDetailCollectionHeaderView: UICollectionReusableView {
     setupLayouts()
     setupConstraints()
     setupStyles()
+    bind()
   }
   
   required init?(coder: NSCoder) {
@@ -200,6 +212,20 @@ final class BoardDetailCollectionHeaderView: UICollectionReusableView {
   
   private func setupStyles() {
     backgroundColor = .white
+  }
+  
+  private func bind() {
+    heartButton.rx.tap
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.didTappedHeartButton()
+      }
+      .disposed(by: disposeBag)
+    
+    settingButton.rx.tap
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.didTappedSettingButton()
+      }
+      .disposed(by: disposeBag)
   }
   
   func configure(with model: BoardModel) {

--- a/PLUB/Sources/Views/Home/Clipboard/Model/BoardModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Model/BoardModel.swift
@@ -25,6 +25,9 @@ struct BoardModel {
   /// 작성날짜
   let date: Date
   
+  /// 유저가 게시글에 좋아요를 눌렀는지 여부를 판단합니다.
+  var isLike: Bool?
+  
   /// 좋아요 수
   let likeCount: Int
   
@@ -69,6 +72,7 @@ extension FeedsContent {
       author: nickname,
       authorProfileImageLink: profileImageURL,
       date: dateFormatter.date(from: postDate)!,
+      isLike: isLike,
       likeCount: likeCount,
       commentCount: commentCount,
       title: title,

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -351,6 +351,8 @@ extension BoardDetailViewModel {
     // Header View Registration, 헤더 뷰 후처리에 사용됨
     let headerRegistration = HeaderRegistration(elementKind: UICollectionView.elementKindSectionHeader) { [weak self] supplementaryView, _, _ in
       supplementaryView.configure(with: content)
+      
+      supplementaryView.delegate = self
     }
     
     // dataSource에 cell 등록
@@ -420,6 +422,18 @@ extension BoardDetailViewModel {
     }
     
     dataSource.apply(snapshot)
+  }
+}
+
+// MARK: - BoardDetailCollectionHeaderViewDelegate
+
+extension BoardDetailViewModel: BoardDetailCollectionHeaderViewDelegate {
+  func didTappedHeartButton() {
+    
+  }
+  
+  func didTappedSettingButton() {
+    PLUBToast.makeToast(text: "Setting Button Tapped")
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -47,8 +47,6 @@ final class BoardDetailViewModel {
   
   // MARK: - Properties
   
-  let content: BoardModel
-  
   /// 댓글 정보 모델입니다.
   ///
   /// 댓글 순서는 작성 날짜를 기준으로 정렬되어있습니다.
@@ -89,7 +87,6 @@ final class BoardDetailViewModel {
   // MARK: - Initializations
   
   init(
-    content: BoardModel,
     getFeedDetailUseCase: GetFeedDetailUseCase,
     getCommentsUseCase: GetCommentsUseCase,
     postCommentUseCase: PostCommentUseCase,
@@ -97,7 +94,6 @@ final class BoardDetailViewModel {
     editCommentUseCase: EditCommentUseCase,
     likeFeedUseCase: LikeFeedUseCase
   ) {
-    self.content = content
     self.getFeedDetailUseCase = getFeedDetailUseCase
     self.getCommentsUseCase   = getCommentsUseCase
     self.postCommentUseCase   = postCommentUseCase
@@ -105,7 +101,7 @@ final class BoardDetailViewModel {
     self.editCommentUseCase   = editCommentUseCase
     self.likeFeedUseCase      = likeFeedUseCase
     
-    fetchComments()
+    fetchInitialStateUI()
     createComments()
     pagingSetup()
     deleteComments()
@@ -120,7 +116,9 @@ final class BoardDetailViewModel {
 extension BoardDetailViewModel {
   
   /// 댓글 정보를 가져와 초기 상태의 UI를 업데이트합니다.
-  private func fetchComments() {
+  private func fetchInitialStateUI() {
+    
+    let feedObservable = getFeedDetailUseCase.execute()
     
     // PagingManager를 이용하여 댓글을 가져옴
     let commentsObservable = pagingManager.fetchNextPage { [getCommentsUseCase] cursorID in
@@ -128,13 +126,13 @@ extension BoardDetailViewModel {
     }
     
     // 첫 세팅 작업
-    Observable.combineLatest(collectionViewSubject, commentsObservable) {
-      return (collectionView: $0, comments: $1)
+    Observable.combineLatest(collectionViewSubject, feedObservable, commentsObservable) {
+      return (collectionView: $0, feed: $1, comments: $2)
     }
     .take(1)  // 첫 세팅 작업이니만큼 한 번만 실행되어야 합니다.
     .subscribe(with: self) { owner, tuple in
       owner.comments.formUnion(tuple.comments) // 댓글 삽입
-      owner.setCollectionView(tuple.collectionView)
+      owner.setCollectionView(tuple.collectionView, content: tuple.feed.toBoardModel)
       owner.applyInitialSnapshots()
     }
     .disposed(by: disposeBag)
@@ -341,7 +339,7 @@ extension BoardDetailViewModel {
   // MARK: Snapshot & DataSource Part
   
   /// Collection View를 세팅하며, `DiffableDataSource`를 초기화하여 해당 Collection View에 데이터를 지닌 셀을 처리합니다.
-  private func setCollectionView(_ collectionView: UICollectionView) {
+  private func setCollectionView(_ collectionView: UICollectionView, content: BoardModel) {
     
     // 단어 그대로 `등록`처리 코드, 셀 후처리할 때 사용됨
     let registration = CellRegistration { [unowned self] cell, indexPath, id in
@@ -351,7 +349,7 @@ extension BoardDetailViewModel {
     }
     
     // Header View Registration, 헤더 뷰 후처리에 사용됨
-    let headerRegistration = HeaderRegistration(elementKind: UICollectionView.elementKindSectionHeader) { [content] supplementaryView, elementKind, indexPath in
+    let headerRegistration = HeaderRegistration(elementKind: UICollectionView.elementKindSectionHeader) { [weak self] supplementaryView, _, _ in
       supplementaryView.configure(with: content)
     }
     

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModelFactory.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModelFactory.swift
@@ -9,15 +9,14 @@ import Foundation
 
 
 protocol BoardDetailViewModelFactory {
-  static func make(plubbingID: Int, boardModel: BoardModel) -> BoardDetailViewModel
+  static func make(plubbingID: Int, feedID: Int) -> BoardDetailViewModelType
 }
 
 final class BoardDetailViewModelWithFeedsFactory: BoardDetailViewModelFactory {
   
   private init() { }
   
-  static func make(plubbingID: Int, boardModel: BoardModel) -> BoardDetailViewModel {
-    let feedID = boardModel.feedID
+  static func make(plubbingID: Int, feedID: Int) -> BoardDetailViewModelType {
     return BoardDetailViewModel(
       getFeedDetailUseCase: DefaultGetFeedDetailUseCase(plubbingID: plubbingID, feedID: feedID),
       getCommentsUseCase: DefaultGetCommentsUseCase(plubbingID: plubbingID, feedID: feedID),

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModelFactory.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModelFactory.swift
@@ -19,7 +19,6 @@ final class BoardDetailViewModelWithFeedsFactory: BoardDetailViewModelFactory {
   static func make(plubbingID: Int, boardModel: BoardModel) -> BoardDetailViewModel {
     let feedID = boardModel.feedID
     return BoardDetailViewModel(
-      content: boardModel,
       getFeedDetailUseCase: DefaultGetFeedDetailUseCase(plubbingID: plubbingID, feedID: feedID),
       getCommentsUseCase: DefaultGetCommentsUseCase(plubbingID: plubbingID, feedID: feedID),
       postCommentUseCase: DefaultPostCommentUseCase(plubbingID: plubbingID, feedID: feedID),

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -248,7 +248,7 @@ extension MainPageViewController: BoardViewControllerDelegate {
   
   func didTappedBoardCollectionViewCell(plubbingID: Int, content: BoardModel) {
     let vc = BoardDetailViewController(
-      viewModel: BoardDetailViewModelWithFeedsFactory.make(plubbingID: plubbingID, boardModel: content)
+      viewModel: BoardDetailViewModelWithFeedsFactory.make(plubbingID: plubbingID, feedID: content.feedID)
     )
     vc.navigationItem.largeTitleDisplayMode = .never
     navigationController?.pushViewController(vc, animated: true)


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용

- 게시글 좋아요 기능 구현
- BoardDetailViewModelFactory 파라미터 일부 수정
   - 게시글 좋아요 기능을 구현하려면 게시글 상세조회 API를 호출해야하는데, 기존에 받았던 boardModel을 이제는 상세조회 API로부터 받으므로 BoardDetailViewModelFactory.make를 실행할 때 boardModel을 파라미터로 받을 필요가 없어졌습니다.

## 📸 스크린샷
|스크린샷|
|:--:|
|![Simulator Screen Recording - iPhone 14 Pro - 2023-05-01 at 23 29 35](https://user-images.githubusercontent.com/57972338/235467798-a960c6ba-1470-48ec-af7a-9abf5fae550b.gif)|

## 📮 관련 이슈
- #302

