### PR TITLE
[FIX] 상태코드 200을 제외한 모든 에러가 Alamofire error로 출력되는 버그 수정

### DIFF
--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -152,7 +152,13 @@ class BaseService {
     Single.create { observer in
       
       self.session.request(router)
-        .validate()
+        .validate({ request, response, data in
+          if response.statusCode != 401 {
+            return .success(Void())
+          }
+          let reason = AFError.ResponseValidationFailureReason.unacceptableStatusCode(code: response.statusCode)
+          return .failure(AFError.responseValidationFailed(reason: reason))
+        })
         .responseData { response in
         switch response.result {
         case .success(let data):


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용

Alamofire의 validate()는 `status code` 200에서 300 사이가 아닌 경우 `Interceptor`에서 `retry(_:)`를 실행하게 되는데, 이렇게 되면 `status code`가 404일 때와 같이 `requestError`로 빠져야하는 에러들도 전부 Alamofire Error로 wrapping하여 리턴됩니다. 즉, 요청실패가 나더라도 그 이유를 확인하지 못하는 불상사가 생기게 되는 것입니다.

이는 제 의도와 맞지 않는 동작이었고, custom validate를 구현하여 `status code`가 401인 경우에만 `retry(_:)`를 시도하도록 구현했습니다.


## 📮 관련 이슈
- Resolved: #348

