### PR TITLE
[FEAT] 최근검색어목록을 10개로 제한합니다.

### DIFF
--- a/PLUB/Configuration/Manager/UserManager.swift
+++ b/PLUB/Configuration/Manager/UserManager.swift
@@ -108,7 +108,12 @@ extension UserManager {
     let recentKeywordList = recentKeywordList ?? []
     var filterList = recentKeywordList.filter { $0 != keyword }
     filterList.insert(keyword, at: 0)
-    self.recentKeywordList = filterList
+    if filterList.count > 10 {
+      _ = filterList.popLast()
+      self.recentKeywordList = filterList
+    } else {
+      self.recentKeywordList = filterList
+    }
   }
   
   /// 최근 검색어목록에 특정 인덱스에 위치한 키워드를 삭제합니다

--- a/PLUB/Configuration/Manager/UserManager.swift
+++ b/PLUB/Configuration/Manager/UserManager.swift
@@ -109,11 +109,9 @@ extension UserManager {
     var filterList = recentKeywordList.filter { $0 != keyword }
     filterList.insert(keyword, at: 0)
     if filterList.count > 10 {
-      _ = filterList.popLast()
-      self.recentKeywordList = filterList
-    } else {
-      self.recentKeywordList = filterList
+      filterList.removeLast()
     }
+    self.recentKeywordList = filterList
   }
   
   /// 최근 검색어목록에 특정 인덱스에 위치한 키워드를 삭제합니다


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 검색에 대한 최근검색어목록을 10개로 제한합니다.

## 📮 관련 이슈
- Resolved: #332 

