### PR TITLE
[FEAT] 투두추가 일부 API 연동

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		705F820E29B1142800830C4F /* MainPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705F820D29B1142800830C4F /* MainPageHeaderView.swift */; };
 		705F821029B127DF00830C4F /* MainPageNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705F820F29B127DF00830C4F /* MainPageNavigationView.swift */; };
 		705F821229B2FCEC00830C4F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 705F821129B2FCEC00830C4F /* GoogleService-Info.plist */; };
+		705FD2742A0E895800F353FE /* AddTodolistBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD2732A0E895800F353FE /* AddTodolistBottomSheetViewController.swift */; };
 		706315962A0BA93400DD8EFE /* AddTodoListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315952A0BA93400DD8EFE /* AddTodoListViewModel.swift */; };
 		706315982A0BAA6000DD8EFE /* CreateTodoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */; };
 		7063159A2A0BAAE200DD8EFE /* CreateTodoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */; };
@@ -468,6 +469,7 @@
 		705F820D29B1142800830C4F /* MainPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageHeaderView.swift; sourceTree = "<group>"; };
 		705F820F29B127DF00830C4F /* MainPageNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageNavigationView.swift; sourceTree = "<group>"; };
 		705F821129B2FCEC00830C4F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		705FD2732A0E895800F353FE /* AddTodolistBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodolistBottomSheetViewController.swift; sourceTree = "<group>"; };
 		706315952A0BA93400DD8EFE /* AddTodoListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodoListViewModel.swift; sourceTree = "<group>"; };
 		706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoRequest.swift; sourceTree = "<group>"; };
 		706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoResponse.swift; sourceTree = "<group>"; };
@@ -1088,6 +1090,7 @@
 				70727A4629D6D507003DE956 /* TodoInfoView.swift */,
 				70FE55312A08CC5E00F11097 /* AddTodoView.swift */,
 				7063159B2A0BB0E700DD8EFE /* TodoView.swift */,
+				705FD2732A0E895800F353FE /* AddTodolistBottomSheetViewController.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -2894,6 +2897,7 @@
 				C3FC181729852D370083039A /* QuestionHeaderView.swift in Sources */,
 				C374E79A29FC3BCA004738C2 /* TodoListView.swift in Sources */,
 				C34F048829C7203600E5B67E /* MeetingCreateSuccessViewController.swift in Sources */,
+				705FD2742A0E895800F353FE /* AddTodolistBottomSheetViewController.swift in Sources */,
 				C38C573E29EC5910002550DD /* MeetingMemberResponse.swift in Sources */,
 				706315982A0BAA6000DD8EFE /* CreateTodoRequest.swift in Sources */,
 				70727A4329D5D679003DE956 /* TodoAlertController.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		706315982A0BAA6000DD8EFE /* CreateTodoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */; };
 		7063159A2A0BAAE200DD8EFE /* CreateTodoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */; };
 		7063159C2A0BB0E700DD8EFE /* TodoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7063159B2A0BB0E700DD8EFE /* TodoView.swift */; };
+		7063159E2A0BBF6B00DD8EFE /* InquireTodolistByDateResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7063159D2A0BBF6B00DD8EFE /* InquireTodolistByDateResponse.swift */; };
 		70727A1F29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */; };
 		70727A2129BF8F2A003DE956 /* Ex+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A2029BF8F2A003DE956 /* Ex+Date.swift */; };
 		70727A2329C4A9E4003DE956 /* CreateBoardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A2229C4A9E4003DE956 /* CreateBoardViewController.swift */; };
@@ -471,6 +472,7 @@
 		706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoRequest.swift; sourceTree = "<group>"; };
 		706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoResponse.swift; sourceTree = "<group>"; };
 		7063159B2A0BB0E700DD8EFE /* TodoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoView.swift; sourceTree = "<group>"; };
+		7063159D2A0BBF6B00DD8EFE /* InquireTodolistByDateResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquireTodolistByDateResponse.swift; sourceTree = "<group>"; };
 		70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSystemCollectionViewCell.swift; sourceTree = "<group>"; };
 		70727A2029BF8F2A003DE956 /* Ex+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+Date.swift"; sourceTree = "<group>"; };
 		70727A2229C4A9E4003DE956 /* CreateBoardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBoardViewController.swift; sourceTree = "<group>"; };
@@ -1107,6 +1109,7 @@
 				70C9CC9E2A03FE8200BEB5F2 /* CompleteTodolistResponse.swift */,
 				70C9CCA52A05044400BEB5F2 /* LikeTodolistResponse.swift */,
 				706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */,
+				7063159D2A0BBF6B00DD8EFE /* InquireTodolistByDateResponse.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -2729,6 +2732,7 @@
 				C374E79329FC1E52004738C2 /* MyTodoTableViewCell.swift in Sources */,
 				BA57F3FF29ED814500A9F790 /* ArchiveUploadedPictureCell.swift in Sources */,
 				70A420AB298FAD000026E9F9 /* TopTabCollectionViewCell.swift in Sources */,
+				7063159E2A0BBF6B00DD8EFE /* InquireTodolistByDateResponse.swift in Sources */,
 				70A420BF29914B690026E9F9 /* RequestBookmarkResponse.swift in Sources */,
 				BAE1AD952944775C00CE36B9 /* PolicyViewController.swift in Sources */,
 				BA5DEB302974D8E200650788 /* NetworkResult.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -43,6 +43,9 @@
 		705F821029B127DF00830C4F /* MainPageNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705F820F29B127DF00830C4F /* MainPageNavigationView.swift */; };
 		705F821229B2FCEC00830C4F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 705F821129B2FCEC00830C4F /* GoogleService-Info.plist */; };
 		706315962A0BA93400DD8EFE /* AddTodoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315952A0BA93400DD8EFE /* AddTodoViewModel.swift */; };
+		706315982A0BAA6000DD8EFE /* CreateTodoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */; };
+		7063159A2A0BAAE200DD8EFE /* CreateTodoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */; };
+		7063159C2A0BB0E700DD8EFE /* TodoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7063159B2A0BB0E700DD8EFE /* TodoView.swift */; };
 		70727A1F29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */; };
 		70727A2129BF8F2A003DE956 /* Ex+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A2029BF8F2A003DE956 /* Ex+Date.swift */; };
 		70727A2329C4A9E4003DE956 /* CreateBoardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A2229C4A9E4003DE956 /* CreateBoardViewController.swift */; };
@@ -56,7 +59,7 @@
 		70727A3B29D32E4C003DE956 /* InquireAllTodoTimelineResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A3A29D32E4C003DE956 /* InquireAllTodoTimelineResponse.swift */; };
 		70727A3D29D447D7003DE956 /* CheckTodoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A3C29D447D7003DE956 /* CheckTodoView.swift */; };
 		70727A3F29D47BB6003DE956 /* TodolistBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A3E29D47BB6003DE956 /* TodolistBottomSheetViewController.swift */; };
-		70727A4129D485E0003DE956 /* AddTodoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A4029D485E0003DE956 /* AddTodoViewController.swift */; };
+		70727A4129D485E0003DE956 /* AddTodoListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A4029D485E0003DE956 /* AddTodoListViewController.swift */; };
 		70727A4329D5D679003DE956 /* TodoAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A4229D5D679003DE956 /* TodoAlertController.swift */; };
 		70727A4529D5E570003DE956 /* TodoAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A4429D5E570003DE956 /* TodoAlertView.swift */; };
 		70727A4729D6D507003DE956 /* TodoInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A4629D6D507003DE956 /* TodoInfoView.swift */; };
