### PR TITLE
[FIX] 메인페이지 투두리스트 UI 오류 수정

### DIFF
--- a/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
@@ -163,9 +163,9 @@ final class TodoCollectionViewCell: UICollectionViewCell {
   }
   
   func configureUI(with model: TodoCollectionViewCellModel) {
-    guard let profileImageString = model.profileImageString,
-          let url = URL(string: profileImageString) else { return }
     self.model = model
+    
+    let url = URL(string: model.profileImageString ?? "")
     profileImageView.kf.setImage(with: url, placeholder: UIImage(named: "userDefaultImage"))
     likeCount = model.totalLikes
     likeButton.isSelected = model.isLike

--- a/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
@@ -25,7 +25,7 @@ struct TodoCollectionViewCellModel {
   let totalLikes: Int
   let isLike: Bool
   let isAuthor: Bool
-  let checkTodoViewModels: [CheckTodoViewModel]
+  var checkTodoViewModels: [CheckTodoViewModel]
   let nickname: String?
   
   init(response: InquireAllTodoTimelineResponse) {

--- a/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
@@ -13,7 +13,7 @@ import SnapKit
 import Then
 
 protocol TodoCollectionViewCellDelegate: AnyObject {
-  func didTappedMoreButton()
+  func didTappedMoreButton(isAuthor: Bool)
   func didTappedLikeButton(timelineID: Int)
   func didTappedTodo(todoID: Int, isCompleted: Bool, model: TodoAlertModel)
 }
@@ -141,7 +141,8 @@ final class TodoCollectionViewCell: UICollectionViewCell {
   private func bind() {
     moreButton.rx.tap
       .subscribe(with: self) { owner, _ in
-        owner.delegate?.didTappedMoreButton()
+        guard let isAuthor = owner.model?.isAuthor else { return }
+        owner.delegate?.didTappedMoreButton(isAuthor: isAuthor)
       }
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Home/MainPage/Component/CheckTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/CheckTodoView.swift
@@ -20,7 +20,7 @@ struct CheckTodoViewModel {
   let todo: String
   let isChecked: Bool
   let isAuthor: Bool
-  let isProof: Bool
+  var isProof: Bool
 }
 
 final class CheckTodoView: UIView {
@@ -86,7 +86,7 @@ final class CheckTodoView: UIView {
   func configureUI(with model: CheckTodoViewModel) {
     self.model = model
     todoLabel.text = model.todo
-    self.isChecked = model.isChecked
+    self.isChecked = model.isChecked || model.isProof
     
     // 해당 투두가 인증되었거나 작성자가 아니라면 -> 체크버튼 비활성화
     checkboxButton.isEnabled = model.isProof || !model.isAuthor ? false : true

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -128,12 +128,12 @@ extension TodolistViewController: UICollectionViewDelegate, UICollectionViewData
   }
   
   func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return model.count
+    return model[section].cellModel.checkTodoViewModels.count
   }
   
   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TodoCollectionViewCell.identifier, for: indexPath) as? TodoCollectionViewCell ?? TodoCollectionViewCell()
-    cell.configureUI(with: model[indexPath.row].cellModel)
+    cell.configureUI(with: model[indexPath.section].cellModel)
     cell.delegate = self
     return cell
   }
@@ -158,7 +158,7 @@ extension TodolistViewController: UICollectionViewDelegateFlowLayout {
         width: view.bounds.width - 32,
         height: UIView.layoutFittingCompressedSize.height
       ),
-      model: model[indexPath.row].cellModel
+      model: model[indexPath.section].cellModel
     )
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -174,8 +174,9 @@ extension TodolistViewController: TodoCollectionViewCellDelegate {
     viewModel.selectLikeButton.onNext(timelineID)
   }
   
-  func didTappedMoreButton() { /// 투두리스트 작성자에 따른 type 지정해줘야함
-    let bottomSheet = TodolistBottomSheetViewController(type: .report)
+  func didTappedMoreButton(isAuthor: Bool) { /// 투두리스트 작성자에 따른 type 지정해줘야함
+    ///
+    let bottomSheet = isAuthor ? TodolistBottomSheetViewController(type: .todoPlanner) : TodolistBottomSheetViewController(type: .report)
     present(bottomSheet, animated: true)
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -12,7 +12,7 @@ import Then
 
 struct TodolistModel {
   let headerModel: TodoCollectionHeaderViewModel
-  let cellModel: TodoCollectionViewCellModel
+  var cellModel: TodoCollectionViewCellModel
 }
 
 final class TodolistViewController: BaseViewController {
@@ -111,13 +111,6 @@ final class TodolistViewController: BaseViewController {
         Log.debug("투두완료성공 \(success)")
       })
       .disposed(by: disposeBag)
-    
-    viewModel.successProofTodolist
-      .emit(with: self) { owner, success in
-        Log.debug("투두인증성공 \(success)")
-        owner.viewModel.selectPlubbingID.onNext(plubbingID)
-      }
-      .disposed(by: disposeBag)
   
   }
 }
@@ -128,7 +121,7 @@ extension TodolistViewController: UICollectionViewDelegate, UICollectionViewData
   }
   
   func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return model[section].cellModel.checkTodoViewModels.count
+    return 1
   }
   
   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 메인페이지 투두리스트 UI가 이상하게 나오는 점을 수정하였습니다.
- 메인페이지 투두리스트 오늘에 대한 투두리스트가 맨 상단에 오게 하였습니다.
- 메인페이지 투두리스트 날짜최신순에 따라서 정렬하게 하였습니다.
- 메인페이지 투두리스트 작성자 여부에 따른 서로 다른 바텀시트를 구현하였습니다.
- 메인페이지 투두 인증 이후 바로 UI 및 로직에 반영되게끔 구현하였습니다.

🌱 PR 포인트
- 지금 제가 잘못 알고있는 걸 수도 있는데 같은 일수에 서로 다른 사용자가 투두를 추가하였을때 하나의 섹션에 서로 다른 별개의 투두리스트로 보여줘야하는거 같은데 기존 타임라인조회에서 내려오는 부분으로는 이 부분이 안되어있는거같아서 일단 기천님이 답해주시기전까지는 다른 섹션으로 보여지도록 놔두도록 하겠습니다.
ps. 안드로이드도 확인해보니 서로 다른 사용자가 올린거라도 하나의 투두리스트에 묶어서 올라가는거같더라구요, 일단 답변기다린 이후에 수정하도록 하겠습니다.

## 📸 동작영상
https://github.com/PLUB2022/PLUB-iOS/assets/39263235/8a1c9d86-b286-4571-8cc4-ae1512b75a10

## 📮 관련 이슈
- Resolved: #368 

