### PR TITLE
[FIX] 모임셀 사이즈 > 디바이스 비율에 맞게 수정

### DIFF
--- a/PLUB/Sources/Views/Meeting/Cell/MeetingCollectionMoreCell.swift
+++ b/PLUB/Sources/Views/Meeting/Cell/MeetingCollectionMoreCell.swift
@@ -12,6 +12,12 @@ import SnapKit
 final class MeetingCollectionMoreCell: UICollectionViewCell {
   static let identifier = "MeetingCollectionMoreCell"
   
+  private let contentStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 23
+    $0.alignment = .center
+  }
+  
   private let imageView = UIImageView().then {
     $0.image = UIImage(named: "plusCircle")
   }
@@ -48,22 +54,26 @@ final class MeetingCollectionMoreCell: UICollectionViewCell {
   }
     
   private func setupLayouts() {
-    [imageView, titleLabel, dimmedView].forEach {
-      addSubview($0)
+    [contentStackView, dimmedView].forEach {
+      contentView.addSubview($0)
+    }
+    
+    [imageView, titleLabel].forEach {
+      contentStackView.addArrangedSubview($0)
     }
   }
     
   private func setupConstraints() {
+    contentStackView.snp.makeConstraints {
+      $0.center.equalToSuperview()
+    }
+    
     imageView.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(163)
       $0.size.equalTo(40)
-      $0.centerX.equalToSuperview()
     }
     
     titleLabel.snp.makeConstraints {
-      $0.top.equalTo(imageView.snp.bottom).offset(23)
-      $0.centerX.equalToSuperview()
-      $0.leading.trailing.equalToSuperview()
+      $0.height.equalTo(50)
     }
     
     dimmedView.snp.makeConstraints {

--- a/PLUB/Sources/Views/Meeting/MeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewController.swift
@@ -81,8 +81,8 @@ final class MeetingViewController: BaseViewController {
     
     collectionView.snp.makeConstraints {
       $0.top.equalTo(meetingTypeControl.snp.bottom).offset(36)
-      $0.leading.trailing.equalToSuperview()
-      $0.height.equalTo(433)
+      $0.directionalHorizontalEdges.equalToSuperview()
+      $0.height.equalTo(Metric.itemHeight)
     }
     
     pageControl.snp.makeConstraints {
@@ -209,7 +209,13 @@ extension MeetingViewController: UICollectionViewDelegate, UICollectionViewDataS
 
 extension MeetingViewController {
   private enum Metric {
-    static let itemSize = CGSize(width: 300, height: 433)
+    static let itemWidth = CGFloat(Device.width - 30 * 2)
+    static let itemHeight = itemWidth * 1.44
+    
+    static let itemSize = CGSize(
+      width: itemWidth,
+      height: itemHeight
+    )
     static let itemSpacing = CGFloat(16)
     
     static var insetX: CGFloat {


### PR DESCRIPTION
## 📌 PR 요약
디바이스 비율에 맞게 모임셀 사이즈를 수정하였습니다.

## 📸 스크린샷

13 mini | 14 pro
-- | --
![IMG_9C2EAD591354-1](https://user-images.githubusercontent.com/77331348/235985566-d9faabf9-abb0-4303-9c4b-a7f42d782bd3.jpeg)  |  ![simulator_screenshot_CB67820E-8A0E-4874-9067-A9550F382561](https://user-images.githubusercontent.com/77331348/235986937-b4490a2a-618d-453c-a245-4c355d7bdd48.png)




## 📮 관련 이슈
- Resolved: #344 