@@ -465,6 +468,9 @@
 		705F820F29B127DF00830C4F /* MainPageNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageNavigationView.swift; sourceTree = "<group>"; };
 		705F821129B2FCEC00830C4F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		706315952A0BA93400DD8EFE /* AddTodoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodoViewModel.swift; sourceTree = "<group>"; };
+		706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoRequest.swift; sourceTree = "<group>"; };
+		706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoResponse.swift; sourceTree = "<group>"; };
+		7063159B2A0BB0E700DD8EFE /* TodoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoView.swift; sourceTree = "<group>"; };
 		70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSystemCollectionViewCell.swift; sourceTree = "<group>"; };
 		70727A2029BF8F2A003DE956 /* Ex+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+Date.swift"; sourceTree = "<group>"; };
 		70727A2229C4A9E4003DE956 /* CreateBoardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBoardViewController.swift; sourceTree = "<group>"; };
@@ -478,7 +484,7 @@
 		70727A3A29D32E4C003DE956 /* InquireAllTodoTimelineResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquireAllTodoTimelineResponse.swift; sourceTree = "<group>"; };
 		70727A3C29D447D7003DE956 /* CheckTodoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckTodoView.swift; sourceTree = "<group>"; };
 		70727A3E29D47BB6003DE956 /* TodolistBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodolistBottomSheetViewController.swift; sourceTree = "<group>"; };
-		70727A4029D485E0003DE956 /* AddTodoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodoViewController.swift; sourceTree = "<group>"; };
+		70727A4029D485E0003DE956 /* AddTodoListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodoListViewController.swift; sourceTree = "<group>"; };
 		70727A4229D5D679003DE956 /* TodoAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoAlertController.swift; sourceTree = "<group>"; };
 		70727A4429D5E570003DE956 /* TodoAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoAlertView.swift; sourceTree = "<group>"; };
 		70727A4629D6D507003DE956 /* TodoInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoInfoView.swift; sourceTree = "<group>"; };
@@ -1038,7 +1044,7 @@
 				705F81C229AFAA3B00830C4F /* BoardViewController.swift */,
 				705F81C429AFAA5200830C4F /* TodolistViewController.swift */,
 				70727A2229C4A9E4003DE956 /* CreateBoardViewController.swift */,
-				70727A4029D485E0003DE956 /* AddTodoViewController.swift */,
+				70727A4029D485E0003DE956 /* AddTodoListViewController.swift */,
 			);
 			path = MainPage;
 			sourceTree = "<group>";
@@ -1079,6 +1085,7 @@
 				70727A4429D5E570003DE956 /* TodoAlertView.swift */,
 				70727A4629D6D507003DE956 /* TodoInfoView.swift */,
 				70FE55312A08CC5E00F11097 /* AddTodoView.swift */,
+				7063159B2A0BB0E700DD8EFE /* TodoView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -1099,6 +1106,7 @@
 				70C9CC942A03720200BEB5F2 /* InquireTodolistResponse.swift */,
 				70C9CC9E2A03FE8200BEB5F2 /* CompleteTodolistResponse.swift */,
 				70C9CCA52A05044400BEB5F2 /* LikeTodolistResponse.swift */,
+				706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1171,6 +1179,7 @@
 			isa = PBXGroup;
 			children = (
 				70C9CCA32A03FFC000BEB5F2 /* ProofTodolistRequest.swift */,
+				706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -2649,6 +2658,7 @@
 				C38A5B93297ACF5B00485355 /* LocationControl.swift in Sources */,
 				C38A5BA3297B17EF00485355 /* MeetingLocationViewModel.swift in Sources */,
 				C359FEA6299FDF2800B2F561 /* CreateScheduleViewController.swift in Sources */,
+				7063159C2A0BB0E700DD8EFE /* TodoView.swift in Sources */,
 				C3D3EA2829EF0B8C00E7E5BB /* EditApplicationViewModel.swift in Sources */,
 				7095A58A292E58F9002A52E6 /* ToggleButton.swift in Sources */,
 				BA780E0D297133F80032C178 /* Router.swift in Sources */,
@@ -2747,7 +2757,7 @@
 				C3B3435129BDEE5100935B73 /* MyPageSectionFooterView.swift in Sources */,
 				70A420C229914B890026E9F9 /* InquireInterestResponse.swift in Sources */,
 				C383967C29A25A3E005998A5 /* ScheduleRouter.swift in Sources */,
-				70727A4129D485E0003DE956 /* AddTodoViewController.swift in Sources */,
+				70727A4129D485E0003DE956 /* AddTodoListViewController.swift in Sources */,
 				70727A3729D32DAA003DE956 /* TodolistService.swift in Sources */,
 				C361743629AFB875006AEAB1 /* MeetingCollectionViewCell.swift in Sources */,
 				BA4CCDF129EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift in Sources */,
@@ -2827,6 +2837,7 @@
 				70A420B629914B4F0026E9F9 /* CategoryMeetingResponse.swift in Sources */,
 				70F1DFD42979508000F9BC83 /* CategoryService.swift in Sources */,
 				BA85BAA829A738DF00B4C59A /* BoardsResponse.swift in Sources */,
+				7063159A2A0BAAE200DD8EFE /* CreateTodoResponse.swift in Sources */,
 				70727A3529D32CBD003DE956 /* TodolistRouter.swift in Sources */,
 				C35AFD012998B0A500AB5CD3 /* EditMeetingViewModel.swift in Sources */,
 				BA8D949A29E96FF00075ACD8 /* ArchivePopUpViewController.swift in Sources */,
@@ -2880,6 +2891,7 @@
 				C374E79A29FC3BCA004738C2 /* TodoListView.swift in Sources */,
 				C34F048829C7203600E5B67E /* MeetingCreateSuccessViewController.swift in Sources */,
 				C38C573E29EC5910002550DD /* MeetingMemberResponse.swift in Sources */,
+				706315982A0BAA6000DD8EFE /* CreateTodoRequest.swift in Sources */,
 				70727A4329D5D679003DE956 /* TodoAlertController.swift in Sources */,
 				7085678C28EFBDC1008047DC /* RegisterInterestViewController.swift in Sources */,
 				C36E64CF29F1AEE300C6C3CF /* EditApplicationUseCase.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		705F820E29B1142800830C4F /* MainPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705F820D29B1142800830C4F /* MainPageHeaderView.swift */; };
 		705F821029B127DF00830C4F /* MainPageNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705F820F29B127DF00830C4F /* MainPageNavigationView.swift */; };
 		705F821229B2FCEC00830C4F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 705F821129B2FCEC00830C4F /* GoogleService-Info.plist */; };
+		706315962A0BA93400DD8EFE /* AddTodoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315952A0BA93400DD8EFE /* AddTodoViewModel.swift */; };
 		70727A1F29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */; };
 		70727A2129BF8F2A003DE956 /* Ex+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A2029BF8F2A003DE956 /* Ex+Date.swift */; };
 		70727A2329C4A9E4003DE956 /* CreateBoardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A2229C4A9E4003DE956 /* CreateBoardViewController.swift */; };
