### PR TITLE
게시글 삭제 기능 구현 및 BoardBottomSheet 추상화

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		BA2173B929F57A97000D72B1 /* DeleteImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2173B829F57A97000D72B1 /* DeleteImageUseCase.swift */; };
 		BA2173BB29F61955000D72B1 /* UploadArchiveUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2173BA29F61955000D72B1 /* UploadArchiveUseCase.swift */; };
 		BA2173BD29F61A36000D72B1 /* EditArchiveUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2173BC29F61A36000D72B1 /* EditArchiveUseCase.swift */; };
+		BA2553282A0F961600194B5A /* DeleteFeedUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2553272A0F961600194B5A /* DeleteFeedUseCase.swift */; };
 		BA3001E429FF98E300C3FB89 /* DeleteArchiveUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3001E329FF98E300C3FB89 /* DeleteArchiveUseCase.swift */; };
 		BA340E1629782207002BAF2C /* IntroduceTagCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA340E1529782207002BAF2C /* IntroduceTagCollectionViewCell.swift */; };
 		BA340E1C297822CC002BAF2C /* IntroduceCategoryInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA340E1B297822CC002BAF2C /* IntroduceCategoryInfoView.swift */; };
@@ -558,6 +559,7 @@
 		BA2173B829F57A97000D72B1 /* DeleteImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteImageUseCase.swift; sourceTree = "<group>"; };
 		BA2173BA29F61955000D72B1 /* UploadArchiveUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadArchiveUseCase.swift; sourceTree = "<group>"; };
 		BA2173BC29F61A36000D72B1 /* EditArchiveUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditArchiveUseCase.swift; sourceTree = "<group>"; };
+		BA2553272A0F961600194B5A /* DeleteFeedUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteFeedUseCase.swift; sourceTree = "<group>"; };
 		BA3001E329FF98E300C3FB89 /* DeleteArchiveUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteArchiveUseCase.swift; sourceTree = "<group>"; };
 		BA340E1529782207002BAF2C /* IntroduceTagCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceTagCollectionViewCell.swift; sourceTree = "<group>"; };
 		BA340E1B297822CC002BAF2C /* IntroduceCategoryInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceCategoryInfoView.swift; sourceTree = "<group>"; };
@@ -1377,6 +1379,7 @@
 			isa = PBXGroup;
 			children = (
 				BA57F3F529ED30D200A9F790 /* DeleteCommentUseCase.swift */,
+				BA2553272A0F961600194B5A /* DeleteFeedUseCase.swift */,
 				BA5EC6C529EFD4E5000A68B7 /* EditCommentUseCase.swift */,
 				BAB2E56D29E30F96006B7BDC /* GetCommentsUseCase.swift */,
 				BA5F050129F7D26500A3FA14 /* GetFeedDetailUseCase.swift */,
@@ -2798,6 +2801,7 @@
 				705F81C329AFAA3B00830C4F /* BoardViewController.swift in Sources */,
 				BAE5D3352975B10F00268D44 /* ReissuanceRequest.swift in Sources */,
 				BA57F3FA29ED4EEC00A9F790 /* ArchiveUploadViewModel.swift in Sources */,
+				BA2553282A0F961600194B5A /* DeleteFeedUseCase.swift in Sources */,
 				70197B6E29535BAA000503F6 /* HomeViewModel.swift in Sources */,
 				BA5D9ED929E3F16900F06AB5 /* ArchiveContent.swift in Sources */,
 				70F1DFE0297A90AE00F9BC83 /* MeetingService.swift in Sources */,

--- a/PLUB/Sources/UseCases/Feeds/DeleteFeedUseCase.swift
+++ b/PLUB/Sources/UseCases/Feeds/DeleteFeedUseCase.swift
@@ -1,0 +1,29 @@
+// 
+//  DeleteFeedUseCase.swift
+//  PLUB
+//
+//  Created by 홍승현 on 2023/05/13.
+//
+
+import RxSwift
+
+protocol DeleteFeedUseCase {
+  func execute() -> Observable<Void>
+}
+
+final class DefaultDeleteFeedUseCase: DeleteFeedUseCase {
+  
+  private let plubbingID: Int
+  private let feedID: Int
+  
+  init(plubbingID: Int, feedID: Int) {
+    self.plubbingID = plubbingID
+    self.feedID = feedID
+  }
+  
+  
+  func execute() -> Observable<Void> {
+    FeedsService.shared.deleteFeed(plubbingID: plubbingID, feedID: feedID)
+      .map { _ in Void() }
+  }
+}

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -160,8 +160,8 @@ final class BoardDetailViewController: BaseViewController {
     
     viewModel.showBoardBottomSheetObservable
       .subscribe(with: self) { owner, tuple in
-        let (accessType, isPinned) = tuple
-        let viewController = BoardBottomSheetViewController(accessType: accessType, isPinned: isPinned)
+        let (bottomSheetType, accessType, isPinned) = tuple
+        let viewController = bottomSheetType.init(accessType: accessType, isPinned: isPinned)
         viewController.delegate = owner
         owner.present(viewController, animated: true)
       }

--- a/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/BoardDetailViewController.swift
@@ -166,6 +166,12 @@ final class BoardDetailViewController: BaseViewController {
         owner.present(viewController, animated: true)
       }
       .disposed(by: disposeBag)
+    
+    viewModel.popViewControllerByMySelfObservable
+      .subscribe(with: self) { owner, _ in
+        owner.navigationController?.popViewController(animated: true)
+      }
+      .disposed(by: disposeBag)
   }
 }
 
