### PR TITLE
[FEAT] 투두리스트 일부 API 연동

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -104,6 +104,9 @@
 		70C9CC8F2A00864400BEB5F2 /* TodolistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C9CC8E2A00864400BEB5F2 /* TodolistViewModel.swift */; };
 		70C9CC932A01CE8B00BEB5F2 /* TodoCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C9CC922A01CE8B00BEB5F2 /* TodoCollectionHeaderView.swift */; };
 		70C9CC952A03720200BEB5F2 /* InquireTodolistResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C9CC942A03720200BEB5F2 /* InquireTodolistResponse.swift */; };
+		70C9CC9F2A03FE8200BEB5F2 /* CompleteTodolistResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C9CC9E2A03FE8200BEB5F2 /* CompleteTodolistResponse.swift */; };
+		70C9CCA42A03FFC000BEB5F2 /* ProofTodolistRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C9CCA32A03FFC000BEB5F2 /* ProofTodolistRequest.swift */; };
+		70C9CCA62A05044400BEB5F2 /* LikeTodolistResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C9CCA52A05044400BEB5F2 /* LikeTodolistResponse.swift */; };
 		70CF3330299793220077FF47 /* RegisterInterestRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CF332F299793220077FF47 /* RegisterInterestRequest.swift */; };
 		70CF33322998EBC30077FF47 /* RecruitmentFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CF33312998EBC30077FF47 /* RecruitmentFilterViewController.swift */; };
 		70CF3335299920CD0077FF47 /* RecruitmentFilterCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CF3334299920CD0077FF47 /* RecruitmentFilterCollectionViewCell.swift */; };
