### PR TITLE
게시글 옵션 클릭시 바텀시트 띄우기

### DIFF
--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -157,6 +157,12 @@ final class BoardDetailViewController: BaseViewController {
         owner.commentInputView.endEditing(true)
       }
       .disposed(by: disposeBag)
+    
+    viewModel.showBoardBottomSheetObservable
+      .subscribe(with: self) { owner, accessType in
+        PLUBToast.makeToast(text: "\(accessType)")
+      }
+      .disposed(by: disposeBag)
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -115,7 +115,7 @@ final class BoardDetailViewController: BaseViewController {
       }
       .disposed(by: disposeBag)
     
-    viewModel.showBottomSheetObservable
+    viewModel.showCommentBottomSheetObservable
       .subscribe(with: self) { owner, tuple in
         let bottomSheetVC = CommentOptionBottomSheetViewController(commentID: tuple.commentID, userAccessType: tuple.userType).then {
           $0.delegate = owner

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -159,8 +159,11 @@ final class BoardDetailViewController: BaseViewController {
       .disposed(by: disposeBag)
     
     viewModel.showBoardBottomSheetObservable
-      .subscribe(with: self) { owner, accessType in
-        PLUBToast.makeToast(text: "\(accessType)")
+      .subscribe(with: self) { owner, tuple in
+        let (accessType, isPinned) = tuple
+        let viewController = BoardBottomSheetViewController(accessType: accessType, isPinned: isPinned)
+        viewController.delegate = owner
+        owner.present(viewController, animated: true)
       }
       .disposed(by: disposeBag)
   }
@@ -200,7 +203,15 @@ extension BoardDetailViewController: CommentOptionBottomSheetDelegate {
   }
   
   func reportButtonTapped(commentID: Int) {
-    print(#function)
+    PLUBToast.makeToast(text: "commentID: \(commentID) report tapped")
+  }
+}
+
+// MARK: - BoardBottomSheetDelegate
+
+extension BoardDetailViewController: BoardBottomSheetDelegate {
+  func selectedBoardSheetType(type: BoardBottomSheetType) {
+    PLUBToast.makeToast(text: "\(type)")
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -42,7 +42,7 @@ protocol BoardDetailViewModelType: BoardDetailViewModel {
   
   var showCommentBottomSheetObservable: Observable<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)> { get }
   
-  var showBoardBottomSheetObservable: Observable<BoardBottomSheetViewController.AccessType> { get }
+  var showBoardBottomSheetObservable: Observable<(BoardBottomSheetViewController.AccessType, Bool)> { get }
 }
 
 protocol FeedLikeDelegate: AnyObject {
@@ -92,7 +92,7 @@ final class BoardDetailViewModel {
   private let decoratorNameSubject              = PublishSubject<(labelText: String, buttonText: String)>()
   private let bottomCellSubject                 = PublishSubject<(collectionViewHeight: CGFloat, offset: CGFloat)>()
   private let showCommentBottomSheetSubject     = PublishSubject<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)>()
-  private let boardBottomSheetAccessTypeSubject = ReplaySubject<BoardBottomSheetViewController.AccessType>.create(bufferSize: 1)
+  private let boardBottomSheetParameterSubject = ReplaySubject<(BoardBottomSheetViewController.AccessType, Bool)>.create(bufferSize: 1)
   private let boardOptionTappedSubject          = PublishSubject<Void>()
   private let targetIDSubject                   = BehaviorSubject<Int?>(value: nil)
   private let deleteIDSubject                   = PublishSubject<Int>()
@@ -157,7 +157,7 @@ extension BoardDetailViewModel {
       } else {
         accessType = .normal
       }
-      owner.boardBottomSheetAccessTypeSubject.onNext(accessType)
+      owner.boardBottomSheetParameterSubject.onNext((accessType, tuple.feed.isPinned))
       
       owner.comments.formUnion(tuple.comments) // 댓글 삽입
       owner.setCollectionView(tuple.collectionView, content: tuple.feed.toBoardModel)
@@ -343,9 +343,9 @@ extension BoardDetailViewModel: BoardDetailViewModelType {
     showCommentBottomSheetSubject.asObservable()
   }
   
-  var showBoardBottomSheetObservable: Observable<BoardBottomSheetViewController.AccessType> {
+  var showBoardBottomSheetObservable: Observable<(BoardBottomSheetViewController.AccessType, Bool)> {
     boardOptionTappedSubject
-      .withLatestFrom(boardBottomSheetAccessTypeSubject)
+      .withLatestFrom(boardBottomSheetParameterSubject)
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -41,6 +41,8 @@ protocol BoardDetailViewModelType: BoardDetailViewModel {
   var decoratorNameObserable: Observable<(labelText: String, buttonText: String)> { get }
   
   var showCommentBottomSheetObservable: Observable<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)> { get }
+  
+  var showBoardBottomSheetObservable: Observable<BoardBottomSheetViewController.AccessType> { get }
 }
 
 protocol FeedLikeDelegate: AnyObject {
@@ -84,15 +86,17 @@ final class BoardDetailViewModel {
   
   // MARK: Subjects
   
-  private let collectionViewSubject           = PublishSubject<UICollectionView>()
-  private let commentInputSubject             = PublishSubject<String>()
-  private let editCommentTextSubject          = PublishSubject<String>()
-  private let decoratorNameSubject            = PublishSubject<(labelText: String, buttonText: String)>()
-  private let bottomCellSubject               = PublishSubject<(collectionViewHeight: CGFloat, offset: CGFloat)>()
-  private let showCommentBottomSheetSubject   = PublishSubject<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)>()
-  private let targetIDSubject                 = BehaviorSubject<Int?>(value: nil)
-  private let deleteIDSubject                 = PublishSubject<Int>()
-  private let commentOptionSubject            = BehaviorSubject<CommentOption>(value: .commentOrReply)
+  private let collectionViewSubject             = PublishSubject<UICollectionView>()
+  private let commentInputSubject               = PublishSubject<String>()
+  private let editCommentTextSubject            = PublishSubject<String>()
+  private let decoratorNameSubject              = PublishSubject<(labelText: String, buttonText: String)>()
+  private let bottomCellSubject                 = PublishSubject<(collectionViewHeight: CGFloat, offset: CGFloat)>()
+  private let showCommentBottomSheetSubject     = PublishSubject<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)>()
+  private let boardBottomSheetAccessTypeSubject = ReplaySubject<BoardBottomSheetViewController.AccessType>.create(bufferSize: 1)
+  private let boardOptionTappedSubject          = PublishSubject<Void>()
+  private let targetIDSubject                   = BehaviorSubject<Int?>(value: nil)
+  private let deleteIDSubject                   = PublishSubject<Int>()
+  private let commentOptionSubject              = BehaviorSubject<CommentOption>(value: .commentOrReply)
   
   // MARK: - Initializations
   
@@ -144,6 +148,17 @@ extension BoardDetailViewModel {
       if let like = tuple.feed.isLike {
         owner.boardLike = like
       }
+      
+      let accessType: BoardBottomSheetViewController.AccessType
+      if tuple.feed.isAuthor {
+        accessType = .author
+      } else if tuple.feed.isHost {
+        accessType = .host
+      } else {
+        accessType = .normal
+      }
+      owner.boardBottomSheetAccessTypeSubject.onNext(accessType)
+      
       owner.comments.formUnion(tuple.comments) // 댓글 삽입
       owner.setCollectionView(tuple.collectionView, content: tuple.feed.toBoardModel)
       owner.applyInitialSnapshots()
@@ -327,6 +342,11 @@ extension BoardDetailViewModel: BoardDetailViewModelType {
   var showCommentBottomSheetObservable: Observable<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)> {
     showCommentBottomSheetSubject.asObservable()
   }
+  
+  var showBoardBottomSheetObservable: Observable<BoardBottomSheetViewController.AccessType> {
+    boardOptionTappedSubject
+      .withLatestFrom(boardBottomSheetAccessTypeSubject)
+  }
 }
 
 // MARK: - Diffable DataSource
@@ -452,7 +472,7 @@ extension BoardDetailViewModel: BoardDetailCollectionHeaderViewDelegate {
   }
   
   func didTappedSettingButton() {
-    PLUBToast.makeToast(text: "Setting Button Tapped")
+    boardOptionTappedSubject.onNext(Void())
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -40,7 +40,7 @@ protocol BoardDetailViewModelType: BoardDetailViewModel {
   /// decoratorView에 들어갈 적절한 text를 처리합니다.
   var decoratorNameObserable: Observable<(labelText: String, buttonText: String)> { get }
   
-  var showBottomSheetObservable: Observable<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)> { get }
+  var showCommentBottomSheetObservable: Observable<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)> { get }
 }
 
 protocol FeedLikeDelegate: AnyObject {
@@ -89,7 +89,7 @@ final class BoardDetailViewModel {
   private let editCommentTextSubject          = PublishSubject<String>()
   private let decoratorNameSubject            = PublishSubject<(labelText: String, buttonText: String)>()
   private let bottomCellSubject               = PublishSubject<(collectionViewHeight: CGFloat, offset: CGFloat)>()
-  private let showBottomSheetSubject          = PublishSubject<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)>()
+  private let showCommentBottomSheetSubject   = PublishSubject<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)>()
   private let targetIDSubject                 = BehaviorSubject<Int?>(value: nil)
   private let deleteIDSubject                 = PublishSubject<Int>()
   private let commentOptionSubject            = BehaviorSubject<CommentOption>(value: .commentOrReply)
@@ -324,8 +324,8 @@ extension BoardDetailViewModel: BoardDetailViewModelType {
     decoratorNameSubject.asObservable()
   }
   
-  var showBottomSheetObservable: Observable<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)> {
-    showBottomSheetSubject.asObservable()
+  var showCommentBottomSheetObservable: Observable<(commentID: Int, userType: CommentOptionBottomSheetViewController.UserAccessType)> {
+    showCommentBottomSheetSubject.asObservable()
   }
 }
 
@@ -487,7 +487,7 @@ extension BoardDetailViewModel: BoardDetailCollectionViewCellDelegate {
       accessType = .normal
     }
     
-    showBottomSheetSubject.onNext((commentID, accessType))
+    showCommentBottomSheetSubject.onNext((commentID, accessType))
   }
 }
 

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -150,7 +150,7 @@ final class BoardViewController: BaseViewController {
     
     if gestureRecognizer.state == .began {
       // 롱 프레스 터치가 시작될 떄
-      let bottomSheet = BoardBottomSheetViewController()
+      let bottomSheet = BoardBottomSheetViewController(accessType: .normal, isPinned: false)
       bottomSheet.delegate = self
       present(bottomSheet, animated: true)
     } else if gestureRecognizer.state == .ended {

--- a/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
@@ -65,18 +65,32 @@ final class BoardBottomSheetViewController: BottomSheetViewController {
     super.setupLayouts()
     contentView.addSubview(contentStackView)
     
-    [clipboardFixView, modifyBoardView, reportBoardView, deleteBoardView].forEach {
-      contentStackView.addArrangedSubview($0)
+    if accessType != .normal {
+      contentStackView.addArrangedSubview(clipboardFixView)
+    }
+    
+    if accessType == .author {
+      contentStackView.addArrangedSubview(modifyBoardView)
+      contentStackView.addArrangedSubview(deleteBoardView)
+    } else {
+      contentStackView.addArrangedSubview(reportBoardView)
     }
   }
   
   override func setupConstraints() {
     super.setupConstraints()
     
-    [clipboardFixView, modifyBoardView, reportBoardView, deleteBoardView].forEach {
-      $0.snp.makeConstraints {
-        $0.height.equalTo(Metrics.Size.listHeight)
-      }
+    let heightConstraint: (ConstraintMaker) -> Void = { $0.height.equalTo(Metrics.Size.listHeight) }
+    
+    if accessType != .normal {
+      clipboardFixView.snp.makeConstraints(heightConstraint)
+    }
+    
+    if accessType == .author {
+      modifyBoardView.snp.makeConstraints(heightConstraint)
+      deleteBoardView.snp.makeConstraints(heightConstraint)
+    } else {
+      reportBoardView.snp.makeConstraints(heightConstraint)
     }
     
     contentStackView.snp.makeConstraints {
@@ -88,29 +102,33 @@ final class BoardBottomSheetViewController: BottomSheetViewController {
   
   override func bind() {
     super.bind()
-    clipboardFixView.button.rx.tap
-      .subscribe(with: self) { owner, _ in
-        owner.delegate?.selectedBoardSheetType(type: .fix)
-      }
-      .disposed(by: disposeBag)
+    if accessType != .normal {
+      clipboardFixView.button.rx.tap
+        .subscribe(with: self) { owner, _ in
+          owner.delegate?.selectedBoardSheetType(type: .fix)
+        }
+        .disposed(by: disposeBag)
+    }
     
-    modifyBoardView.button.rx.tap
-      .subscribe(with: self) { owner, _ in
-        owner.delegate?.selectedBoardSheetType(type: .modify)
-      }
-      .disposed(by: disposeBag)
-    
-    reportBoardView.button.rx.tap
-      .subscribe(with: self) { owner, _ in
-        owner.delegate?.selectedBoardSheetType(type: .report)
-      }
-      .disposed(by: disposeBag)
-    
-    deleteBoardView.button.rx.tap
-      .subscribe(with: self) { owner, _ in
-        owner.delegate?.selectedBoardSheetType(type: .delete)
-      }
-      .disposed(by: disposeBag)
+    if accessType == .author {
+      modifyBoardView.button.rx.tap
+        .subscribe(with: self) { owner, _ in
+          owner.delegate?.selectedBoardSheetType(type: .modify)
+        }
+        .disposed(by: disposeBag)
+      
+      deleteBoardView.button.rx.tap
+        .subscribe(with: self) { owner, _ in
+          owner.delegate?.selectedBoardSheetType(type: .delete)
+        }
+        .disposed(by: disposeBag)
+    } else {
+      reportBoardView.button.rx.tap
+        .subscribe(with: self) { owner, _ in
+          owner.delegate?.selectedBoardSheetType(type: .report)
+        }
+        .disposed(by: disposeBag)
+    }
   }
 }
 

--- a/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
@@ -29,7 +29,7 @@ final class BoardBottomSheetViewController: BottomSheetViewController {
   weak var delegate: BoardBottomSheetDelegate?
   
   private let accessType: AccessType
-  private let accessViewControllerType: AccessViewControllerType
+  private let isPinned: Bool
   
   // MARK: - UI Components
   
@@ -38,7 +38,10 @@ final class BoardBottomSheetViewController: BottomSheetViewController {
     $0.spacing = 8
   }
   
-  private lazy var clipboardFixView = BottomSheetListView(text: accessViewControllerType.text, image: "pinBlack")
+  private lazy var clipboardFixView = BottomSheetListView(
+    text: isPinned ? "클립보드 고정 해제" : "클립보드에 고정",
+    image: "pinBlack"
+  )
   private lazy var modifyBoardView  = BottomSheetListView(text: "게시글 수정", image: "editBlack")
   private lazy var reportBoardView  = BottomSheetListView(text: "게시글 신고", image: "lightBeaconMain")
   private lazy var deleteBoardView  = BottomSheetListView(text: "게시글 삭제", image: "trashRed", textColor: .error)
@@ -46,9 +49,9 @@ final class BoardBottomSheetViewController: BottomSheetViewController {
   
   // MARK: - Initializations
   
-  init(accessType: AccessType = .normal, in accessViewControllerType: AccessViewControllerType = .mainPage) {
+  init(accessType: AccessType, isPinned: Bool) {
     self.accessType = accessType
-    self.accessViewControllerType = accessViewControllerType
+    self.isPinned = isPinned
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -124,22 +127,5 @@ extension BoardBottomSheetViewController {
     
     /// 일반
     case normal
-  }
-  
-  /// 접근한 뷰 컨트롤러
-  enum AccessViewControllerType {
-    
-    case mainPage
-    
-    case clipboard
-    
-    fileprivate var text: String {
-      switch self {
-      case .clipboard:
-        return "클립보드 고정 해제"
-      case .mainPage:
-        return "클립보드에 고정"
-      }
-    }
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
@@ -24,17 +24,39 @@ enum BoardBottomSheetType {
 
 final class BoardBottomSheetViewController: BottomSheetViewController {
   
+  // MARK: - Properties
+  
   weak var delegate: BoardBottomSheetDelegate?
+  
+  private let accessType: AccessType
+  private let accessViewControllerType: AccessViewControllerType
+  
+  // MARK: - UI Components
   
   private let contentStackView = UIStackView().then {
     $0.axis = .vertical
     $0.spacing = 8
   }
   
-  private let clipboardFixView = BottomSheetListView(text: "클립보드에 고정", image: "pinBlack")
-  private let modifyBoardView  = BottomSheetListView(text: "게시글 수정", image: "editBlack")
-  private let reportBoardView  = BottomSheetListView(text: "게시글 신고", image: "lightBeaconMain")
-  private let deleteBoardView  = BottomSheetListView(text: "게시글 삭제", image: "trashRed", textColor: .error)
+  private lazy var clipboardFixView = BottomSheetListView(text: accessViewControllerType.text, image: "pinBlack")
+  private lazy var modifyBoardView  = BottomSheetListView(text: "게시글 수정", image: "editBlack")
+  private lazy var reportBoardView  = BottomSheetListView(text: "게시글 신고", image: "lightBeaconMain")
+  private lazy var deleteBoardView  = BottomSheetListView(text: "게시글 삭제", image: "trashRed", textColor: .error)
+  
+  
+  // MARK: - Initializations
+  
+  init(accessType: AccessType = .normal, in accessViewControllerType: AccessViewControllerType = .mainPage) {
+    self.accessType = accessType
+    self.accessViewControllerType = accessViewControllerType
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Configurations
   
   override func setupLayouts() {
     super.setupLayouts()

--- a/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
@@ -103,4 +103,21 @@ extension BoardBottomSheetViewController {
     /// 일반
     case normal
   }
+  
+  /// 접근한 뷰 컨트롤러
+  enum AccessViewControllerType {
+    
+    case mainPage
+    
+    case clipboard
+    
+    fileprivate var text: String {
+      switch self {
+      case .clipboard:
+        return "클립보드 고정 해제"
+      case .mainPage:
+        return "클립보드에 고정"
+      }
+    }
+  }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
@@ -88,3 +88,19 @@ final class BoardBottomSheetViewController: BottomSheetViewController {
       .disposed(by: disposeBag)
   }
 }
+
+// MARK: - Enum Type
+
+extension BoardBottomSheetViewController {
+  enum AccessType {
+    
+    /// 호스트
+    case host
+    
+    /// 게시글 저자
+    case author
+    
+    /// 일반
+    case normal
+  }
+}


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 상세 게시글 화면(BoardDetailViewController)에서 게시글 바텀시트가 띄워지도록 구현했습니다.

🌱 PR 포인트
- BoardBottomSheetViewController에 initializer를 추가했습니다.
   - accessType: 사용자 타입을 의미합니다. `author`, `host`, `normal`이 존재하며 각각 `게시글 저자`, `호스트`, `일반 유저`를 뜻합니다.
   - isPinned: 해당 게시글이 고정되어있는지를 나타냅니다. 고정 여부에 따라 보여지는 텍스트가 달라집니다. 만약 고정되어있는 게시글에서 바텀시트가 띄워지는 경우, `클립보드 고정 해제` 문구가 나타나고, 고정되어있지 않는 상태이면 `클립보드에 고정`이 나타납니다.


## 📸 스크린샷
|host|author|normal|
|:--:|:-:|:-:|
|![RPReplay_Final1683717898](https://github.com/PLUB2022/PLUB-iOS/assets/57972338/32a6306b-025f-42e8-b5b6-c4093eeb7837)|![Simulator Screen Recording - iPhone 14 Pro - 2023-05-10 at 20 29 54](https://github.com/PLUB2022/PLUB-iOS/assets/57972338/a568bc51-404d-4089-af4f-bca9ccba05de)|![Simulator Screen Recording - iPhone 14 Pro - 2023-05-10 at 20 30 18](https://github.com/PLUB2022/PLUB-iOS/assets/57972338/fd759b55-9927-433b-8e2e-63e069541a32)|

## 📮 관련 이슈
- #335

