### PR TITLE
바텀시트 Constraint 리팩토링 + 애니메이션 코드 적용

### DIFF
--- a/PLUB/Configuration/CommonClass/BottomSheetViewController.swift
+++ b/PLUB/Configuration/CommonClass/BottomSheetViewController.swift
@@ -60,6 +60,7 @@ extension BottomSheetViewController {
     enum Size {
       static let height       = 48
       static let filterHeight = 32
+      static let button       = 48
     }
   }
 }

--- a/PLUB/Configuration/CommonClass/BottomSheetViewController.swift
+++ b/PLUB/Configuration/CommonClass/BottomSheetViewController.swift
@@ -52,13 +52,14 @@ extension UISheetPresentationController.Detent.Identifier {
 extension BottomSheetViewController {
   enum Metrics {
     enum Margin {
-      static let horizontal = 16
-      static let top        = 36
-      static let bottom     = 24
+      static let horizontal   = 16
+      static let top          = 36
+      static let bottom       = 24
     }
     
     enum Size {
-      static let height     = 48
+      static let height       = 48
+      static let filterHeight = 32
     }
   }
 }

--- a/PLUB/Configuration/CommonClass/BottomSheetViewController.swift
+++ b/PLUB/Configuration/CommonClass/BottomSheetViewController.swift
@@ -58,7 +58,7 @@ extension BottomSheetViewController {
     }
     
     enum Size {
-      static let height       = 48
+      static let listHeight   = 48
       static let filterHeight = 32
       static let button       = 48
     }

--- a/PLUB/Configuration/CommonClass/BottomSheetViewController.swift
+++ b/PLUB/Configuration/CommonClass/BottomSheetViewController.swift
@@ -23,7 +23,7 @@ class BottomSheetViewController: BaseViewController {
     super.setupConstraints()
     contentView.snp.makeConstraints {
       $0.leading.trailing.equalToSuperview()
-      $0.bottom.equalTo(view.safeAreaLayoutGuide)
+      $0.top.equalTo(view.safeAreaLayoutGuide)
     }
   }
   

--- a/PLUB/Sources/Views/Home/Archive/Component/ArchiveBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/Archive/Component/ArchiveBottomSheetViewController.swift
@@ -70,7 +70,7 @@ final class ArchiveBottomSheetViewController: BottomSheetViewController {
     super.setupConstraints()
     
     let heightConstraints: (ConstraintMaker) -> Void = {
-      $0.height.equalTo(Metrics.Size.height)
+      $0.height.equalTo(Metrics.Size.listHeight)
     }
     
     contentStackView.snp.makeConstraints {

--- a/PLUB/Sources/Views/Home/Clipboard/Component/CommentOptionBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Component/CommentOptionBottomSheetViewController.swift
@@ -86,7 +86,7 @@ final class CommentOptionBottomSheetViewController: BottomSheetViewController {
     super.setupConstraints()
     
     let heightConstraints: (ConstraintMaker) -> Void = {
-      $0.height.equalTo(Metrics.Size.height)
+      $0.height.equalTo(Metrics.Size.listHeight)
     }
     
     contentStackView.snp.makeConstraints {

--- a/PLUB/Sources/Views/Home/Component/ParticipantBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/Component/ParticipantBottomSheetViewController.swift
@@ -48,15 +48,15 @@ final class ParticipantBottomSheetViewController: BottomSheetViewController {
     super.setupConstraints()
     
     titleLabel.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(28)
-      $0.directionalHorizontalEdges.equalToSuperview().inset(24)
+      $0.top.equalToSuperview().inset(Metrics.Margin.top)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(Metrics.Margin.horizontal)
       $0.height.equalTo(23)
     }
     
     participantCollectionView.snp.makeConstraints {
       $0.top.equalTo(titleLabel.snp.bottom).offset(24)
-      $0.leading.trailing.equalToSuperview().inset(24)
-      $0.bottom.equalToSuperview().inset(24)
+      $0.leading.trailing.equalToSuperview().inset(Metrics.Margin.horizontal)
+      $0.bottom.equalToSuperview().inset(Metrics.Margin.bottom)
       $0.height.equalTo(ceil(Double(model.count) / Double(4)) * (48 + 4 + 21) + (ceil(Double(model.count) / Double(4)) - 1) * 16)
       // (총 참여자 수 / 행 최대 인원 수) * (참여자프로필높이 + 프로필, 라벨 offset + 라벨높이) + ((총 참여자 수 / 행 최대 인원 수) - 1) * minimumLine
     }

--- a/PLUB/Sources/Views/Home/Component/SortBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/Component/SortBottomSheetViewController.swift
@@ -12,7 +12,7 @@ import RxCocoa
 import SnapKit
 import Then
 
-final class SortBottomSheetView: UIControl {
+final class BottomSheetFilterView: UIControl {
   
   private let type: SortType
   
@@ -62,7 +62,7 @@ final class SortBottomSheetView: UIControl {
   }
 }
 
-extension Reactive where Base: SortBottomSheetView {
+extension Reactive where Base: BottomSheetFilterView {
   var tap: ControlEvent<Void> {
     controlEvent(.touchUpInside)
   }
@@ -89,8 +89,8 @@ final class SortBottomSheetViewController: BottomSheetViewController {
     $0.sizeToFit()
   }
   
-  private let popularButton = SortBottomSheetView(type: .popular)
-  private let newButton = SortBottomSheetView(type: .new)
+  private let popularButton = BottomSheetFilterView(text: SortType.popular.text)
+  private let newButton = BottomSheetFilterView(text: SortType.new.text)
   
   override func setupLayouts() {
     super.setupLayouts()

--- a/PLUB/Sources/Views/Home/Component/SortBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/Component/SortBottomSheetViewController.swift
@@ -18,8 +18,8 @@ final class BottomSheetFilterView: UIControl {
   
   var isTapped: Bool = false {
     didSet {
-      label.textColor      = isTapped ? .main : .black
-      selectImageView.isHidden = !isTapped
+      label.textColor           = isTapped ? .main : .black
+      selectImageView.isHidden  = !isTapped
     }
   }
   

--- a/PLUB/Sources/Views/Home/Component/SortBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/Component/SortBottomSheetViewController.swift
@@ -95,7 +95,7 @@ final class SortBottomSheetViewController: BottomSheetViewController {
   }
   
   private let popularButton = BottomSheetFilterView(text: SortType.popular.text)
-  private let newButton = BottomSheetFilterView(text: SortType.new.text)
+  private let newButton     = BottomSheetFilterView(text: SortType.new.text)
   
   override func setupLayouts() {
     super.setupLayouts()
@@ -107,17 +107,17 @@ final class SortBottomSheetViewController: BottomSheetViewController {
     super.setupConstraints()
     
     stackView.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(36)
-      $0.leading.trailing.equalToSuperview().inset(24)
-      $0.bottom.equalToSuperview().inset(24)
+      $0.top.equalToSuperview().inset(Metrics.Margin.top)
+      $0.leading.trailing.equalToSuperview().inset(Metrics.Margin.horizontal)
+      $0.bottom.equalToSuperview().inset(Metrics.Margin.bottom)
     }
     
     popularButton.snp.makeConstraints {
-      $0.height.equalTo(32)
+      $0.height.equalTo(Metrics.Size.filterHeight)
     }
     
     newButton.snp.makeConstraints {
-      $0.height.equalTo(32)
+      $0.height.equalTo(Metrics.Size.filterHeight)
     }
   }
   

--- a/PLUB/Sources/Views/Home/Component/SortBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/Component/SortBottomSheetViewController.swift
@@ -14,16 +14,18 @@ import Then
 
 final class BottomSheetFilterView: UIControl {
   
-  private let type: SortType
+  // MARK: - Properties
   
   var isTapped: Bool = false {
     didSet {
-      sortLabel.textColor = isTapped ? .main : .black
+      label.textColor      = isTapped ? .main : .black
       selectImageView.isHidden = !isTapped
     }
   }
   
-  private let sortLabel = UILabel().then {
+  // MARK: - UI Components
+  
+  private let label = UILabel().then {
     $0.font = .body1
     $0.textColor = .black
     $0.sizeToFit()
@@ -34,30 +36,33 @@ final class BottomSheetFilterView: UIControl {
     $0.contentMode = .scaleAspectFit
   }
   
-  init(type: SortType) {
-    self.type = type
+  // MARK: - Initializations
+  
+  init(text: String) {
     super.init(frame: .zero)
-    configureUI()
+    configureUI(text: text)
   }
   
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
   
-  private func configureUI() {
-    [sortLabel, selectImageView].forEach { addSubview($0) }
+  // MARK: - Configuration
+  
+  private func configureUI(text: String) {
+    [label, selectImageView].forEach { addSubview($0) }
     
-    sortLabel.snp.makeConstraints {
+    label.snp.makeConstraints {
       $0.leading.top.bottom.equalToSuperview()
     }
     
     selectImageView.snp.makeConstraints {
-      $0.leading.equalTo(sortLabel.snp.trailing).offset(8)
+      $0.leading.equalTo(label.snp.trailing).offset(8)
       $0.top.bottom.equalToSuperview()
       $0.trailing.lessThanOrEqualToSuperview()
     }
     
-    sortLabel.text = type.text
+    label.text = text
     selectImageView.isHidden = true
   }
 }

--- a/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
+++ b/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
@@ -294,7 +294,6 @@ extension DetailRecruitmentViewController: UICollectionViewDelegate, UICollectio
 extension DetailRecruitmentViewController: ParticipantListViewDelegate {
   func didTappedMoreButton(accountInfos: [AccountInfo]) {
     let vc = ParticipantBottomSheetViewController(model: accountInfos)
-    vc.modalPresentationStyle = .overFullScreen
-    present(vc, animated: false)
+    present(vc, animated: true)
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -151,9 +151,8 @@ final class BoardViewController: BaseViewController {
     if gestureRecognizer.state == .began {
       // 롱 프레스 터치가 시작될 떄
       let bottomSheet = BoardBottomSheetViewController()
-      bottomSheet.modalPresentationStyle = .overFullScreen
       bottomSheet.delegate = self
-      present(bottomSheet, animated: false)
+      present(bottomSheet, animated: true)
     } else if gestureRecognizer.state == .ended {
       // 롱 프레스 터치가 끝날 떄
       guard let feedID = cell.feedID else { return }
@@ -267,7 +266,7 @@ extension BoardViewController: BoardBottomSheetDelegate {
     case .delete:
       viewModel.selectDelete.onNext(())
     }
-    dismiss(animated: false)
+    dismiss(animated: true)
   }
   
 }

--- a/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
@@ -50,14 +50,14 @@ final class BoardBottomSheetViewController: BottomSheetViewController {
     
     [clipboardFixView, modifyBoardView, reportBoardView, deleteBoardView].forEach {
       $0.snp.makeConstraints {
-        $0.height.equalTo(50)
+        $0.height.equalTo(Metrics.Size.height)
       }
     }
     
     contentStackView.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(36)
-      $0.directionalHorizontalEdges.equalToSuperview().inset(24)
-      $0.bottom.equalToSuperview().inset(24)
+      $0.top.equalToSuperview().inset(Metrics.Margin.top)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(Metrics.Margin.horizontal)
+      $0.bottom.equalToSuperview().inset(Metrics.Margin.bottom)
     }
   }
   

--- a/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
@@ -50,7 +50,7 @@ final class BoardBottomSheetViewController: BottomSheetViewController {
     
     [clipboardFixView, modifyBoardView, reportBoardView, deleteBoardView].forEach {
       $0.snp.makeConstraints {
-        $0.height.equalTo(Metrics.Size.height)
+        $0.height.equalTo(Metrics.Size.listHeight)
       }
     }
     

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoAlertController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoAlertController.swift
@@ -187,9 +187,8 @@ final class TodoAlertController: BaseViewController {
     todoAlertView.button.rx.tap
       .subscribe(with: self) { owner, _ in
         let bottomSheet = PhotoBottomSheetViewController()
-        bottomSheet.modalPresentationStyle = .overFullScreen
         bottomSheet.delegate = owner
-        owner.present(bottomSheet, animated: false)
+        owner.present(bottomSheet, animated: true)
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodolistBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodolistBottomSheetViewController.swift
@@ -59,9 +59,9 @@ final class TodolistBottomSheetViewController: BottomSheetViewController {
   override func setupConstraints() {
     super.setupConstraints()
     bottomSheetView.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(36)
-      $0.directionalHorizontalEdges.bottom.equalToSuperview().inset(24)
-      $0.height.equalTo(48)
+      $0.top.equalToSuperview().inset(Metrics.Margin.top)
+      $0.directionalHorizontalEdges.bottom.equalToSuperview().inset(Metrics.Margin.horizontal)
+      $0.height.equalTo(Metrics.Size.height)
     }
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodolistBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodolistBottomSheetViewController.swift
@@ -61,7 +61,7 @@ final class TodolistBottomSheetViewController: BottomSheetViewController {
     bottomSheetView.snp.makeConstraints {
       $0.top.equalToSuperview().inset(Metrics.Margin.top)
       $0.directionalHorizontalEdges.bottom.equalToSuperview().inset(Metrics.Margin.horizontal)
-      $0.height.equalTo(Metrics.Size.height)
+      $0.height.equalTo(Metrics.Size.listHeight)
     }
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -197,9 +197,8 @@ final class CreateBoardViewController: BaseViewController {
     tapGesture.rx.event
       .subscribe(with: self) { owner, _ in
         let bottomSheet = PhotoBottomSheetViewController()
-        bottomSheet.modalPresentationStyle = .overFullScreen
         bottomSheet.delegate = owner
-        owner.present(bottomSheet, animated: false)
+        owner.present(bottomSheet, animated: true)
       }
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -173,7 +173,6 @@ extension TodolistViewController: TodoCollectionViewCellDelegate {
   
   func didTappedMoreButton() { /// 투두리스트 작성자에 따른 type 지정해줘야함
     let bottomSheet = TodolistBottomSheetViewController(type: .report)
-    bottomSheet.modalPresentationStyle = .overFullScreen
-    present(bottomSheet, animated: false)
+    present(bottomSheet, animated: true)
   }
 }

--- a/PLUB/Sources/Views/Home/MeetingSchedule/MeetingScheduleViewController.swift
+++ b/PLUB/Sources/Views/Home/MeetingSchedule/MeetingScheduleViewController.swift
@@ -126,8 +126,7 @@ final class MeetingScheduleViewController: BaseViewController {
           let calendarID = viewModel.getCellScheduleID(indexPath) else { return }
     let vc = ScheduleBottomSheetViewController(calendarID: calendarID)
     vc.delegate = self
-    vc.modalPresentationStyle = .overFullScreen
-    present(vc, animated: false)
+    present(vc, animated: true)
   }
 }
 

--- a/PLUB/Sources/Views/Home/SearchInputViewController.swift
+++ b/PLUB/Sources/Views/Home/SearchInputViewController.swift
@@ -334,10 +334,9 @@ extension SearchInputViewController: SearchOutputHeaderViewDelegate {
   
   func didTappedSortControl() {
     let vc = SortBottomSheetViewController()
-    vc.modalPresentationStyle = .overFullScreen
     vc.delegate = self
     vc.configureUI(with: type)
-    present(vc, animated: false)
+    present(vc, animated: true)
   }
   
   func didTappedInterestListChartButton() {
@@ -354,7 +353,7 @@ extension SearchInputViewController: SearchOutputHeaderViewDelegate {
 extension SearchInputViewController: SortBottomSheetViewControllerDelegate {
   func didTappedSortButton(type: SortType) {
     self.type = type
-    dismiss(animated: false)
+    dismiss(animated: true)
   }
 }
 

--- a/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
+++ b/PLUB/Sources/Views/Home/SelectedCategoryViewController.swift
@@ -173,10 +173,9 @@ extension SelectedCategoryViewController: UICollectionViewDelegate, UICollection
 extension SelectedCategoryViewController: SelectedCategoryFilterHeaderViewDelegate {
   func didTappedSortControl() {
     let vc = SortBottomSheetViewController()
-    vc.modalPresentationStyle = .overFullScreen
     vc.delegate = self
     vc.configureUI(with: type)
-    present(vc, animated: false)
+    present(vc, animated: true)
   }
   
   func didTappedInterestListFilterButton() {
@@ -201,7 +200,7 @@ extension SelectedCategoryViewController: SelectedCategoryFilterHeaderViewDelega
 extension SelectedCategoryViewController: SortBottomSheetViewControllerDelegate {
   func didTappedSortButton(type: SortType) {
     self.type = type
-    dismiss(animated: false)
+    dismiss(animated: true)
   }
 }
 

--- a/PLUB/Sources/Views/Login/ViewController/BirthViewController.swift
+++ b/PLUB/Sources/Views/Login/ViewController/BirthViewController.swift
@@ -143,9 +143,8 @@ final class BirthViewController: BaseViewController {
       .subscribe(onNext: { owner, _ in
         let date14YearsBefore = Calendar.current.date(byAdding: .year, value: -14, to: Date())!
         let vc = DateBottomSheetViewController(maximumDate: date14YearsBefore, buttonTitle: "생일 입력 완료")
-        vc.modalPresentationStyle = .overFullScreen
         vc.delegate = owner
-        owner.parent?.present(vc, animated: false)
+        owner.parent?.present(vc, animated: true)
       })
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Login/ViewController/ProfileViewController.swift
+++ b/PLUB/Sources/Views/Login/ViewController/ProfileViewController.swift
@@ -160,9 +160,8 @@ final class ProfileViewController: BaseViewController {
       .asDriver()
       .drive(with: self, onNext: { owner, _ in
         let photoVC = PhotoBottomSheetViewController()
-        photoVC.modalPresentationStyle = .overFullScreen
         photoVC.delegate = owner
-        owner.parent?.present(photoVC, animated: false)
+        owner.parent?.present(photoVC, animated: true)
       })
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Component/DateBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Component/DateBottomSheetViewController.swift
@@ -67,8 +67,8 @@ final class DateBottomSheetViewController: BottomSheetViewController {
     
     
     contentStackView.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(36)
-      $0.leading.trailing.bottom.equalToSuperview().inset(24)
+      $0.top.equalToSuperview().inset(Metrics.Margin.top)
+      $0.leading.trailing.bottom.equalToSuperview().inset(Metrics.Margin.horizontal)
     }
     
     datePicker.snp.makeConstraints {
@@ -76,7 +76,7 @@ final class DateBottomSheetViewController: BottomSheetViewController {
     }
     
     nextButton.snp.makeConstraints {
-      $0.height.equalTo(48)
+      $0.height.equalTo(Metrics.Size.button)
     }
   }
   

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Component/LocationBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Component/LocationBottomSheetViewController.swift
@@ -68,7 +68,7 @@ final class LocationBottomSheetViewController: BottomSheetViewController {
     
     searchView.snp.makeConstraints {
       $0.top.equalTo(titleLabel.snp.bottom).offset(24)
-      $0.leading.trailing.equalToSuperview().inset(16)
+      $0.leading.trailing.equalToSuperview().inset(Metrics.Margin.horizontal)
       $0.height.equalTo(40)
     }
     
@@ -90,14 +90,14 @@ final class LocationBottomSheetViewController: BottomSheetViewController {
     
     tableView.snp.makeConstraints {
       $0.top.equalTo(searchCountLabel.snp.bottom).offset(16)
-      $0.directionalHorizontalEdges.equalToSuperview().inset(24)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(Metrics.Margin.horizontal)
       $0.bottom.equalTo(nextButton.snp.top).offset(-6)
       $0.height.equalTo(352)
     }
     
     nextButton.snp.makeConstraints {
-      $0.directionalHorizontalEdges.bottom.equalToSuperview().inset(24)
-      $0.height.equalTo(46)
+      $0.directionalHorizontalEdges.bottom.equalToSuperview().inset(Metrics.Margin.horizontal)
+      $0.height.equalTo(Metrics.Size.button)
     }
   }
   

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Component/PhotoBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Component/PhotoBottomSheetViewController.swift
@@ -53,17 +53,17 @@ final class PhotoBottomSheetViewController: BottomSheetViewController {
     super.setupConstraints()
     
     contentStackView.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(36)
-      $0.directionalHorizontalEdges.equalToSuperview().inset(24)
-      $0.bottom.equalToSuperview().inset(24)
+      $0.top.equalToSuperview().inset(Metrics.Margin.top)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(Metrics.Margin.horizontal)
+      $0.bottom.equalToSuperview().inset(Metrics.Margin.bottom)
     }
     
     cameraView.snp.makeConstraints {
-      $0.height.equalTo(48)
+      $0.height.equalTo(Metrics.Size.height)
     }
     
     albumView.snp.makeConstraints {
-      $0.height.equalTo(48)
+      $0.height.equalTo(Metrics.Size.height)
     }
   }
   

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Component/PhotoBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Component/PhotoBottomSheetViewController.swift
@@ -59,11 +59,11 @@ final class PhotoBottomSheetViewController: BottomSheetViewController {
     }
     
     cameraView.snp.makeConstraints {
-      $0.height.equalTo(Metrics.Size.height)
+      $0.height.equalTo(Metrics.Size.listHeight)
     }
     
     albumView.snp.makeConstraints {
-      $0.height.equalTo(Metrics.Size.height)
+      $0.height.equalTo(Metrics.Size.listHeight)
     }
   }
   

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/Component/QuestionDeleteBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/Component/QuestionDeleteBottomSheetViewController.swift
@@ -82,13 +82,14 @@ final class QuestionDeleteBottomSheetViewController: BottomSheetViewController {
     titleLabel.snp.makeConstraints {
       $0.top.equalToSuperview().inset(43)
       $0.height.greaterThanOrEqualTo(19)
-      $0.directionalHorizontalEdges.equalToSuperview().inset(24)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(Metrics.Margin.horizontal)
       $0.bottom.equalTo(buttonStackView.snp.top).offset(-15)
     }
     
     buttonStackView.snp.makeConstraints {
-      $0.directionalHorizontalEdges.bottom.equalToSuperview().inset(24)
-      $0.height.equalTo(46)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(Metrics.Margin.horizontal)
+      $0.bottom.equalToSuperview().inset(Metrics.Margin.bottom)
+      $0.height.equalTo(Metrics.Size.button)
     }
   }
   

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingDateViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingDateViewController.swift
@@ -214,9 +214,8 @@ final class MeetingDateViewController: BaseViewController {
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
         let vc = DateBottomSheetViewController(type: .time, buttonTitle: "시간 입력 완료")
-        vc.modalPresentationStyle = .overFullScreen
         vc.delegate = owner
-        owner.parent?.present(vc, animated: false)
+        owner.parent?.present(vc, animated: true)
       })
       .disposed(by: disposeBag)
     
@@ -224,9 +223,8 @@ final class MeetingDateViewController: BaseViewController {
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
         let vc = LocationBottomSheetViewController()
-        vc.modalPresentationStyle = .overFullScreen
         vc.delegate = owner
-        owner.parent?.present(vc, animated: false)
+        owner.parent?.present(vc, animated: true)
       })
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingIntroduceViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingIntroduceViewController.swift
@@ -153,9 +153,8 @@ final class MeetingIntroduceViewController: BaseViewController {
       .drive(onNext: {[weak self] in
         guard let self = self else { return }
         let vc = PhotoBottomSheetViewController()
-        vc.modalPresentationStyle = .overFullScreen
         vc.delegate = self
-        self.parent?.present(vc, animated: false)
+        self.parent?.present(vc, animated: true)
       })
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
+++ b/PLUB/Sources/Views/Meeting/CreateMeeting/ViewController/MeetingQuestionViewController.swift
@@ -237,8 +237,7 @@ extension MeetingQuestionViewController: QuestionTableViewCellDelegate {
     
     let vc = QuestionDeleteBottomSheetViewController(index: index, lastQuestion: lastQuestion)
     vc.delegate = self
-    vc.modalPresentationStyle = .overFullScreen
-    present(vc, animated: false)
+    present(vc, animated: true)
   }
   
   func updateHeightOfRow(_ cell: QuestionTableViewCell, _ textView: UITextView) {

--- a/PLUB/Sources/Views/Meeting/EditMeeting/ViewController/GuestQuestionViewController.swift
+++ b/PLUB/Sources/Views/Meeting/EditMeeting/ViewController/GuestQuestionViewController.swift
@@ -292,8 +292,7 @@ extension GuestQuestionViewController: QuestionTableViewCellDelegate {
     
     let vc = QuestionDeleteBottomSheetViewController(index: index, lastQuestion: lastQuestion)
     vc.delegate = self
-    vc.modalPresentationStyle = .overFullScreen
-    present(vc, animated: false)
+    present(vc, animated: true)
   }
   
   func updateHeightOfRow(_ cell: QuestionTableViewCell, _ textView: UITextView) {

--- a/PLUB/Sources/Views/Meeting/EditMeeting/ViewController/MeetingInfoViewController.swift
+++ b/PLUB/Sources/Views/Meeting/EditMeeting/ViewController/MeetingInfoViewController.swift
@@ -242,9 +242,8 @@ final class MeetingInfoViewController: BaseViewController {
       .withUnretained(self)
       .subscribe(onNext: { owner, _ in
         let vc = LocationBottomSheetViewController()
-        vc.modalPresentationStyle = .overFullScreen
         vc.delegate = owner
-        owner.parent?.present(vc, animated: false)
+        owner.parent?.present(vc, animated: true)
       })
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Meeting/EditMeeting/ViewController/RecruitPostViewController.swift
+++ b/PLUB/Sources/Views/Meeting/EditMeeting/ViewController/RecruitPostViewController.swift
@@ -157,9 +157,8 @@ final class RecruitPostViewController: BaseViewController {
       .drive(onNext: {[weak self] in
         guard let self = self else { return }
         let vc = PhotoBottomSheetViewController()
-        vc.modalPresentationStyle = .overFullScreen
         vc.delegate = self
-        self.parent?.present(vc, animated: false)
+        self.parent?.present(vc, animated: true)
       })
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Meeting/Schedule/CreateSchedule/Component/ScheduleBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Meeting/Schedule/CreateSchedule/Component/ScheduleBottomSheetViewController.swift
@@ -60,16 +60,17 @@ final class ScheduleBottomSheetViewController: BottomSheetViewController {
     super.setupConstraints()
     
     contentStackView.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(36)
-      $0.directionalHorizontalEdges.bottom.equalToSuperview().inset(24)
+      $0.top.equalToSuperview().inset(Metrics.Margin.top)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(Metrics.Margin.horizontal)
+      $0.bottom.equalToSuperview().inset(Metrics.Margin.bottom)
     }
     
     editView.snp.makeConstraints {
-      $0.height.equalTo(52)
+      $0.height.equalTo(Metrics.Size.height)
     }
     
     deleteView.snp.makeConstraints {
-      $0.height.equalTo(52)
+      $0.height.equalTo(Metrics.Size.height)
     }
   }
   

--- a/PLUB/Sources/Views/Meeting/Schedule/CreateSchedule/Component/ScheduleBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Meeting/Schedule/CreateSchedule/Component/ScheduleBottomSheetViewController.swift
@@ -66,11 +66,11 @@ final class ScheduleBottomSheetViewController: BottomSheetViewController {
     }
     
     editView.snp.makeConstraints {
-      $0.height.equalTo(Metrics.Size.height)
+      $0.height.equalTo(Metrics.Size.listHeight)
     }
     
     deleteView.snp.makeConstraints {
-      $0.height.equalTo(Metrics.Size.height)
+      $0.height.equalTo(Metrics.Size.listHeight)
     }
   }
   

--- a/PLUB/Sources/Views/Meeting/Schedule/CreateSchedule/CreateScheduleViewController.swift
+++ b/PLUB/Sources/Views/Meeting/Schedule/CreateSchedule/CreateScheduleViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import RxSwift
+import RxCocoa
 import SnapKit
 import Then
 
@@ -233,9 +235,8 @@ final class CreateScheduleViewController: BaseViewController {
       .drive(with: self) { owner, _ in
         owner.view.endEditing(true)
         let vc = LocationBottomSheetViewController()
-        vc.modalPresentationStyle = .overFullScreen
         vc.delegate = owner
-        owner.parent?.present(vc, animated: false)
+        owner.parent?.present(vc, animated: true)
       }
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewController.swift
+++ b/PLUB/Sources/Views/MyPage/ProfileEdit/ProfileEditViewController.swift
@@ -198,9 +198,8 @@ final class ProfileEditViewController: BaseViewController {
       .asDriver()
       .drive(with: self, onNext: { owner, _ in
         let photoVC = PhotoBottomSheetViewController()
-        photoVC.modalPresentationStyle = .overFullScreen
         photoVC.delegate = owner
-        owner.parent?.present(photoVC, animated: false)
+        owner.parent?.present(photoVC, animated: true)
       })
       .disposed(by: disposeBag)
     


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용

- 기존 레거시 코드에 적용시켰던 `animated: false`와 `presentationStyle = .overFullScreen`을 제거하고, `animated: true`로 변경했습니다.
- BottomSheet의 Constraints는 되도록 BaseBottomSheetVC의 Margin, Size 값으로 맞추도록 설정했습니다. (나중에 수정하기 편함!)

🌱 PR 포인트

- SortBottomSheetView를 BottomSheetFilterView로 변경하였고, 내부 로직도 변경했습니다.
   - 알림에서도 똑같은 바텀시트 뷰를 사용하기 때문에, 이를 재사용하고자 initializer를 수정했습니다.
- 이제 Grabber를 당기면 Context가 위로 올라갑니다. (이전에는 당겨도 View들(Context)이 고정이었음)

> **Note**: 기존에는 Bottom을 기준으로 Constraint를 잡아 BottomSheet의 높이를 계산했다면, 이번 PR 이후로는 Top을 기준으로 높이를 계산하기 때문에, top의 constraint를 잡지 않으면 BottomSheet가 뜨질 않으니 유의해주세요!

## 📸 스크린샷

|수정 후|
|:-:|
|![BoardBottomSheet](https://user-images.githubusercontent.com/57972338/237002298-98ff8dd6-29e5-41bb-8bbb-09ec943691d8.gif)|

- 수정 전 화면은 #278 을 참고해주세요.

## 📮 관련 이슈
- Resolved: #357