@@ -463,6 +464,7 @@
 		705F820D29B1142800830C4F /* MainPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageHeaderView.swift; sourceTree = "<group>"; };
 		705F820F29B127DF00830C4F /* MainPageNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageNavigationView.swift; sourceTree = "<group>"; };
 		705F821129B2FCEC00830C4F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		706315952A0BA93400DD8EFE /* AddTodoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodoViewModel.swift; sourceTree = "<group>"; };
 		70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSystemCollectionViewCell.swift; sourceTree = "<group>"; };
 		70727A2029BF8F2A003DE956 /* Ex+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+Date.swift"; sourceTree = "<group>"; };
 		70727A2229C4A9E4003DE956 /* CreateBoardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBoardViewController.swift; sourceTree = "<group>"; };
@@ -1060,6 +1062,7 @@
 				705F820829B0EE6600830C4F /* BoardViewModel.swift */,
 				70727A2429C4C21A003DE956 /* CreateBoardViewModel.swift */,
 				70C9CC8E2A00864400BEB5F2 /* TodolistViewModel.swift */,
+				706315952A0BA93400DD8EFE /* AddTodoViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -2604,6 +2607,7 @@
 				BA2173BD29F61A36000D72B1 /* EditArchiveUseCase.swift in Sources */,
 				BAB2E56C29E30A13006B7BDC /* PostCommentUseCase.swift in Sources */,
 				C39E09B629C604DE00ECAD11 /* RecruitingFooterView.swift in Sources */,
+				706315962A0BA93400DD8EFE /* AddTodoViewModel.swift in Sources */,
 				BA340E1629782207002BAF2C /* IntroduceTagCollectionViewCell.swift in Sources */,
 				70197B7D29549B96000503F6 /* SelectedCategoryFilterHeaderView.swift in Sources */,
 				C39E09B829C6089300ECAD11 /* RecruitingSectionFooterView.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -42,7 +42,7 @@
 		705F820E29B1142800830C4F /* MainPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705F820D29B1142800830C4F /* MainPageHeaderView.swift */; };
 		705F821029B127DF00830C4F /* MainPageNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705F820F29B127DF00830C4F /* MainPageNavigationView.swift */; };
 		705F821229B2FCEC00830C4F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 705F821129B2FCEC00830C4F /* GoogleService-Info.plist */; };
-		706315962A0BA93400DD8EFE /* AddTodoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315952A0BA93400DD8EFE /* AddTodoViewModel.swift */; };
+		706315962A0BA93400DD8EFE /* AddTodoListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315952A0BA93400DD8EFE /* AddTodoListViewModel.swift */; };
 		706315982A0BAA6000DD8EFE /* CreateTodoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */; };
 		7063159A2A0BAAE200DD8EFE /* CreateTodoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */; };
 		7063159C2A0BB0E700DD8EFE /* TodoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7063159B2A0BB0E700DD8EFE /* TodoView.swift */; };
@@ -468,7 +468,7 @@
 		705F820D29B1142800830C4F /* MainPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageHeaderView.swift; sourceTree = "<group>"; };
 		705F820F29B127DF00830C4F /* MainPageNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageNavigationView.swift; sourceTree = "<group>"; };
 		705F821129B2FCEC00830C4F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
-		706315952A0BA93400DD8EFE /* AddTodoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodoViewModel.swift; sourceTree = "<group>"; };
+		706315952A0BA93400DD8EFE /* AddTodoListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodoListViewModel.swift; sourceTree = "<group>"; };
 		706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoRequest.swift; sourceTree = "<group>"; };
 		706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoResponse.swift; sourceTree = "<group>"; };
 		7063159B2A0BB0E700DD8EFE /* TodoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoView.swift; sourceTree = "<group>"; };
@@ -1070,7 +1070,7 @@
 				705F820829B0EE6600830C4F /* BoardViewModel.swift */,
 				70727A2429C4C21A003DE956 /* CreateBoardViewModel.swift */,
 				70C9CC8E2A00864400BEB5F2 /* TodolistViewModel.swift */,
-				706315952A0BA93400DD8EFE /* AddTodoViewModel.swift */,
+				706315952A0BA93400DD8EFE /* AddTodoListViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -2619,7 +2619,7 @@
 				BA2173BD29F61A36000D72B1 /* EditArchiveUseCase.swift in Sources */,
 				BAB2E56C29E30A13006B7BDC /* PostCommentUseCase.swift in Sources */,
 				C39E09B629C604DE00ECAD11 /* RecruitingFooterView.swift in Sources */,
-				706315962A0BA93400DD8EFE /* AddTodoViewModel.swift in Sources */,
+				706315962A0BA93400DD8EFE /* AddTodoListViewModel.swift in Sources */,
 				BA340E1629782207002BAF2C /* IntroduceTagCollectionViewCell.swift in Sources */,
 				70197B7D29549B96000503F6 /* SelectedCategoryFilterHeaderView.swift in Sources */,
 				C39E09B829C6089300ECAD11 /* RecruitingSectionFooterView.swift in Sources */,

--- a/PLUB/Sources/Models/Todolist/Request/CreateTodoRequest.swift
+++ b/PLUB/Sources/Models/Todolist/Request/CreateTodoRequest.swift
@@ -1,0 +1,13 @@
+//
+//  CreateTodoRequest.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/05/10.
+//
+
+import Foundation
+
+struct CreateTodoRequest: Codable {
+  let content: String
+  let date: String
+}

--- a/PLUB/Sources/Models/Todolist/Response/CreateTodoResponse.swift
+++ b/PLUB/Sources/Models/Todolist/Response/CreateTodoResponse.swift
@@ -1,0 +1,23 @@
+//
+//  CreateTodoResponse.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/05/10.
+//
+
+import Foundation
+
+struct CreateTodoResponse: Codable {
+  let todoID: Int
+  let content: String
+  let date: String
+  let isChecked: Bool
+  let isProof: Bool
+  let proofImage: String
+  let isAuthor: Bool
+  
+  enum CodingKeys: String, CodingKey {
+    case todoID = "todoId"
+    case content, date, isChecked, isProof, proofImage, isAuthor
+  }
+}

--- a/PLUB/Sources/Models/Todolist/Response/InquireTodolistByDateResponse.swift
+++ b/PLUB/Sources/Models/Todolist/Response/InquireTodolistByDateResponse.swift
@@ -1,0 +1,21 @@
+//
+//  InquireTodolistByDateResponse.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/05/10.
+//
+
+import Foundation
+
+struct InquireTodolistByDateResponse: Codable {
+  let todoTimelineID: Int
+  let date: String
+  let totalLikes: Int
+  let isAuthor: Bool
+  let todoList: [Todo]
+  
+  enum CodingKeys: String, CodingKey {
+    case todoTimelineID = "todoTimelineId"
+    case date, totalLikes, isAuthor, todoList
+  }
+}

--- a/PLUB/Sources/Network/Routers/TodolistRouter.swift
+++ b/PLUB/Sources/Network/Routers/TodolistRouter.swift
@@ -65,10 +65,7 @@ extension TodolistRouter: Router {
   }
   
   var headers: HeaderType {
-    switch self {
-    case .inquireAllTodoTimeline, .inquireTodolist, .completeTodolist, .proofTodolist, .cancelCompleteTodolist, .likeTodolist, .createTodo, .inquireTodolistByDate:
-      return .withAccessToken
-    }
+    return .withAccessToken
   }
 }
 