@@ -211,7 +217,8 @@ extension BoardDetailViewController: CommentOptionBottomSheetDelegate {
 
 extension BoardDetailViewController: BoardBottomSheetDelegate {
   func selectedBoardSheetType(type: BoardBottomSheetType) {
-    PLUBToast.makeToast(text: "\(type)")
+    viewModel.boardOptionObserver.onNext(type)
+    dismiss(animated: true)
   }
 }
 

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModel.swift
@@ -77,12 +77,13 @@ final class BoardDetailViewModel {
   
   // MARK: Use Cases
   
+  private let deleteFeedUseCase:    DeleteFeedUseCase
   private let getFeedDetailUseCase: GetFeedDetailUseCase
-  private let getCommentsUseCase: GetCommentsUseCase
-  private let postCommentUseCase: PostCommentUseCase
+  private let getCommentsUseCase:   GetCommentsUseCase
+  private let postCommentUseCase:   PostCommentUseCase
   private let deleteCommentUseCase: DeleteCommentUseCase
-  private let editCommentUseCase: EditCommentUseCase
-  private let likeFeedUseCase: LikeFeedUseCase
+  private let editCommentUseCase:   EditCommentUseCase
+  private let likeFeedUseCase:      LikeFeedUseCase
   
   // MARK: Subjects
   
@@ -102,6 +103,7 @@ final class BoardDetailViewModel {
   
   init(
     boardBottomSheetController: BoardBottomSheetViewControllerType.Type,
+    deleteFeedUseCase: DeleteFeedUseCase,
     getFeedDetailUseCase: GetFeedDetailUseCase,
     getCommentsUseCase: GetCommentsUseCase,
     postCommentUseCase: PostCommentUseCase,
@@ -109,6 +111,7 @@ final class BoardDetailViewModel {
     editCommentUseCase: EditCommentUseCase,
     likeFeedUseCase: LikeFeedUseCase
   ) {
+    self.deleteFeedUseCase    = deleteFeedUseCase
     self.getFeedDetailUseCase = getFeedDetailUseCase
     self.getCommentsUseCase   = getCommentsUseCase
     self.postCommentUseCase   = postCommentUseCase

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModelFactory.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModelFactory.swift
@@ -19,6 +19,7 @@ final class BoardDetailViewModelWithFeedsFactory: BoardDetailViewModelFactory {
   static func make(plubbingID: Int, feedID: Int) -> BoardDetailViewModelType {
     return BoardDetailViewModel(
       boardBottomSheetController: BoardBottomSheetViewController.self,
+      deleteFeedUseCase: DefaultDeleteFeedUseCase(plubbingID: plubbingID, feedID: feedID),
       getFeedDetailUseCase: DefaultGetFeedDetailUseCase(plubbingID: plubbingID, feedID: feedID),
       getCommentsUseCase: DefaultGetCommentsUseCase(plubbingID: plubbingID, feedID: feedID),
       postCommentUseCase: DefaultPostCommentUseCase(plubbingID: plubbingID, feedID: feedID),

--- a/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModelFactory.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/ViewModel/BoardDetailViewModelFactory.swift
@@ -18,6 +18,7 @@ final class BoardDetailViewModelWithFeedsFactory: BoardDetailViewModelFactory {
   
   static func make(plubbingID: Int, feedID: Int) -> BoardDetailViewModelType {
     return BoardDetailViewModel(
+      boardBottomSheetController: BoardBottomSheetViewController.self,
       getFeedDetailUseCase: DefaultGetFeedDetailUseCase(plubbingID: plubbingID, feedID: feedID),
       getCommentsUseCase: DefaultGetCommentsUseCase(plubbingID: plubbingID, feedID: feedID),
       postCommentUseCase: DefaultPostCommentUseCase(plubbingID: plubbingID, feedID: feedID),

--- a/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/BoardBottomSheetViewController.swift
@@ -15,6 +15,16 @@ protocol BoardBottomSheetDelegate: AnyObject {
   func selectedBoardSheetType(type: BoardBottomSheetType)
 }
 
+
+// MARK: 바텀시트 추상화
+
+protocol BoardBottomSheetViewControllerType: BottomSheetViewController {
+  
+  init(accessType: BoardBottomSheetViewController.AccessType, isPinned: Bool)
+  
+  var delegate: BoardBottomSheetDelegate? { get set }
+}
+
 enum BoardBottomSheetType {
   case fix // 클립보드 고정
   case modify // 게시글 수정
@@ -22,7 +32,7 @@ enum BoardBottomSheetType {
   case delete // 게시글 삭제
 }
 
-final class BoardBottomSheetViewController: BottomSheetViewController {
+final class BoardBottomSheetViewController: BottomSheetViewController, BoardBottomSheetViewControllerType {
   
   // MARK: - Properties
   


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용

- DeleteFeedUseCase 구현 -> 삭제 기능 구현
- BoardBottomSheetViewController를 추상화한 프로토콜인 `BoardBottomSheetViewControllerType`을 추가
   - 공지 UI랑 게시글 UI와 기능 자체가 똑같기에, ViewModel과 ViewController를 재사용하고자 BottomSheet호출부분을 추상화하였습니다.
   - ViewModel에서 `BoardBottomSheetViewControllerType`를 인자로 받으며, 나중에 공지를 구현하게 된다면 `BoardBottomSheetViewControllerType`을 준수(conform)하는 `AnnouncementBottomSheetViewController`를 넣을 예정입니다.

## 📸 스크린샷

https://github.com/PLUB2022/PLUB-iOS/assets/57972338/7e3082e2-e102-41d9-ba4b-f3ac672e2b35


## 📮 관련 이슈
- #335