@@ -510,6 +513,9 @@
 		70C9CC8E2A00864400BEB5F2 /* TodolistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodolistViewModel.swift; sourceTree = "<group>"; };
 		70C9CC922A01CE8B00BEB5F2 /* TodoCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoCollectionHeaderView.swift; sourceTree = "<group>"; };
 		70C9CC942A03720200BEB5F2 /* InquireTodolistResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquireTodolistResponse.swift; sourceTree = "<group>"; };
+		70C9CC9E2A03FE8200BEB5F2 /* CompleteTodolistResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteTodolistResponse.swift; sourceTree = "<group>"; };
+		70C9CCA32A03FFC000BEB5F2 /* ProofTodolistRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProofTodolistRequest.swift; sourceTree = "<group>"; };
+		70C9CCA52A05044400BEB5F2 /* LikeTodolistResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeTodolistResponse.swift; sourceTree = "<group>"; };
 		70CF332F299793220077FF47 /* RegisterInterestRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterInterestRequest.swift; sourceTree = "<group>"; };
 		70CF33312998EBC30077FF47 /* RecruitmentFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecruitmentFilterViewController.swift; sourceTree = "<group>"; };
 		70CF3334299920CD0077FF47 /* RecruitmentFilterCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecruitmentFilterCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -1054,6 +1060,7 @@
 		70727A3829D32E31003DE956 /* Todolist */ = {
 			isa = PBXGroup;
 			children = (
+				70C9CCA22A03FFB600BEB5F2 /* Request */,
 				70727A3929D32E3B003DE956 /* Response */,
 			);
 			path = Todolist;
@@ -1064,6 +1071,8 @@
 			children = (
 				70727A3A29D32E4C003DE956 /* InquireAllTodoTimelineResponse.swift */,
 				70C9CC942A03720200BEB5F2 /* InquireTodolistResponse.swift */,
+				70C9CC9E2A03FE8200BEB5F2 /* CompleteTodolistResponse.swift */,
+				70C9CCA52A05044400BEB5F2 /* LikeTodolistResponse.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1130,6 +1139,14 @@
 				70BD5F34296491C8002CBA89 /* ApplyQuestionHeaderView.swift */,
 			);
 			path = ApplyQuestion;
+			sourceTree = "<group>";
+		};
+		70C9CCA22A03FFB600BEB5F2 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				70C9CCA32A03FFC000BEB5F2 /* ProofTodolistRequest.swift */,
+			);
+			path = Request;
 			sourceTree = "<group>";
 		};
 		70CF332E299793160077FF47 /* Request */ = {
@@ -2672,6 +2689,7 @@
 				70727A3729D32DAA003DE956 /* TodolistService.swift in Sources */,
 				C361743629AFB875006AEAB1 /* MeetingCollectionViewCell.swift in Sources */,
 				BA4CCDF129EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift in Sources */,
+				70C9CCA42A03FFC000BEB5F2 /* ProofTodolistRequest.swift in Sources */,
 				C359FEAA29A08B7E00B2F561 /* ScheduleTitleView.swift in Sources */,
 				BA7255C12992445600A3E8F5 /* PLUBTabBarController.swift in Sources */,
 				70A420B229914B370026E9F9 /* MainCategoryListResponse.swift in Sources */,
@@ -2704,6 +2722,7 @@
 				70C42454296C86A400DECA0D /* HomeMainCollectionHeaderView.swift in Sources */,
 				BAC5EF31298B6F2D00F3955E /* CongratulationViewController.swift in Sources */,
 				70727ABD29DDD519003DE956 /* SelectedCategoryCollectionViewCellModel.swift in Sources */,
+				70C9CCA62A05044400BEB5F2 /* LikeTodolistResponse.swift in Sources */,
 				70F1DFE8297D969000F9BC83 /* RecruitmentRouter.swift in Sources */,
 				BA784FAA2978EB9900E8B06F /* SignUpViewModel.swift in Sources */,
 				702876C229A3751400E57509 /* ArchiveViewController.swift in Sources */,
@@ -2751,6 +2770,7 @@
 				C359FEA8299FE3AB00B2F561 /* CreateScheduleViewModel.swift in Sources */,
 				BA780E1529714AAB0032C178 /* GeneralResponse.swift in Sources */,
 				70727ABF29DE8B82003DE956 /* CategoryModel.swift in Sources */,
+				70C9CC9F2A03FE8200BEB5F2 /* CompleteTodolistResponse.swift in Sources */,
 				C3AD265D296ACC0600C57370 /* MeetingNameViewController.swift in Sources */,
 				BA1FC12B29A62E3600AB3F91 /* FeedsClipboardResponse.swift in Sources */,
 				C38A5B99297ADE8500485355 /* KakaoLocationResponse.swift in Sources */,

--- a/PLUB/Configuration/Utils/DateFormatterFactory.swift
+++ b/PLUB/Configuration/Utils/DateFormatterFactory.swift
@@ -38,7 +38,8 @@ enum DateFormatterFactory {
   
   static var todolistDate: DateFormatter {
     dateFormatter.then { $0.dateFormat = "MM.dd" }
-
+  }
+  
   /// `a h시 m분`
   static var koreanTime: DateFormatter {
     dateFormatter.then { $0.dateFormat = "a h시 m분" }

--- a/PLUB/Sources/Models/Todolist/Request/ProofTodolistRequest.swift
+++ b/PLUB/Sources/Models/Todolist/Request/ProofTodolistRequest.swift
@@ -1,0 +1,12 @@
+//
+//  ProofTodolistRequest.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/05/04.
+//
+
+import Foundation
+
+struct ProofTodolistRequest: Codable {
+  let proofImage: String
+}

--- a/PLUB/Sources/Models/Todolist/Response/CompleteTodolistResponse.swift
+++ b/PLUB/Sources/Models/Todolist/Response/CompleteTodolistResponse.swift
@@ -8,12 +8,28 @@
 import Foundation
 
 struct CompleteProofTodolistResponse: Codable {
+  
+  /// 투두를 나타내는 아이디 값
   let todoID: Int
+  
+  /// 투두 완성 혹은 인증을 하고싶은 투두의 콘텐츠
   let content: String
+  
+  /// 투두가 작성된 일자
   let date: String
+  
+  /// 해당 투두를 체크했는지 안했는지에 대한 여부
   let isChecked: Bool
+  
+  /// 해당 투두가 인증이 된 투두인지 아닌지에 대한 여부
   let isProof: Bool
+  
+  /// 투두 인증모달 이미지 값
+  ///
+  /// 투두 인증에 성공하여 인증성공모달을 띄어줄때 해당 값을 이용하여 이미지를 띄어줍니다.
   let proofImage: String
+  
+  /// 해당 투두의 작성자인지 아닌지에 대한 여부
   let isAuthor: Bool
   
   enum CodingKeys: String, CodingKey {

--- a/PLUB/Sources/Models/Todolist/Response/CompleteTodolistResponse.swift
+++ b/PLUB/Sources/Models/Todolist/Response/CompleteTodolistResponse.swift
@@ -1,0 +1,23 @@
+//
+//  CompleteTodolistResponse.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/05/04.
+//
+
+import Foundation
+
+struct CompleteProofTodolistResponse: Codable {
+  let todoID: Int
+  let content: String
+  let date: String
+  let isChecked: Bool
+  let isProof: Bool
+  let proofImage: String
+  let isAuthor: Bool
+  
+  enum CodingKeys: String, CodingKey {
+    case todoID = "todoId"
+    case content, date, isChecked, isProof, proofImage, isAuthor
+  }
+}

--- a/PLUB/Sources/Models/Todolist/Response/LikeTodolistResponse.swift
+++ b/PLUB/Sources/Models/Todolist/Response/LikeTodolistResponse.swift
@@ -1,0 +1,22 @@
+//
+//  LikeTodolistResponse.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/05/05.
+//
+
+import Foundation
+
+struct LikeTodolistResponse: Codable {
+  let todoTimelineID: Int
+  let date: String
+  let totalLikes: Int
+  let isAuthor: Bool
+  let isLike: Bool
+  let todoList: [Todo]
+  
+  enum CodingKeys: String, CodingKey {
+    case todoTimelineID = "todoTimelineId"
+    case date, totalLikes, isAuthor, isLike, todoList
+  }
+}

--- a/PLUB/Sources/Models/Todolist/Response/LikeTodolistResponse.swift
+++ b/PLUB/Sources/Models/Todolist/Response/LikeTodolistResponse.swift
@@ -8,11 +8,23 @@
 import Foundation
 
 struct LikeTodolistResponse: Codable {
+  
+  /// 투두리스트에 해당하는 타임라인 아이디
   let todoTimelineID: Int
+  
+  /// 해당 투두리스트가 작성된 일자
   let date: String
+  
+  /// 해당 투두리스트의 좋아요 수
   let totalLikes: Int
+  
+  /// 해당 투두리스트의 작성자인지에 대한 여부
   let isAuthor: Bool
+  
+  /// 해당 투두리스트를 내가 좋아요 눌렀는지에 대한 여부
   let isLike: Bool
+  
+  /// 해당 투두리스트의 존재하는 투두
   let todoList: [Todo]
   
   enum CodingKeys: String, CodingKey {

--- a/PLUB/Sources/Network/Foundation/BaseService.swift
+++ b/PLUB/Sources/Network/Foundation/BaseService.swift
@@ -152,7 +152,13 @@ class BaseService {
     Single.create { observer in
       
       self.session.request(router)
-        .validate()
+        .validate({ request, response, data in
+          if response.statusCode != 401 {
+            return .success(Void())
+          }
+          let reason = AFError.ResponseValidationFailureReason.unacceptableStatusCode(code: response.statusCode)
+          return .failure(AFError.responseValidationFailed(reason: reason))
+        })
         .responseData { response in
         switch response.result {
         case .success(let data):

--- a/PLUB/Sources/Network/Routers/TodolistRouter.swift
+++ b/PLUB/Sources/Network/Routers/TodolistRouter.swift
@@ -13,6 +13,7 @@ enum TodolistRouter {
   case completeTodolist(Int, Int)
   case cancelCompleteTodolist(Int, Int)
   case proofTodolist(Int, Int, ProofTodolistRequest)
+  case likeTodolist(Int, Int)
 }
 
 extension TodolistRouter: Router {
@@ -20,7 +21,7 @@ extension TodolistRouter: Router {
     switch self {
     case .inquireAllTodoTimeline, .inquireTodolist:
       return .get
-    case .completeTodolist, .cancelCompleteTodolist:
+    case .completeTodolist, .cancelCompleteTodolist, .likeTodolist:
       return .put
     case .proofTodolist:
       return .post
@@ -39,6 +40,8 @@ extension TodolistRouter: Router {
       return "/plubbings/\(plubbingID)/todolist/\(todolistID)/proof"
     case .cancelCompleteTodolist(let plubbingID, let todolistID):
       return "/plubbings/\(plubbingID)/todolist/\(todolistID)/cancel"
+    case .likeTodolist(let plubbingID, let timelineID):
+      return "/plubbings/\(plubbingID)/timeline/\(timelineID)/like"
     }
   }
   
@@ -46,7 +49,7 @@ extension TodolistRouter: Router {
     switch self {
     case .inquireAllTodoTimeline(_, let cursorID):
       return .query(["cursorId": cursorID])
-    case .inquireTodolist, .completeTodolist, .cancelCompleteTodolist:
+    case .inquireTodolist, .completeTodolist, .cancelCompleteTodolist, .likeTodolist:
       return .plain
     case .proofTodolist(_, _, let request):
       return .body(request)
@@ -55,7 +58,7 @@ extension TodolistRouter: Router {
   
   var headers: HeaderType {
     switch self {
-    case .inquireAllTodoTimeline, .inquireTodolist, .completeTodolist, .proofTodolist, .cancelCompleteTodolist:
+    case .inquireAllTodoTimeline, .inquireTodolist, .completeTodolist, .proofTodolist, .cancelCompleteTodolist, .likeTodolist:
       return .withAccessToken
     }
   }

--- a/PLUB/Sources/Network/Routers/TodolistRouter.swift
+++ b/PLUB/Sources/Network/Routers/TodolistRouter.swift
@@ -10,6 +10,9 @@ import Alamofire
 enum TodolistRouter {
   case inquireAllTodoTimeline(Int, Int)
   case inquireTodolist(Int, Int)
+  case completeTodolist(Int, Int)
+  case cancelCompleteTodolist(Int, Int)
+  case proofTodolist(Int, Int, ProofTodolistRequest)
 }
 
 extension TodolistRouter: Router {
@@ -17,6 +20,10 @@ extension TodolistRouter: Router {
     switch self {
     case .inquireAllTodoTimeline, .inquireTodolist:
       return .get
+    case .completeTodolist, .cancelCompleteTodolist:
+      return .put
+    case .proofTodolist:
+      return .post
     }
   }
   
@@ -26,6 +33,12 @@ extension TodolistRouter: Router {
       return "/plubbings/\(plubbingID)/timeline"
     case .inquireTodolist(let plubbingID, let timelineID):
       return "/plubbings/\(plubbingID)/timeline/\(timelineID)/todolist"
+    case .completeTodolist(let plubbingID, let todolistID):
+      return "/plubbings/\(plubbingID)/todolist/\(todolistID)/complete"
+    case .proofTodolist(let plubbingID, let todolistID, _):
+      return "/plubbings/\(plubbingID)/todolist/\(todolistID)/proof"
+    case .cancelCompleteTodolist(let plubbingID, let todolistID):
+      return "/plubbings/\(plubbingID)/todolist/\(todolistID)/cancel"
     }
   }
   
@@ -33,14 +46,16 @@ extension TodolistRouter: Router {
     switch self {
     case .inquireAllTodoTimeline(_, let cursorID):
       return .query(["cursorId": cursorID])
-    case .inquireTodolist:
+    case .inquireTodolist, .completeTodolist, .cancelCompleteTodolist:
       return .plain
+    case .proofTodolist(_, _, let request):
+      return .body(request)
     }
   }
   
   var headers: HeaderType {
     switch self {
-    case .inquireAllTodoTimeline, .inquireTodolist:
+    case .inquireAllTodoTimeline, .inquireTodolist, .completeTodolist, .proofTodolist, .cancelCompleteTodolist:
       return .withAccessToken
     }
   }

--- a/PLUB/Sources/Network/Services/TodolistService.swift
+++ b/PLUB/Sources/Network/Services/TodolistService.swift
@@ -14,6 +14,11 @@ final class TodolistService: BaseService {
 }
 
 extension TodolistService {
+  
+  /// 전체타임라인을 조회합니다.
+  /// - Parameters:
+  ///   - plubbingID: 플럽 모임 ID
+  ///   - cursorID: 타임라인 페이징을 위한 커서 ID
   func inquireAllTodoTimeline(plubbingID: Int, cursorID: Int = 0) -> PLUBResult<PaginatedDataResponse<InquireAllTodoTimelineResponse>> {
     sendRequest(
       TodolistRouter.inquireAllTodoTimeline(plubbingID, cursorID),
@@ -21,22 +26,43 @@ extension TodolistService {
     )
   }
   
+  /// 투두 상세조회합니다.
+  /// - Parameters:
+  ///   - plubbingID: 플럽 모임 ID
+  ///   - timelineID: 투두에 해당하는 타임라인 ID
   func inquireTodolist(plubbingID: Int, timelineID: Int) -> Observable<InquireTodolistResponse> {
     sendObservableRequest(TodolistRouter.inquireTodolist(plubbingID, timelineID))
   }
   
+  /// 투두리스트 완료요청합니다.
+  /// - Parameters:
+  ///   - plubbingID: 플럽 모임 ID
+  ///   - todolistID: 투두리스트 ID
   func completeTodolist(plubbingID: Int, todolistID: Int) -> Observable<CompleteProofTodolistResponse> {
     sendObservableRequest(TodolistRouter.completeTodolist(plubbingID, todolistID))
   }
   
+  /// 투두리스트 완료취소요청합니다.
+  /// - Parameters:
+  ///   - plubbingID: 플럽 모임 ID
+  ///   - todolistID: 투두리스트 ID
   func cancelCompleteTodolist(plubbingID: Int, todolistID: Int) -> Observable<CompleteProofTodolistResponse> {
     sendObservableRequest(TodolistRouter.cancelCompleteTodolist(plubbingID, todolistID))
   }
   
+  /// 투두리스트 인증요청합니다.
+  /// - Parameters:
+  ///   - plubbingID: 플럽 모임 ID
+  ///   - todolistID: 투두리스트 ID
+  ///   - request: 인증을 위한 이미지 요청모델
   func proofTodolist(plubbingID: Int, todolistID: Int, request: ProofTodolistRequest) -> Observable<CompleteProofTodolistResponse> {
     sendObservableRequest(TodolistRouter.proofTodolist(plubbingID, todolistID, request))
   }
   
+  /// 투두리스트 좋아요/좋아요 취소 요청합니다.
+  /// - Parameters:
+  ///   - plubbingID: 플럽 모임 ID
+  ///   - timelineID: 타임라인 ID
   func likeTodolist(plubbingID: Int, timelineID: Int) -> Observable<LikeTodolistResponse> {
     sendObservableRequest(TodolistRouter.likeTodolist(plubbingID, timelineID))
   }

--- a/PLUB/Sources/Network/Services/TodolistService.swift
+++ b/PLUB/Sources/Network/Services/TodolistService.swift
@@ -37,5 +37,7 @@ extension TodolistService {
     sendObservableRequest(TodolistRouter.proofTodolist(plubbingID, todolistID, request))
   }
   
-  
+  func likeTodolist(plubbingID: Int, timelineID: Int) -> Observable<LikeTodolistResponse> {
+    sendObservableRequest(TodolistRouter.likeTodolist(plubbingID, timelineID))
+  }
 }

--- a/PLUB/Sources/Network/Services/TodolistService.swift
+++ b/PLUB/Sources/Network/Services/TodolistService.swift
@@ -24,4 +24,18 @@ extension TodolistService {
   func inquireTodolist(plubbingID: Int, timelineID: Int) -> Observable<InquireTodolistResponse> {
     sendObservableRequest(TodolistRouter.inquireTodolist(plubbingID, timelineID))
   }
+  
+  func completeTodolist(plubbingID: Int, todolistID: Int) -> Observable<CompleteProofTodolistResponse> {
+    sendObservableRequest(TodolistRouter.completeTodolist(plubbingID, todolistID))
+  }
+  
+  func cancelCompleteTodolist(plubbingID: Int, todolistID: Int) -> Observable<CompleteProofTodolistResponse> {
+    sendObservableRequest(TodolistRouter.cancelCompleteTodolist(plubbingID, todolistID))
+  }
+  
+  func proofTodolist(plubbingID: Int, todolistID: Int, request: ProofTodolistRequest) -> Observable<CompleteProofTodolistResponse> {
+    sendObservableRequest(TodolistRouter.proofTodolist(plubbingID, todolistID, request))
+  }
+  
+  
 }

--- a/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
@@ -15,7 +15,7 @@ import Then
 protocol TodoCollectionViewCellDelegate: AnyObject {
   func didTappedMoreButton()
   func didTappedLikeButton(isLiked: Bool)
-  func didTappedTodo()
+  func didTappedTodo(todoID: Int, isCompleted: Bool)
 }
 
 struct TodoCollectionViewCellModel {
@@ -32,7 +32,7 @@ struct TodoCollectionViewCellModel {
     totalLikes = response.totalLikes
     isLike = response.isLike
     isAuthor = response.isAuthor
-    checkTodoViewModels = response.todoList.map { CheckTodoViewModel(todo: $0.content, isChecked: $0.isChecked) }
+    checkTodoViewModels = response.todoList.map { CheckTodoViewModel(todoID: $0.todoID, todo: $0.content, isChecked: $0.isChecked) }
   }
 }
 
@@ -163,7 +163,7 @@ extension TodoCollectionViewCell {
 }
 
 extension TodoCollectionViewCell: CheckTodoViewDelegate {
-  func didTappedCheckboxButton() {
-    delegate?.didTappedTodo()
+  func didTappedCheckboxButton(todoID: Int, isCompleted: Bool) {
+    delegate?.didTappedTodo(todoID: todoID, isCompleted: isCompleted)
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
@@ -14,11 +14,12 @@ import Then
 
 protocol TodoCollectionViewCellDelegate: AnyObject {
   func didTappedMoreButton()
-  func didTappedLikeButton(isLiked: Bool)
+  func didTappedLikeButton(timelineID: Int)
   func didTappedTodo(todoID: Int, isCompleted: Bool)
 }
 
 struct TodoCollectionViewCellModel {
+  let todoTimelineID: Int
   let date: String
   let profileImageString: String?
   let totalLikes: Int
@@ -27,6 +28,7 @@ struct TodoCollectionViewCellModel {
   let checkTodoViewModels: [CheckTodoViewModel]
   
   init(response: InquireAllTodoTimelineResponse) {
+    todoTimelineID = response.todoTimelineID
     date = response.date
     profileImageString = response.accountInfo?.profileImage
     totalLikes = response.totalLikes
@@ -48,6 +50,7 @@ final class TodoCollectionViewCell: UICollectionViewCell {
   
   static let identifier = "TodoCollectionViewCell"
   private let disposeBag = DisposeBag()
+  private var timelineID: Int?
   weak var delegate: TodoCollectionViewCellDelegate?
   
   private let profileImageView = UIImageView().then {
@@ -150,6 +153,7 @@ final class TodoCollectionViewCell: UICollectionViewCell {
   func configureUI(with model: TodoCollectionViewCellModel) {
     guard let profileImageString = model.profileImageString,
           let url = URL(string: profileImageString) else { return }
+    timelineID = model.todoTimelineID
     profileImageView.kf.setImage(with: url, placeholder: UIImage(named: "userDefaultImage"))
     likeCountLabel.text = "\(model.totalLikes)"
     likeButton.isSelected = model.isLike

--- a/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
@@ -32,7 +32,15 @@ struct TodoCollectionViewCellModel {
     totalLikes = response.totalLikes
     isLike = response.isLike
     isAuthor = response.isAuthor
-    checkTodoViewModels = response.todoList.map { CheckTodoViewModel(todoID: $0.todoID, todo: $0.content, isChecked: $0.isChecked) }
+    checkTodoViewModels = response.todoList.map {
+      CheckTodoViewModel(
+        todoID: $0.todoID,
+        todo: $0.content,
+        isChecked: $0.isChecked,
+        isAuthor: $0.isAuthor,
+        isProof: $0.isProof
+      )
+    }
   }
 }
 

--- a/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
@@ -53,6 +53,12 @@ final class TodoCollectionViewCell: UICollectionViewCell {
   private var timelineID: Int?
   weak var delegate: TodoCollectionViewCellDelegate?
   
+  private var likeCount: Int = 0 {
+    didSet {
+      likeCountLabel.text = "\(likeCount)"
+    }
+  }
+  
   private let profileImageView = UIImageView().then {
     $0.layer.masksToBounds = true
     $0.layer.cornerRadius = 12
@@ -139,13 +145,17 @@ final class TodoCollectionViewCell: UICollectionViewCell {
     
     likeButton.buttonTapObservable
       .subscribe(with: self) { owner, _ in
-        owner.delegate?.didTappedLikeButton(isLiked: true)
+        guard let timelineID = owner.timelineID else { return }
+        owner.delegate?.didTappedLikeButton(timelineID: timelineID)
+        owner.likeCount += 1
       }
       .disposed(by: disposeBag)
     
     likeButton.buttonUnTapObservable
       .subscribe(with: self) { owner, _ in
-        owner.delegate?.didTappedLikeButton(isLiked: false)
+        guard let timelineID = owner.timelineID else { return }
+        owner.delegate?.didTappedLikeButton(timelineID: timelineID)
+        owner.likeCount -= 1
       }
       .disposed(by: disposeBag)
   }
@@ -155,7 +165,7 @@ final class TodoCollectionViewCell: UICollectionViewCell {
           let url = URL(string: profileImageString) else { return }
     timelineID = model.todoTimelineID
     profileImageView.kf.setImage(with: url, placeholder: UIImage(named: "userDefaultImage"))
-    likeCountLabel.text = "\(model.totalLikes)"
+    likeCount = model.totalLikes
     likeButton.isSelected = model.isLike
     model.checkTodoViewModels.forEach { checkTodoVieModel in
       let todoView = CheckTodoView()

--- a/PLUB/Sources/Views/Home/MainPage/Component/CheckTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/CheckTodoView.swift
@@ -26,7 +26,7 @@ struct CheckTodoViewModel {
 final class CheckTodoView: UIView {
   
   weak var delegate: CheckTodoViewDelegate?
-  private var todoID: Int?
+  private var model: CheckTodoViewModel?
   private let disposeBag = DisposeBag()
   
   private let checkboxButton = CheckBoxButton(type: .none)
@@ -70,7 +70,7 @@ final class CheckTodoView: UIView {
   }
   
   func configureUI(with model: CheckTodoViewModel) {
-    self.todoID = model.todoID
+    self.model = model
     todoLabel.text = model.todo
     checkboxButton.isChecked = model.isChecked
   }

--- a/PLUB/Sources/Views/Home/MainPage/Component/CheckTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/CheckTodoView.swift
@@ -12,10 +12,11 @@ import SnapKit
 import Then
 
 protocol CheckTodoViewDelegate: AnyObject {
-  func didTappedCheckboxButton()
+  func didTappedCheckboxButton(todoID: Int, isCompleted: Bool)
 }
 
 struct CheckTodoViewModel {
+  let todoID: Int
   let todo: String
   let isChecked: Bool
 }
@@ -23,6 +24,7 @@ struct CheckTodoViewModel {
 final class CheckTodoView: UIView {
   
   weak var delegate: CheckTodoViewDelegate?
+  private var todoID: Int?
   private let disposeBag = DisposeBag()
   
   private let checkboxButton = CheckBoxButton(type: .none)
@@ -45,7 +47,8 @@ final class CheckTodoView: UIView {
   private func bind() {
     checkboxButton.rx.isChecked
       .subscribe(with: self) { owner, _ in
-        owner.delegate?.didTappedCheckboxButton()
+        guard let todoID = owner.todoID else { return }
+        owner.delegate?.didTappedCheckboxButton(todoID: todoID, isCompleted: owner.checkboxButton.isChecked)
       }
       .disposed(by: disposeBag)
   }
@@ -65,6 +68,7 @@ final class CheckTodoView: UIView {
   }
   
   func configureUI(with model: CheckTodoViewModel) {
+    self.todoID = model.todoID
     todoLabel.text = model.todo
     checkboxButton.isChecked = model.isChecked
   }

--- a/PLUB/Sources/Views/Home/MainPage/Component/CheckTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/CheckTodoView.swift
@@ -49,8 +49,10 @@ final class CheckTodoView: UIView {
   private func bind() {
     checkboxButton.rx.isChecked
       .subscribe(with: self) { owner, _ in
-        guard let todoID = owner.todoID else { return }
-        owner.delegate?.didTappedCheckboxButton(todoID: todoID, isCompleted: owner.checkboxButton.isChecked)
+        guard let model = owner.model else { return }
+        if model.isAuthor && !model.isProof { // 내가 작성했고 인증되있지않은 투두만 완료/인증 가능
+          owner.delegate?.didTappedCheckboxButton(todoID: model.todoID, isCompleted: owner.checkboxButton.isChecked)
+        }
       }
       .disposed(by: disposeBag)
   }
@@ -73,5 +75,9 @@ final class CheckTodoView: UIView {
     self.model = model
     todoLabel.text = model.todo
     checkboxButton.isChecked = model.isChecked
+    
+    // 해당 투두가 인증되었거나 작성자가 아니라면 -> 체크버튼 비활성화
+    checkboxButton.isEnabled = model.isProof || !model.isAuthor ? false : true
+    
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Component/CheckTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/CheckTodoView.swift
@@ -19,6 +19,8 @@ struct CheckTodoViewModel {
   let todoID: Int
   let todo: String
   let isChecked: Bool
+  let isAuthor: Bool
+  let isProof: Bool
 }
 
 final class CheckTodoView: UIView {

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -19,6 +19,8 @@ final class TodolistViewController: BaseViewController {
   
   private let viewModel: TodolistViewModelType
   
+  private let plubbingID: Int
+  
   private var model: [TodolistModel] = [] {
     didSet {
       todoCollectionView.reloadData()
@@ -56,12 +58,18 @@ final class TodolistViewController: BaseViewController {
   
   init(plubbingID: Int, viewModel: TodolistViewModelType = TodolistViewModel()) {
     self.viewModel = viewModel
+    self.plubbingID = plubbingID
     super.init(nibName: nil, bundle: nil)
     bind(plubbingID: plubbingID)
   }
   
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    viewModel.selectPlubbingID.onNext(plubbingID)
   }
   
   override func setupLayouts() {

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -97,6 +97,12 @@ final class TodolistViewController: BaseViewController {
     viewModel.todoTimelineModel
       .drive(rx.model)
       .disposed(by: disposeBag)
+    
+    viewModel.successCompleteTodolist
+      .emit(onNext: { success in
+        print("성공했니 \(success)")
+      })
+      .disposed(by: disposeBag)
   
   }
 }
@@ -143,7 +149,9 @@ extension TodolistViewController: UICollectionViewDelegateFlowLayout {
 }
 
 extension TodolistViewController: TodoCollectionViewCellDelegate {
-  func didTappedTodo() {
+  func didTappedTodo(todoID: Int, isCompleted: Bool) {
+    viewModel.selectTodolistID.onNext(todoID)
+    viewModel.selectComplete.onNext(isCompleted)
     let alert = TodoAlertController()
     alert.modalPresentationStyle = .overFullScreen
     present(alert, animated: false)

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -167,15 +167,8 @@ extension TodolistViewController: TodoCollectionViewCellDelegate {
     }
   }
   
-  func didTappedLikeButton(isLiked: Bool) {
-    if isLiked {
-      /// 해당 투두리스트 좋아요 눌렀을 때
-      print("좋아요")
-    }
-    else {
-      /// 해당 투두리스트 좋아요 취소했을 때
-      print("좋아요 취소")
-    }
+  func didTappedLikeButton(timelineID: Int) {
+    viewModel.selectLikeButton.onNext(timelineID)
   }
   
   func didTappedMoreButton() { /// 투두리스트 작성자에 따른 type 지정해줘야함

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -152,9 +152,11 @@ extension TodolistViewController: TodoCollectionViewCellDelegate {
   func didTappedTodo(todoID: Int, isCompleted: Bool) {
     viewModel.selectTodolistID.onNext(todoID)
     viewModel.selectComplete.onNext(isCompleted)
-    let alert = TodoAlertController()
-    alert.modalPresentationStyle = .overFullScreen
-    present(alert, animated: false)
+    if isCompleted {
+      let alert = TodoAlertController()
+      alert.modalPresentationStyle = .overFullScreen
+      present(alert, animated: false)
+    }
   }
   
   func didTappedLikeButton(isLiked: Bool) {

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/TodolistViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/TodolistViewModel.swift
@@ -5,33 +5,47 @@
 //  Created by 이건준 on 2023/05/02.
 //
 
-import Foundation
+import UIKit
 
 import RxSwift
 import RxCocoa
 
 protocol TodolistViewModelType {
   // Input
+  var selectComplete: AnyObserver<Bool> { get }
   var selectPlubbingID: AnyObserver<Int> { get }
+  var selectTodolistID: AnyObserver<Int> { get }
+  var whichProofImage: AnyObserver<UIImage?> { get }
   
   // Output
   var todoTimelineModel: Driver<[TodolistModel]> { get }
+  var successCompleteTodolist: Signal<Bool> { get }
 }
 
 final class TodolistViewModel {
   
   private let disposeBag = DisposeBag()
   
+  private let selectingComplete = PublishSubject<Bool>()
   private let selectingPlubbingID = PublishSubject<Int>()
+  private let selectingTodolistID = PublishSubject<Int>()
   private let allTodoTimeline = BehaviorSubject<[InquireAllTodoTimelineResponse]>(value: [])
+  private let completeTodolist = PublishSubject<CompleteProofTodolistResponse>()
+  private let whichUploadingImage = PublishSubject<UIImage?>()
   
   init() {
     inquireAllTodoTimeline()
+    tryCompleteTodolist()
+    tryCancelCompleteTodolist()
+    tryProofTodolist()
   }
   
   private func inquireAllTodoTimeline() {
     let inquireAllTodoTimeline = selectingPlubbingID.flatMapLatest {
-      return TodolistService.shared.inquireAllTodoTimeline(plubbingID: $0, cursorID: 0)
+      return TodolistService.shared.inquireAllTodoTimeline(
+        plubbingID: $0,
+        cursorID: 0
+      )
     }
       .share()
     
@@ -44,11 +58,96 @@ final class TodolistViewModel {
       .bind(to: allTodoTimeline)
       .disposed(by: disposeBag)
   }
+  
+  private func tryCompleteTodolist() {
+    let completeTodolist = selectingComplete
+      .filter { $0 }
+      .withLatestFrom(
+        Observable.combineLatest(
+          selectingPlubbingID,
+          selectingTodolistID
+        )
+      )
+      .flatMapLatest(TodolistService.shared.completeTodolist)
+      
+    completeTodolist.subscribe(onNext: { response in
+      print("완료 \(response) ")
+    })
+    .disposed(by: disposeBag)
+  }
+  
+  private func tryCancelCompleteTodolist() {
+    let cancelCompleteTodolist = selectingComplete
+      .filter { !$0 }
+      .withLatestFrom(
+        Observable.combineLatest(
+          selectingPlubbingID,
+          selectingTodolistID
+        )
+      )
+      .flatMapLatest(TodolistService.shared.cancelCompleteTodolist)
+    
+    cancelCompleteTodolist.subscribe(onNext: { response in
+      print("취소완료 \(response) ")
+    })
+    .disposed(by: disposeBag)
+  }
+  
+  private func getProofImage() -> Observable<String> { // 투두리스트 인증을 위한 이미지를 받아오는 함수
+    let uploadImage = whichUploadingImage
+      .compactMap { $0 }
+      .flatMapLatest { image in
+        ImageService.shared.uploadImage(
+          images: [image],
+          params: .init(type: .feed)
+        )
+      }
+    
+    let tryImageToString = uploadImage
+      .flatMap { response -> Observable<String?> in
+        switch response {
+        case let .success(imageModel):
+          return .just(imageModel.data?.files.first?.fileURL)
+        default:
+          // 이미지 등록이 되지 못함 (오류 발생)
+          return .empty()
+        }
+      }
+    
+    return tryImageToString.compactMap { $0 }
+  }
+  
+  private func tryProofTodolist() { // 투두리스트 인증에 대한 API를 호출하는 함수
+    let proofTodolist = Observable.combineLatest(
+      selectingPlubbingID,
+      selectingTodolistID,
+      getProofImage().map { ProofTodolistRequest(proofImage: $0) }
+    )
+      .flatMapLatest(TodolistService.shared.proofTodolist)
+    
+    proofTodolist.subscribe(onNext: { response in
+      print("인증 \(response) ")
+    })
+    .disposed(by: disposeBag)
+  }
 }
 
 extension TodolistViewModel: TodolistViewModelType {
+ 
   var selectPlubbingID: AnyObserver<Int> { // 선택한 plubbingID가 무엇인지
     selectingPlubbingID.asObserver()
+  }
+  
+  var selectTodolistID: AnyObserver<Int> {
+    selectingTodolistID.asObserver()
+  }
+  
+  var selectComplete: AnyObserver<Bool> {
+    selectingComplete.asObserver()
+  }
+  
+  var whichProofImage: AnyObserver<UIImage?> {
+    whichUploadingImage.asObserver()
   }
   
   var todoTimelineModel: Driver<[TodolistModel]> { // 조회한 투두타임라인에 대한 데이터를 TodolistModel로 파싱한 값
@@ -68,5 +167,12 @@ extension TodolistViewModel: TodolistViewModelType {
       return todolistModel
     }
     .asDriver(onErrorDriveWith: .empty())
+  }
+  
+  var successCompleteTodolist: Signal<Bool> {
+    completeTodolist
+      .do(onNext: { print("응답 \($0)") })
+      .map { $0.isChecked }
+      .asSignal(onErrorSignalWith: .empty())
   }
 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 좋아요/ 좋아요 취소/ 투두완료/ 투두완료취소/ 투두인증/ 투두타임라인에 대한 API를 추가 및 연동하였습니다.
- 해당 투두의 작성자인지 아닌지 이미 인증된 투두인지에 따라서 체크버튼 비활성화같은 로직을 추가하였습니다.
- 해당 투두 완료인 경우에만 인증모달을 띄어주었습니다.
- 해당 투두인증한 경우에 변경불가한 로직을 추가하였습니다.
- 해당 투두리스트 좋아요요청할 시에 UI변경하는 로직을 추가하였습니다.

🌱 PR 포인트
- 투두인증에 관련된 로직은 따로 pr올리도록 하겠습니다.
- 완료/ 인증 시에 라벨에 라인이 그어지는 부분 따로 pr올리도록 하겠습니다.
- 아직 투두리스트의 페이징작업하지않았습니다.

## 📮 관련 이슈
- Resolved: #346 