--- a/PLUB/Sources/Network/Routers/TodolistRouter.swift
+++ b/PLUB/Sources/Network/Routers/TodolistRouter.swift
@@ -14,6 +14,7 @@ enum TodolistRouter {
   case cancelCompleteTodolist(Int, Int)
   case proofTodolist(Int, Int, ProofTodolistRequest)
   case likeTodolist(Int, Int)
+  case createTodo(Int, CreateTodoRequest)
 }
 
 extension TodolistRouter: Router {
@@ -23,7 +24,7 @@ extension TodolistRouter: Router {
       return .get
     case .completeTodolist, .cancelCompleteTodolist, .likeTodolist:
       return .put
-    case .proofTodolist:
+    case .proofTodolist, .createTodo:
       return .post
     }
   }
@@ -42,6 +43,8 @@ extension TodolistRouter: Router {
       return "/plubbings/\(plubbingID)/todolist/\(todolistID)/cancel"
     case .likeTodolist(let plubbingID, let timelineID):
       return "/plubbings/\(plubbingID)/timeline/\(timelineID)/like"
+    case .createTodo(let plubbingID, _):
+      return "/plubbings/\(plubbingID)/todolist"
     }
   }
   
@@ -53,12 +56,14 @@ extension TodolistRouter: Router {
       return .plain
     case .proofTodolist(_, _, let request):
       return .body(request)
+    case .createTodo(_, let request):
+      return .body(request)
     }
   }
   
   var headers: HeaderType {
     switch self {
-    case .inquireAllTodoTimeline, .inquireTodolist, .completeTodolist, .proofTodolist, .cancelCompleteTodolist, .likeTodolist:
+    case .inquireAllTodoTimeline, .inquireTodolist, .completeTodolist, .proofTodolist, .cancelCompleteTodolist, .likeTodolist, .createTodo:
       return .withAccessToken
     }
   }

--- a/PLUB/Sources/Network/Routers/TodolistRouter.swift
+++ b/PLUB/Sources/Network/Routers/TodolistRouter.swift
@@ -15,12 +15,13 @@ enum TodolistRouter {
   case proofTodolist(Int, Int, ProofTodolistRequest)
   case likeTodolist(Int, Int)
   case createTodo(Int, CreateTodoRequest)
+  case inquireTodolistByDate(Int, String)
 }
 
 extension TodolistRouter: Router {
   var method: HTTPMethod {
     switch self {
-    case .inquireAllTodoTimeline, .inquireTodolist:
+    case .inquireAllTodoTimeline, .inquireTodolist, .inquireTodolistByDate:
       return .get
     case .completeTodolist, .cancelCompleteTodolist, .likeTodolist:
       return .put
@@ -45,6 +46,8 @@ extension TodolistRouter: Router {
       return "/plubbings/\(plubbingID)/timeline/\(timelineID)/like"
     case .createTodo(let plubbingID, _):
       return "/plubbings/\(plubbingID)/todolist"
+    case .inquireTodolistByDate(let plubbingID, let todoDate):
+      return "/plubbings/\(plubbingID)/timeline/\(todoDate)"
     }
   }
   
@@ -52,7 +55,7 @@ extension TodolistRouter: Router {
     switch self {
     case .inquireAllTodoTimeline(_, let cursorID):
       return .query(["cursorId": cursorID])
-    case .inquireTodolist, .completeTodolist, .cancelCompleteTodolist, .likeTodolist:
+    case .inquireTodolist, .completeTodolist, .cancelCompleteTodolist, .likeTodolist, .inquireTodolistByDate:
       return .plain
     case .proofTodolist(_, _, let request):
       return .body(request)
@@ -63,7 +66,7 @@ extension TodolistRouter: Router {
   
   var headers: HeaderType {
     switch self {
-    case .inquireAllTodoTimeline, .inquireTodolist, .completeTodolist, .proofTodolist, .cancelCompleteTodolist, .likeTodolist, .createTodo:
+    case .inquireAllTodoTimeline, .inquireTodolist, .completeTodolist, .proofTodolist, .cancelCompleteTodolist, .likeTodolist, .createTodo, .inquireTodolistByDate:
       return .withAccessToken
     }
   }

--- a/PLUB/Sources/Network/Services/TodolistService.swift
+++ b/PLUB/Sources/Network/Services/TodolistService.swift
@@ -70,4 +70,8 @@ extension TodolistService {
   func createTodo(plubbingID: Int, request: CreateTodoRequest) -> Observable<CreateTodoResponse> {
     sendObservableRequest(TodolistRouter.createTodo(plubbingID, request))
   }
+  
+  func inquireTodolistByDate(plubbingID: Int, todoDate: String) -> Observable<InquireTodolistByDateResponse> {
+    sendObservableRequest(TodolistRouter.inquireTodolistByDate(plubbingID, todoDate))
+  }
 }

--- a/PLUB/Sources/Network/Services/TodolistService.swift
+++ b/PLUB/Sources/Network/Services/TodolistService.swift
@@ -66,4 +66,8 @@ extension TodolistService {
   func likeTodolist(plubbingID: Int, timelineID: Int) -> Observable<LikeTodolistResponse> {
     sendObservableRequest(TodolistRouter.likeTodolist(plubbingID, timelineID))
   }
+  
+  func createTodo(plubbingID: Int, request: CreateTodoRequest) -> Observable<CreateTodoResponse> {
+    sendObservableRequest(TodolistRouter.createTodo(plubbingID, request))
+  }
 }

--- a/PLUB/Sources/Views/Home/MainPage/AddTodoListViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/AddTodoListViewController.swift
@@ -11,7 +11,9 @@ import FSCalendar
 import SnapKit
 import Then
 
-final class AddTodoViewController: BaseViewController {
+final class AddTodoListViewController: BaseViewController {
+  
+  private let viewModel: AddTodoListViewModelType
   
   private let scrollView = UIScrollView()
   
@@ -85,7 +87,7 @@ final class AddTodoViewController: BaseViewController {
   }
 }
 
-extension AddTodoViewController: FSCalendarDelegate, FSCalendarDataSource, FSCalendarDelegateAppearance {
+extension AddTodoListViewController: FSCalendarDelegate, FSCalendarDataSource, FSCalendarDelegateAppearance {
   func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, fillSelectionColorFor date: Date) -> UIColor? {
       return .main
   }

--- a/PLUB/Sources/Views/Home/MainPage/AddTodoListViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/AddTodoListViewController.swift
@@ -178,6 +178,14 @@ extension AddTodoListViewController: FSCalendarDelegate, FSCalendarDataSource, F
 }
 
 extension AddTodoListViewController: AddTodoViewDelegate {
+  func tappedMoreButton() {
+    print("탭")
+  }
+  
+  func whichTodoChecked(isChecked: Bool, todoID: Int) {
+    viewModel.whichTodoChecked.onNext((isChecked, todoID))
+  }
+  
   func whichCreateTodoRequest(request: CreateTodoRequest) {
     Log.debug("투두생성리퀘스트 \(request)")
     viewModel.whichCreateTodoRequest.onNext(request)

--- a/PLUB/Sources/Views/Home/MainPage/AddTodoListViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/AddTodoListViewController.swift
@@ -42,12 +42,22 @@ final class AddTodoListViewController: BaseViewController {
     $0.appearance.titleWeekendColor = .red
   }
   
-  private let addTodoView = AddTodoView().then {
+  private lazy var addTodoView = AddTodoView().then {
     $0.backgroundColor = .subMain
     $0.layer.borderWidth = 1
     $0.layer.borderColor = UIColor.main.cgColor
     $0.layer.cornerRadius = 10
     $0.layer.masksToBounds = true
+    $0.delegate = self
+  }
+  
+  init(viewModel: AddTodoListViewModelType) {
+    self.viewModel = viewModel
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
   }
   
   override func setupStyles() {

--- a/PLUB/Sources/Views/Home/MainPage/AddTodoListViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/AddTodoListViewController.swift
@@ -178,8 +178,10 @@ extension AddTodoListViewController: FSCalendarDelegate, FSCalendarDataSource, F
 }
 
 extension AddTodoListViewController: AddTodoViewDelegate {
-  func tappedMoreButton() {
-    print("탭")
+  func tappedMoreButton(todoID: Int, isChecked: Bool) {
+    let bottomSheet = AddTodolistBottomSheetViewController(type: isChecked ? .complete : .noComplete, todoID: todoID)
+    bottomSheet.delegate = self
+    present(bottomSheet, animated: true)
   }
   
   func whichTodoChecked(isChecked: Bool, todoID: Int) {
@@ -189,5 +191,19 @@ extension AddTodoListViewController: AddTodoViewDelegate {
   func whichCreateTodoRequest(request: CreateTodoRequest) {
     Log.debug("투두생성리퀘스트 \(request)")
     viewModel.whichCreateTodoRequest.onNext(request)
+  }
+}
+
+extension AddTodoListViewController: AddTodolistBottomSheetDelegate {
+  func proofImage(todoID: Int) {
+    
+  }
+  
+  func editTodo(todoID: Int) {
+    
+  }
+  
+  func deleteTodo(todoID: Int) {
+    
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/AddTodoListViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/AddTodoListViewController.swift
@@ -83,7 +83,7 @@ final class AddTodoListViewController: BaseViewController {
   
   override func setupStyles() {
     super.setupStyles()
-
+    viewModel.whichInquireDate.onNext(Date())
   }
   
   override func setupLayouts() {

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
@@ -94,13 +94,11 @@ final class AddTodoView: UIView {
       .arrangedSubviews.dropFirst()
       .forEach { $0.removeFromSuperview() }
     
-    let sortedModel = model.todoViewModel.sorted { $0.isChecked || $1.isChecked }
-    
     let inputTodoView = TodoView(type: .input)
     inputTodoView.delegate = self
     todoContainerView.addArrangedSubview(inputTodoView)
     
-    sortedModel.forEach { model in
+    model.todoViewModel.forEach { model in
       let todoView = TodoView(type: .todo)
       todoView.configureUI(with: .init(
         todoID: model.todoID,

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
@@ -16,17 +16,18 @@ enum TodoViewType {
   case todo // 입력한 투두에 대한 타입
 }
 
-struct TodoViewModel {
-  let isChecked: Bool
-  let content: String
-}
-
 struct AddTodoViewModel {
   let todoViewModel: [TodoViewModel]
 }
 
+protocol AddTodoViewDelegate: AnyObject {
+  func whichCreateTodoRequest(request: CreateTodoRequest)
+}
+
 final class AddTodoView: UIView {
   
+  weak var delegate: AddTodoViewDelegate?
+  private var date: Date?
   private(set) var completionHandler: ((Date) -> Void)?
   
   private let todoContainerView = UIStackView().then {
@@ -45,6 +46,7 @@ final class AddTodoView: UIView {
     super.init(frame: frame)
     configureUI()
     completionHandler = { [weak self] date in
+      self?.date = date
       let dateString = DateFormatterFactory.todolistDate.string(from: date)
       let isToday = Calendar.current.isDateInToday(date)
       self?.dateLabel.text = isToday ? "\(dateString) (오늘)" : dateString
@@ -76,6 +78,7 @@ final class AddTodoView: UIView {
   func configureUI(with model: AddTodoViewModel) {
     model.todoViewModel.forEach { model in
       let todoView = TodoView(type: .todo)
+      todoView.delegate = self
       todoView.configureUI(with: .init(
         isChecked: model.isChecked,
         content: model.content)
@@ -85,110 +88,10 @@ final class AddTodoView: UIView {
   }
 }
 
-extension AddTodoView {
-  final class TodoView: UIView {
-    
-    private let disposeBag = DisposeBag()
-    private let type: TodoViewType
-    
-    private lazy var emptyCheckView = UIView().then {
-      $0.layer.borderWidth = 1
-      $0.layer.borderColor = UIColor.lightGray.cgColor
-      $0.layer.cornerRadius = 3
-      $0.layer.masksToBounds = true
-    }
-    
-    private lazy var contentLabel = UILabel().then {
-      $0.text = "투두리스트목록"
-    }
-    
-    private lazy var checkBoxButton = CheckBoxButton(type: .none)
-    
-    private let todoTextField = UITextField().then {
-      $0.placeholder = "새로운 TO-DO 추가하기"
-      $0.layer.shouldRasterize = true
-    }
-    
-    private lazy var moreButton = UIButton().then {
-      $0.setImage(UIImage(named: "meatballMenuBlack"), for: .normal)
-    }
-    
-    private lazy var bottomLineView = UIView().then {
-      $0.backgroundColor = .lightGray
-    }
-    
-    init(type: TodoViewType) {
-      self.type = type
-      super.init(frame: .zero)
-      configureUI()
-      bind()
-    }
-    
-    required init(coder: NSCoder) {
-      fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func configureUI() {
-      switch type {
-      case .input:
-        [emptyCheckView, todoTextField].forEach { addSubview($0) }
-        todoTextField.addSubview(bottomLineView)
-        
-        emptyCheckView.snp.makeConstraints {
-          $0.size.equalTo(18)
-          $0.leading.directionalVerticalEdges.equalToSuperview().inset(7)
-        }
-        
-        todoTextField.snp.makeConstraints {
-          $0.leading.equalTo(emptyCheckView.snp.trailing).offset(7)
-          $0.directionalVerticalEdges.trailing.equalToSuperview()
-        }
-        
-        bottomLineView.snp.makeConstraints {
-          $0.directionalHorizontalEdges.bottom.equalToSuperview()
-          $0.height.equalTo(1)
-        }
-        
-      case .todo:
-        [checkBoxButton, contentLabel].forEach { addSubview($0) }
-        contentLabel.addSubview(bottomLineView)
-        contentLabel.addSubview(moreButton)
-        checkBoxButton.snp.makeConstraints {
-          $0.size.equalTo(18)
-          $0.leading.directionalVerticalEdges.equalToSuperview().inset(7)
-        }
-        
-        contentLabel.snp.makeConstraints {
-          $0.leading.equalTo(checkBoxButton.snp.trailing).offset(7)
-          $0.directionalVerticalEdges.equalToSuperview()
-          $0.trailing.equalToSuperview()
-        }
-        
-        bottomLineView.snp.makeConstraints {
-          $0.width.equalToSuperview()
-          $0.height.equalTo(1)
-          $0.bottom.equalToSuperview()
-        }
-        
-        moreButton.snp.makeConstraints {
-          $0.size.equalTo(32)
-          $0.directionalVerticalEdges.trailing.equalToSuperview()
-        }
-      }
-    }
-    
-    func configureUI(with model: TodoViewModel) {
-      contentLabel.text = model.content
-      checkBoxButton.isChecked = model.isChecked
-      contentLabel.attributedText = model.isChecked ? contentLabel.text?.strikeThrough() : NSAttributedString(string: contentLabel.text ?? "")
-    }
-    
-    private func bind() {
-      checkBoxButton.rx.isChecked
-        .subscribe(with: self) { owner, isChecked in
-          owner.contentLabel.attributedText = isChecked ? owner.contentLabel.text?.strikeThrough() : NSAttributedString(string: owner.contentLabel.text ?? "")
-        }
-        .disposed(by: disposeBag)
-    }
+extension AddTodoView: TodoViewDelegate {
+  func whichTodoContent(content: String) {
+    guard let date = self.date else { return }
+    let dateString = DateFormatterFactory.dateWithHypen.string(from: date)
+    delegate?.whichCreateTodoRequest(request: .init(content: content, date: dateString))
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
@@ -20,7 +20,17 @@ struct AddTodoViewModel {
   let todoViewModel: [TodoViewModel]
   
   init(response: InquireTodolistByDateResponse) {
-    todoViewModel = response.todoList.map { TodoViewModel(isChecked: $0.isChecked, content: $0.content) }
+    todoViewModel = response.todoList.map {
+      TodoViewModel(
+        todoID: $0.todoID,
+        isChecked: $0.isChecked,
+        content: $0.content
+      )
+    }
+  }
+  
+  init(todoViewModel: [TodoViewModel]) {
+    self.todoViewModel = todoViewModel
   }
 }
 
@@ -81,14 +91,19 @@ final class AddTodoView: UIView {
   
   func configureUI(with model: AddTodoViewModel) {
     todoContainerView
-      .arrangedSubviews.dropFirst(2)
+      .arrangedSubviews.dropFirst()
       .forEach { $0.removeFromSuperview() }
     
     let sortedModel = model.todoViewModel.sorted { $0.isChecked || $1.isChecked }
+    
+    let inputTodoView = TodoView(type: .input)
+    inputTodoView.delegate = self
+    todoContainerView.addArrangedSubview(inputTodoView)
+    
     sortedModel.forEach { model in
       let todoView = TodoView(type: .todo)
-      todoView.delegate = self
       todoView.configureUI(with: .init(
+        todoID: model.todoID,
         isChecked: model.isChecked,
         content: model.content)
       )

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
@@ -23,6 +23,7 @@ struct AddTodoViewModel {
     todoViewModel = response.todoList.map {
       TodoViewModel(
         todoID: $0.todoID,
+        date: $0.date,
         isChecked: $0.isChecked,
         content: $0.content
       )
@@ -36,6 +37,8 @@ struct AddTodoViewModel {
 
 protocol AddTodoViewDelegate: AnyObject {
   func whichCreateTodoRequest(request: CreateTodoRequest)
+  func whichTodoChecked(isChecked: Bool, todoID: Int)
+  func tappedMoreButton()
 }
 
 final class AddTodoView: UIView {
@@ -100,8 +103,10 @@ final class AddTodoView: UIView {
     
     model.todoViewModel.forEach { model in
       let todoView = TodoView(type: .todo)
+      todoView.delegate = self
       todoView.configureUI(with: .init(
         todoID: model.todoID,
+        date: model.date,
         isChecked: model.isChecked,
         content: model.content)
       )
@@ -111,6 +116,14 @@ final class AddTodoView: UIView {
 }
 
 extension AddTodoView: TodoViewDelegate {
+  func tappedMoreButton() {
+    delegate?.tappedMoreButton()
+  }
+  
+  func whichTodoChecked(isChecked: Bool, todoID: Int) {
+    delegate?.whichTodoChecked(isChecked: isChecked, todoID: todoID)
+  }
+  
   func whichTodoContent(content: String) {
     guard let date = self.date else { return }
     let dateString = DateFormatterFactory.dateWithHypen.string(from: date)

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
@@ -38,7 +38,7 @@ struct AddTodoViewModel {
 protocol AddTodoViewDelegate: AnyObject {
   func whichCreateTodoRequest(request: CreateTodoRequest)
   func whichTodoChecked(isChecked: Bool, todoID: Int)
-  func tappedMoreButton()
+  func tappedMoreButton(todoID: Int, isChecked: Bool)
 }
 
 final class AddTodoView: UIView {
@@ -116,8 +116,8 @@ final class AddTodoView: UIView {
 }
 
 extension AddTodoView: TodoViewDelegate {
-  func tappedMoreButton() {
-    delegate?.tappedMoreButton()
+  func tappedMoreButton(todoID: Int, isChecked: Bool) {
+    delegate?.tappedMoreButton(todoID: todoID, isChecked: isChecked)
   }
   
   func whichTodoChecked(isChecked: Bool, todoID: Int) {

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
@@ -18,6 +18,10 @@ enum TodoViewType {
 
 struct AddTodoViewModel {
   let todoViewModel: [TodoViewModel]
+  
+  init(response: InquireTodolistByDateResponse) {
+    todoViewModel = response.todoList.map { TodoViewModel(isChecked: $0.isChecked, content: $0.content) }
+  }
 }
 
 protocol AddTodoViewDelegate: AnyObject {

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
@@ -80,7 +80,12 @@ final class AddTodoView: UIView {
   }
   
   func configureUI(with model: AddTodoViewModel) {
-    model.todoViewModel.forEach { model in
+    todoContainerView
+      .arrangedSubviews.dropFirst(2)
+      .forEach { $0.removeFromSuperview() }
+    
+    let sortedModel = model.todoViewModel.sorted { $0.isChecked || $1.isChecked }
+    sortedModel.forEach { model in
       let todoView = TodoView(type: .todo)
       todoView.delegate = self
       todoView.configureUI(with: .init(

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodolistBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodolistBottomSheetViewController.swift
@@ -1,0 +1,109 @@
+//
+//  AddTodolistBottomSheetViewController.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/05/12.
+//
+
+import UIKit
+
+import RxSwift
+import SnapKit
+import Then
+
+enum AddTodolistBottomSheetType {
+  case complete
+  case noComplete
+}
+
+protocol AddTodolistBottomSheetDelegate: AnyObject {
+  func proofImage(todoID: Int)
+  func editTodo(todoID: Int)
+  func deleteTodo(todoID: Int)
+}
+
+final class AddTodolistBottomSheetViewController: BottomSheetViewController {
+  
+  weak var delegate: AddTodolistBottomSheetDelegate?
+  
+  private let type: AddTodolistBottomSheetType
+  private let todoID: Int
+  
+  private let stackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 8
+  }
+  
+  private lazy var proofImageListView = BottomSheetListView(text: "사진 인증", image: "editBlack")
+  private let editTodoListView = BottomSheetListView(text: "TO-DO 수정", image: "editBlack")
+  private let deleteTodoListView = BottomSheetListView(text: "TO-DO 삭제", image: "trashRed", textColor: .error)
+  
+  init(type: AddTodolistBottomSheetType, todoID: Int) {
+    self.type = type
+    self.todoID = todoID
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func bind() {
+    super.bind()
+    
+    proofImageListView.button.rx.tap
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.proofImage(todoID: owner.todoID)
+      }
+      .disposed(by: disposeBag)
+    
+    editTodoListView.button.rx.tap
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.editTodo(todoID: owner.todoID)
+      }
+      .disposed(by: disposeBag)
+    
+    deleteTodoListView.button.rx.tap
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.deleteTodo(todoID: owner.todoID)
+      }
+      .disposed(by: disposeBag)
+  }
+  
+  override func setupLayouts() {
+    super.setupLayouts()
+    contentView.addSubview(stackView)
+    
+    switch type {
+    case .complete:
+      [proofImageListView, editTodoListView, deleteTodoListView].forEach { stackView.addArrangedSubview($0) }
+    case .noComplete:
+      [editTodoListView, deleteTodoListView].forEach { stackView.addArrangedSubview($0) }
+    }
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    
+    stackView.snp.makeConstraints {
+      $0.top.equalToSuperview().inset(Metrics.Margin.top)
+      $0.directionalHorizontalEdges.equalToSuperview().inset(Metrics.Margin.horizontal)
+      $0.bottom.equalToSuperview().inset(Metrics.Margin.bottom)
+    }
+    
+    switch type {
+    case .complete:
+      [proofImageListView, editTodoListView, deleteTodoListView].forEach {
+        $0.snp.makeConstraints {
+          $0.height.equalTo(Metrics.Size.listHeight)
+        }
+      }
+    case .noComplete:
+      [editTodoListView, deleteTodoListView].forEach {
+        $0.snp.makeConstraints {
+          $0.height.equalTo(Metrics.Size.listHeight)
+        }
+      }
+    }
+  }
+}

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
@@ -16,8 +16,21 @@ protocol TodoViewDelegate: AnyObject {
 }
 
 struct TodoViewModel {
+  let todoID: Int
   let isChecked: Bool
   let content: String
+  
+  init(todoID: Int, isChecked: Bool, content: String) {
+    self.todoID = todoID
+    self.isChecked = isChecked
+    self.content = content
+  }
+  
+  init(response: CreateTodoResponse) {
+    todoID = response.todoID
+    isChecked = response.isChecked
+    content = response.content
+  }
 }
 
 final class TodoView: UIView {

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
@@ -1,0 +1,139 @@
+//
+//  TodoView.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/05/10.
+//
+
+import UIKit
+
+import RxSwift
+import SnapKit
+import Then
+
+protocol TodoViewDelegate: AnyObject {
+  func whichTodoContent(content: String)
+}
+
+struct TodoViewModel {
+  let isChecked: Bool
+  let content: String
+}
+
+final class TodoView: UIView {
+  
+  weak var delegate: TodoViewDelegate?
+  private let disposeBag = DisposeBag()
+  private let type: TodoViewType
+  
+  private lazy var emptyCheckView = UIView().then {
+    $0.layer.borderWidth = 1
+    $0.layer.borderColor = UIColor.lightGray.cgColor
+    $0.layer.cornerRadius = 3
+    $0.layer.masksToBounds = true
+  }
+  
+  private lazy var contentLabel = UILabel().then {
+    $0.text = "투두리스트목록"
+  }
+  
+  private lazy var checkBoxButton = CheckBoxButton(type: .none)
+  
+  private lazy var todoTextField = UITextField().then {
+    $0.placeholder = "새로운 TO-DO 추가하기"
+    $0.layer.shouldRasterize = true
+    $0.delegate = self
+    $0.returnKeyType = .done
+  }
+  
+  private lazy var moreButton = UIButton().then {
+    $0.setImage(UIImage(named: "meatballMenuBlack"), for: .normal)
+  }
+  
+  private lazy var bottomLineView = UIView().then {
+    $0.backgroundColor = .lightGray
+  }
+  
+  init(type: TodoViewType) {
+    self.type = type
+    super.init(frame: .zero)
+    configureUI()
+    bind()
+  }
+  
+  required init(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func configureUI() {
+    switch type {
+    case .input:
+      [emptyCheckView, todoTextField].forEach { addSubview($0) }
+      todoTextField.addSubview(bottomLineView)
+      
+      emptyCheckView.snp.makeConstraints {
+        $0.size.equalTo(18)
+        $0.leading.directionalVerticalEdges.equalToSuperview().inset(7)
+      }
+      
+      todoTextField.snp.makeConstraints {
+        $0.leading.equalTo(emptyCheckView.snp.trailing).offset(7)
+        $0.directionalVerticalEdges.trailing.equalToSuperview()
+      }
+      
+      bottomLineView.snp.makeConstraints {
+        $0.directionalHorizontalEdges.bottom.equalToSuperview()
+        $0.height.equalTo(1)
+      }
+      
+    case .todo:
+      [checkBoxButton, contentLabel].forEach { addSubview($0) }
+      contentLabel.addSubview(bottomLineView)
+      contentLabel.addSubview(moreButton)
+      checkBoxButton.snp.makeConstraints {
+        $0.size.equalTo(18)
+        $0.leading.directionalVerticalEdges.equalToSuperview().inset(7)
+      }
+      
+      contentLabel.snp.makeConstraints {
+        $0.leading.equalTo(checkBoxButton.snp.trailing).offset(7)
+        $0.directionalVerticalEdges.equalToSuperview()
+        $0.trailing.equalToSuperview()
+      }
+      
+      bottomLineView.snp.makeConstraints {
+        $0.width.equalToSuperview()
+        $0.height.equalTo(1)
+        $0.bottom.equalToSuperview()
+      }
+      
+      moreButton.snp.makeConstraints {
+        $0.size.equalTo(32)
+        $0.directionalVerticalEdges.trailing.equalToSuperview()
+      }
+    }
+  }
+  
+  func configureUI(with model: TodoViewModel) {
+    contentLabel.text = model.content
+    checkBoxButton.isChecked = model.isChecked
+    contentLabel.attributedText = model.isChecked ? contentLabel.text?.strikeThrough() : NSAttributedString(string: contentLabel.text ?? "")
+  }
+  
+  private func bind() {
+    checkBoxButton.rx.isChecked
+      .subscribe(with: self) { owner, isChecked in
+        owner.contentLabel.attributedText = isChecked ? owner.contentLabel.text?.strikeThrough() : NSAttributedString(string: owner.contentLabel.text ?? "")
+      }
+      .disposed(by: disposeBag)
+  }
+}
+
+extension TodoView: UITextFieldDelegate {
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    guard let text = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines) else { return false }
+    delegate?.whichTodoContent(content: text)
+    textField.resignFirstResponder()
+    return true
+  }
+}

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
@@ -14,7 +14,7 @@ import Then
 protocol TodoViewDelegate: AnyObject {
   func whichTodoContent(content: String)
   func whichTodoChecked(isChecked: Bool, todoID: Int)
-  func tappedMoreButton()
+  func tappedMoreButton(todoID: Int, isChecked: Bool)
 }
 
 struct TodoViewModel {
@@ -159,7 +159,8 @@ final class TodoView: UIView {
     
     moreButton.rx.tap
       .subscribe(with: self) { owner, _ in
-        owner.delegate?.tappedMoreButton()
+        guard let todoID = owner.todoID else { return }
+        owner.delegate?.tappedMoreButton(todoID: todoID, isChecked: owner.checkBoxButton.isChecked)
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -187,7 +187,7 @@ final class MainPageViewController: BaseViewController {
           owner.navigationController?.pushViewController(vc, animated: true)
         }
         else {
-          let vc = AddTodoListViewController(viewModel: AddTodoListViewModel(plubbingID: owner.plubbingID))
+          let vc = AddTodoListViewController(plubbingID: owner.plubbingID)
           vc.navigationItem.largeTitleDisplayMode = .never
           vc.title = "요란한 밧줄"
           owner.navigationController?.pushViewController(vc, animated: true)

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -187,7 +187,7 @@ final class MainPageViewController: BaseViewController {
           owner.navigationController?.pushViewController(vc, animated: true)
         }
         else {
-          let vc = AddTodoViewController()
+          let vc = AddTodoListViewController(viewModel: AddTodoListViewModel(plubbingID: owner.plubbingID))
           vc.navigationItem.largeTitleDisplayMode = .never
           vc.title = "요란한 밧줄"
           owner.navigationController?.pushViewController(vc, animated: true)

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/AddTodoViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/AddTodoViewModel.swift
@@ -5,29 +5,42 @@
 //  Created by 이건준 on 2023/05/10.
 //
 
+import Foundation
+
 import RxSwift
+import RxCocoa
+import RxRelay
 
 protocol AddTodoListViewModelType {
   var whichCreateTodoRequest: AnyObserver<CreateTodoRequest> { get }
+  var whichInquireDate: AnyObserver<Date> { get }
+  var selectPlubbingID: AnyObserver<Int> { get }
+  
+  var todolistModelByDate: Driver<AddTodoViewModel> { get }
 }
 
 final class AddTodoListViewModel: AddTodoListViewModelType {
   
   private let disposeBag = DisposeBag()
   
-  private(set) var plubbingID: Int = 0
+  private let whichPlubbingID = PublishSubject<Int>()
   private let createTodoRequst = PublishSubject<CreateTodoRequest>()
+  private let inquireDate = PublishSubject<Date>()
+  private let todolistModelByCurrentDate = PublishRelay<AddTodoViewModel>()
   
-  init(plubbingID: Int) {
-    self.plubbingID = plubbingID
+  init() {
     tryCreateTodo()
+    tryInquireTodolistByDate()
   }
   
   private func tryCreateTodo() {
-    let requestCreateTodo = createTodoRequst
-      .withUnretained(self)
-      .flatMapLatest { owner, request in
-        TodolistService.shared.createTodo(plubbingID: owner.plubbingID, request: request)
+    let requestCreateTodo =
+    Observable.combineLatest(
+      whichPlubbingID,
+      createTodoRequst
+    )
+      .flatMapLatest { plubbingID, request in
+        TodolistService.shared.createTodo(plubbingID: plubbingID, request: request)
       }
     
     requestCreateTodo.subscribe(onNext: { response in
@@ -35,10 +48,43 @@ final class AddTodoListViewModel: AddTodoListViewModelType {
     })
       .disposed(by: disposeBag)
   }
+  
+  private func tryInquireTodolistByDate() {
+    let inquireTodolistByDate =
+    Observable.combineLatest(
+      whichPlubbingID,
+      inquireDate.map { DateFormatterFactory.dateWithHypen.string(from: $0) }
+    )
+      .flatMapLatest { plubbingID, date in
+        return TodolistService.shared.inquireTodolistByDate(
+          plubbingID: plubbingID,
+          todoDate: date
+        )
+      }
+    
+    inquireTodolistByDate
+      .map { AddTodoViewModel(response: $0) }
+      .bind(to: todolistModelByCurrentDate)
+      .disposed(by: disposeBag)
+  }
 }
 
 extension AddTodoListViewModel {
+  
+  var selectPlubbingID: AnyObserver<Int> {
+    whichPlubbingID.asObserver()
+  }
+  
   var whichCreateTodoRequest: AnyObserver<CreateTodoRequest> {
     createTodoRequst.asObserver()
+  }
+  
+  var whichInquireDate: AnyObserver<Date> {
+    inquireDate.asObserver()
+  }
+  
+  var todolistModelByDate: Driver<AddTodoViewModel> {
+    todolistModelByCurrentDate
+      .asDriver(onErrorDriveWith: .empty())
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/AddTodoViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/AddTodoViewModel.swift
@@ -5,12 +5,40 @@
 //  Created by 이건준 on 2023/05/10.
 //
 
-import Foundation
+import RxSwift
 
-protocol AddTodoViewModelType {
-  
+protocol AddTodoListViewModelType {
+  var whichCreateTodoRequest: AnyObserver<CreateTodoRequest> { get }
 }
 
-final class AddTodoViewModel: AddTodoViewModelType {
+final class AddTodoListViewModel: AddTodoListViewModelType {
   
+  private let disposeBag = DisposeBag()
+  
+  private(set) var plubbingID: Int = 0
+  private let createTodoRequst = PublishSubject<CreateTodoRequest>()
+  
+  init(plubbingID: Int) {
+    self.plubbingID = plubbingID
+    tryCreateTodo()
+  }
+  
+  private func tryCreateTodo() {
+    let requestCreateTodo = createTodoRequst
+      .withUnretained(self)
+      .flatMapLatest { owner, request in
+        TodolistService.shared.createTodo(plubbingID: owner.plubbingID, request: request)
+      }
+    
+    requestCreateTodo.subscribe(onNext: { response in
+      Log.debug("투두생성응답값 \(response)")
+    })
+      .disposed(by: disposeBag)
+  }
+}
+
+extension AddTodoListViewModel {
+  var whichCreateTodoRequest: AnyObserver<CreateTodoRequest> {
+    createTodoRequst.asObserver()
+  }
 }

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/AddTodoViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/AddTodoViewModel.swift
@@ -1,0 +1,16 @@
+//
+//  AddTodoViewModel.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/05/10.
+//
+
+import Foundation
+
+protocol AddTodoViewModelType {
+  
+}
+
+final class AddTodoViewModel: AddTodoViewModelType {
+  
+}


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 날짜별 투두리스트 UI 연동
- 날짜별 투두리스트 체크여부에 따른 정렬
- 날짜별 투두리스트 투두완료/ 완료취소 API 연동
- 투두추가에 대한 API 연동
- 투두 체크여부에 따른 서로 다른 바텀시트 동작

🌱 PR 포인트
- 이미지인증, 투두수정, 투두삭제에 관련된 API는 양이 너무 많아서 따로 올리도록 하겠습니다.
- 날짜별 투두리스트 날짜에 관련된 정렬은 아직 추가하지않았습니다.
- 투두추가에 대한 API를 연동하면서 투두리스트에 대한 UI가 불완전하다는것을 알게되어서 이 부분 또한 수정하여 pr올리도록 하겠습니다.
- 투두추가뷰에서 체크박스를 승현님이 만들어주신 버튼을 사용해서 기존 피그마디자인하고 다른데 이 부분은 중요한 부분은 아닌거같아서 추후에 수정하도록 하겠습니다.

## 📸 동작영상
https://github.com/PLUB2022/PLUB-iOS/assets/39263235/4a7c5c40-2a83-4abe-bfac-e66076599619


## 📮 관련 이슈
- Resolved: #364 

