### PR TITLE
[FEAT] 메인페이지 모임타이틀 전달

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -43,7 +43,7 @@
 		705F821029B127DF00830C4F /* MainPageNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705F820F29B127DF00830C4F /* MainPageNavigationView.swift */; };
 		705F821229B2FCEC00830C4F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 705F821129B2FCEC00830C4F /* GoogleService-Info.plist */; };
 		705FD2742A0E895800F353FE /* AddTodolistBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD2732A0E895800F353FE /* AddTodolistBottomSheetViewController.swift */; };
-		706315962A0BA93400DD8EFE /* AddTodoListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315952A0BA93400DD8EFE /* AddTodoListViewModel.swift */; };
+		706315962A0BA93400DD8EFE /* TodoPlannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315952A0BA93400DD8EFE /* TodoPlannerViewModel.swift */; };
 		706315982A0BAA6000DD8EFE /* CreateTodoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */; };
 		7063159A2A0BAAE200DD8EFE /* CreateTodoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */; };
 		7063159C2A0BB0E700DD8EFE /* TodoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7063159B2A0BB0E700DD8EFE /* TodoView.swift */; };
@@ -471,7 +471,7 @@
 		705F820F29B127DF00830C4F /* MainPageNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageNavigationView.swift; sourceTree = "<group>"; };
 		705F821129B2FCEC00830C4F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		705FD2732A0E895800F353FE /* AddTodolistBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodolistBottomSheetViewController.swift; sourceTree = "<group>"; };
-		706315952A0BA93400DD8EFE /* AddTodoListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodoListViewModel.swift; sourceTree = "<group>"; };
+		706315952A0BA93400DD8EFE /* TodoPlannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPlannerViewModel.swift; sourceTree = "<group>"; };
 		706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoRequest.swift; sourceTree = "<group>"; };
 		706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoResponse.swift; sourceTree = "<group>"; };
 		7063159B2A0BB0E700DD8EFE /* TodoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoView.swift; sourceTree = "<group>"; };
@@ -1074,7 +1074,7 @@
 				705F820829B0EE6600830C4F /* BoardViewModel.swift */,
 				70727A2429C4C21A003DE956 /* CreateBoardViewModel.swift */,
 				70C9CC8E2A00864400BEB5F2 /* TodolistViewModel.swift */,
-				706315952A0BA93400DD8EFE /* AddTodoListViewModel.swift */,
+				706315952A0BA93400DD8EFE /* TodoPlannerViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -2625,7 +2625,7 @@
 				BA2173BD29F61A36000D72B1 /* EditArchiveUseCase.swift in Sources */,
 				BAB2E56C29E30A13006B7BDC /* PostCommentUseCase.swift in Sources */,
 				C39E09B629C604DE00ECAD11 /* RecruitingFooterView.swift in Sources */,
-				706315962A0BA93400DD8EFE /* AddTodoListViewModel.swift in Sources */,
+				706315962A0BA93400DD8EFE /* TodoPlannerViewModel.swift in Sources */,
 				BA340E1629782207002BAF2C /* IntroduceTagCollectionViewCell.swift in Sources */,
 				70197B7D29549B96000503F6 /* SelectedCategoryFilterHeaderView.swift in Sources */,
 				C39E09B829C6089300ECAD11 /* RecruitingSectionFooterView.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -42,7 +42,7 @@
 		705F820E29B1142800830C4F /* MainPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705F820D29B1142800830C4F /* MainPageHeaderView.swift */; };
 		705F821029B127DF00830C4F /* MainPageNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705F820F29B127DF00830C4F /* MainPageNavigationView.swift */; };
 		705F821229B2FCEC00830C4F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 705F821129B2FCEC00830C4F /* GoogleService-Info.plist */; };
-		705FD2742A0E895800F353FE /* AddTodolistBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD2732A0E895800F353FE /* AddTodolistBottomSheetViewController.swift */; };
+		705FD2742A0E895800F353FE /* TodoPlannerBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD2732A0E895800F353FE /* TodoPlannerBottomSheetViewController.swift */; };
 		706315962A0BA93400DD8EFE /* TodoPlannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315952A0BA93400DD8EFE /* TodoPlannerViewModel.swift */; };
 		706315982A0BAA6000DD8EFE /* CreateTodoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */; };
 		7063159A2A0BAAE200DD8EFE /* CreateTodoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */; };
@@ -470,7 +470,7 @@
 		705F820D29B1142800830C4F /* MainPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageHeaderView.swift; sourceTree = "<group>"; };
 		705F820F29B127DF00830C4F /* MainPageNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageNavigationView.swift; sourceTree = "<group>"; };
 		705F821129B2FCEC00830C4F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
-		705FD2732A0E895800F353FE /* AddTodolistBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodolistBottomSheetViewController.swift; sourceTree = "<group>"; };
+		705FD2732A0E895800F353FE /* TodoPlannerBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPlannerBottomSheetViewController.swift; sourceTree = "<group>"; };
 		706315952A0BA93400DD8EFE /* TodoPlannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPlannerViewModel.swift; sourceTree = "<group>"; };
 		706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoRequest.swift; sourceTree = "<group>"; };
 		706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoResponse.swift; sourceTree = "<group>"; };
@@ -1092,7 +1092,7 @@
 				70727A4629D6D507003DE956 /* TodoInfoView.swift */,
 				70FE55312A08CC5E00F11097 /* AddTodoView.swift */,
 				7063159B2A0BB0E700DD8EFE /* TodoView.swift */,
-				705FD2732A0E895800F353FE /* AddTodolistBottomSheetViewController.swift */,
+				705FD2732A0E895800F353FE /* TodoPlannerBottomSheetViewController.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -2901,7 +2901,7 @@
 				C3FC181729852D370083039A /* QuestionHeaderView.swift in Sources */,
 				C374E79A29FC3BCA004738C2 /* TodoListView.swift in Sources */,
 				C34F048829C7203600E5B67E /* MeetingCreateSuccessViewController.swift in Sources */,
-				705FD2742A0E895800F353FE /* AddTodolistBottomSheetViewController.swift in Sources */,
+				705FD2742A0E895800F353FE /* TodoPlannerBottomSheetViewController.swift in Sources */,
 				C38C573E29EC5910002550DD /* MeetingMemberResponse.swift in Sources */,
 				706315982A0BAA6000DD8EFE /* CreateTodoRequest.swift in Sources */,
 				70727A4329D5D679003DE956 /* TodoAlertController.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -61,7 +61,7 @@
 		70727A3B29D32E4C003DE956 /* InquireAllTodoTimelineResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A3A29D32E4C003DE956 /* InquireAllTodoTimelineResponse.swift */; };
 		70727A3D29D447D7003DE956 /* CheckTodoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A3C29D447D7003DE956 /* CheckTodoView.swift */; };
 		70727A3F29D47BB6003DE956 /* TodolistBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A3E29D47BB6003DE956 /* TodolistBottomSheetViewController.swift */; };
-		70727A4129D485E0003DE956 /* AddTodoListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A4029D485E0003DE956 /* AddTodoListViewController.swift */; };
+		70727A4129D485E0003DE956 /* TodoPlannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A4029D485E0003DE956 /* TodoPlannerViewController.swift */; };
 		70727A4329D5D679003DE956 /* TodoAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A4229D5D679003DE956 /* TodoAlertController.swift */; };
 		70727A4529D5E570003DE956 /* TodoAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A4429D5E570003DE956 /* TodoAlertView.swift */; };
 		70727A4729D6D507003DE956 /* TodoInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70727A4629D6D507003DE956 /* TodoInfoView.swift */; };
@@ -489,7 +489,7 @@
 		70727A3A29D32E4C003DE956 /* InquireAllTodoTimelineResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquireAllTodoTimelineResponse.swift; sourceTree = "<group>"; };
 		70727A3C29D447D7003DE956 /* CheckTodoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckTodoView.swift; sourceTree = "<group>"; };
 		70727A3E29D47BB6003DE956 /* TodolistBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodolistBottomSheetViewController.swift; sourceTree = "<group>"; };
-		70727A4029D485E0003DE956 /* AddTodoListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodoListViewController.swift; sourceTree = "<group>"; };
+		70727A4029D485E0003DE956 /* TodoPlannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPlannerViewController.swift; sourceTree = "<group>"; };
 		70727A4229D5D679003DE956 /* TodoAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoAlertController.swift; sourceTree = "<group>"; };
 		70727A4429D5E570003DE956 /* TodoAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoAlertView.swift; sourceTree = "<group>"; };
 		70727A4629D6D507003DE956 /* TodoInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoInfoView.swift; sourceTree = "<group>"; };
@@ -1050,7 +1050,7 @@
 				705F81C229AFAA3B00830C4F /* BoardViewController.swift */,
 				705F81C429AFAA5200830C4F /* TodolistViewController.swift */,
 				70727A2229C4A9E4003DE956 /* CreateBoardViewController.swift */,
-				70727A4029D485E0003DE956 /* AddTodoListViewController.swift */,
+				70727A4029D485E0003DE956 /* TodoPlannerViewController.swift */,
 			);
 			path = MainPage;
 			sourceTree = "<group>";
@@ -2767,7 +2767,7 @@
 				C3B3435129BDEE5100935B73 /* MyPageSectionFooterView.swift in Sources */,
 				70A420C229914B890026E9F9 /* InquireInterestResponse.swift in Sources */,
 				C383967C29A25A3E005998A5 /* ScheduleRouter.swift in Sources */,
-				70727A4129D485E0003DE956 /* AddTodoListViewController.swift in Sources */,
+				70727A4129D485E0003DE956 /* TodoPlannerViewController.swift in Sources */,
 				70727A3729D32DAA003DE956 /* TodolistService.swift in Sources */,
 				C361743629AFB875006AEAB1 /* MeetingCollectionViewCell.swift in Sources */,
 				BA4CCDF129EA79EA0040D0D7 /* CommentOptionBottomSheetViewController.swift in Sources */,

--- a/PLUB/Sources/Views/Home/Component/IntroduceCategoryTitleView.swift
+++ b/PLUB/Sources/Views/Home/Component/IntroduceCategoryTitleView.swift
@@ -18,6 +18,8 @@ struct IntroduceCategoryTitleViewModel {
 
 final class IntroduceCategoryTitleView: UIView {
   
+  private(set) var meetingTitle: String?
+  
   private let meetingTitleLabel = UILabel().then {
     $0.textColor = .black
     $0.font = .systemFont(ofSize: 18)
@@ -65,6 +67,7 @@ final class IntroduceCategoryTitleView: UIView {
   }
   
   func configureUI(with model: IntroduceCategoryTitleViewModel) {
+    meetingTitle = model.title
     meetingTitleLabel.text = model.title
     introduceTitleLabel.text = model.name
     

--- a/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
+++ b/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
@@ -235,8 +235,9 @@ final class DetailRecruitmentViewController: BaseViewController {
     surroundMeetingButton.rx.tap
       .subscribe(with: self) { owner, _ in
         if !owner.isHost {
-          guard let recommendText = owner.introduceCategoryInfoView.recommendedText else { return }
-          let vc = MainPageViewController(plubbingID: Int(owner.plubbingID), recommendedText: recommendText)
+          guard let recommendText = owner.introduceCategoryInfoView.recommendedText,
+                let meetingTitle = owner.introduceCategoryTitleView.meetingTitle else { return }
+          let vc = MainPageViewController(plubbingID: Int(owner.plubbingID), recommendedText: recommendText, meetingTitle: meetingTitle)
           vc.navigationItem.largeTitleDisplayMode = .never
           owner.navigationController?.pushViewController(vc, animated: true)
         }

--- a/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
+++ b/PLUB/Sources/Views/Home/DetailRecruitmentViewController.swift
@@ -237,7 +237,8 @@ final class DetailRecruitmentViewController: BaseViewController {
         if !owner.isHost {
           guard let recommendText = owner.introduceCategoryInfoView.recommendedText,
                 let meetingTitle = owner.introduceCategoryTitleView.meetingTitle else { return }
-          let vc = MainPageViewController(plubbingID: Int(owner.plubbingID), recommendedText: recommendText, meetingTitle: meetingTitle)
+          let vc = MainPageViewController(plubbingID: Int(owner.plubbingID), recommendedText: recommendText)
+          vc.title = meetingTitle
           vc.navigationItem.largeTitleDisplayMode = .never
           owner.navigationController?.pushViewController(vc, animated: true)
         }

--- a/PLUB/Sources/Views/Home/MainPage/AddTodoListViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/AddTodoListViewController.swift
@@ -84,6 +84,7 @@ final class AddTodoListViewController: BaseViewController {
   override func setupStyles() {
     super.setupStyles()
     viewModel.whichInquireDate.onNext(Date())
+    navigationItem.title = title
   }
   
   override func setupLayouts() {

--- a/PLUB/Sources/Views/Home/MainPage/Component/MainPageHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/MainPageHeaderView.swift
@@ -15,6 +15,7 @@ import Then
 protocol MainPageHeaderViewDelegate: AnyObject {
   func didTappedMainPageBackButton()
   func didTappedArchiveButton()
+  func didTappedNoticeButton()
 }
 
 class MainPageHeaderView: UIView {
@@ -39,7 +40,6 @@ class MainPageHeaderView: UIView {
   
   private let archiveButton = UIButton().then {
     $0.setImage(UIImage(named: "photoStackWhite"), for: .normal)
-    $0.addTarget(self, action: #selector(didTappedArchiveButton), for: .touchUpInside)
   }
   
   private let moreButton = UIButton().then {
@@ -86,9 +86,17 @@ class MainPageHeaderView: UIView {
         owner.delegate?.didTappedMainPageBackButton()
       }
       .disposed(by: disposeBag)
-  }
-  
-  @objc private func didTappedArchiveButton() {
-    delegate?.didTappedArchiveButton()
+    
+    archiveButton.rx.tap
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.didTappedArchiveButton()
+      }
+      .disposed(by: disposeBag)
+    
+    speakerButton.rx.tap
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.didTappedNoticeButton()
+      }
+      .disposed(by: disposeBag)
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Component/MainPageNavigationView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/MainPageNavigationView.swift
@@ -7,24 +7,26 @@
 
 import UIKit
 
+import RxSwift
 import SnapKit
 import Then
 
 protocol MainPageNavigationViewDelegate: AnyObject {
   func didTappedArchiveButton()
+  func didTappedNoticeButton()
 }
 
 final class MainPageNavigationView: UIStackView {
   
   weak var delegate: MainPageNavigationViewDelegate?
+  private let disposeBag = DisposeBag()
   
-  private let speakerBlack = UIButton().then {
+  private let speakerButton = UIButton().then {
     $0.setImage(UIImage(named: "speakerBlack"), for: .normal)
   }
   
   private let archiveButton = UIButton().then {
     $0.setImage(UIImage(named: "photoStackBlack"), for: .normal)
-    $0.addTarget(self, action: #selector(didTappedArchiveButton), for: .touchUpInside)
   }
   
   private let verticalEllipsisBlack = UIButton().then {
@@ -34,6 +36,7 @@ final class MainPageNavigationView: UIStackView {
   override init(frame: CGRect) {
     super.init(frame: frame)
     configureUI()
+    bind()
   }
   
   required init(coder: NSCoder) {
@@ -41,10 +44,20 @@ final class MainPageNavigationView: UIStackView {
   }
   
   private func configureUI() {
-    [speakerBlack, archiveButton, verticalEllipsisBlack].forEach { addArrangedSubview($0) }
+    [speakerButton, archiveButton, verticalEllipsisBlack].forEach { addArrangedSubview($0) }
   }
   
-  @objc private func didTappedArchiveButton() {
-    delegate?.didTappedArchiveButton()
+  private func bind() {
+    speakerButton.rx.tap
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.didTappedNoticeButton()
+      }
+      .disposed(by: disposeBag)
+    
+    archiveButton.rx.tap
+      .subscribe(with: self) { owner, _ in
+        owner.delegate?.didTappedArchiveButton()
+      }
+      .disposed(by: disposeBag)
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoPlannerBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoPlannerBottomSheetViewController.swift
@@ -11,22 +11,22 @@ import RxSwift
 import SnapKit
 import Then
 
-enum AddTodolistBottomSheetType {
+enum TodoPlannerBottomSheetType {
   case complete
   case noComplete
 }
 
-protocol AddTodolistBottomSheetDelegate: AnyObject {
+protocol TodoPlannerBottomSheetDelegate: AnyObject {
   func proofImage(todoID: Int)
   func editTodo(todoID: Int)
   func deleteTodo(todoID: Int)
 }
 
-final class AddTodolistBottomSheetViewController: BottomSheetViewController {
+final class TodoPlannerBottomSheetViewController: BottomSheetViewController {
   
-  weak var delegate: AddTodolistBottomSheetDelegate?
+  weak var delegate: TodoPlannerBottomSheetDelegate?
   
-  private let type: AddTodolistBottomSheetType
+  private let type: TodoPlannerBottomSheetType
   private let todoID: Int
   
   private let stackView = UIStackView().then {
@@ -38,7 +38,7 @@ final class AddTodolistBottomSheetViewController: BottomSheetViewController {
   private let editTodoListView = BottomSheetListView(text: "TO-DO 수정", image: "editBlack")
   private let deleteTodoListView = BottomSheetListView(text: "TO-DO 삭제", image: "trashRed", textColor: .error)
   
-  init(type: AddTodolistBottomSheetType, todoID: Int) {
+  init(type: TodoPlannerBottomSheetType, todoID: Int) {
     self.type = type
     self.todoID = todoID
     super.init(nibName: nil, bundle: nil)

--- a/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/CreateBoardViewController.swift
@@ -97,6 +97,7 @@ final class CreateBoardViewController: BaseViewController {
   override func setupStyles() {
     super.setupStyles()
     addPhotoImageView.addGestureRecognizer(tapGesture)
+    navigationItem.title = title
   }
   
   override func setupLayouts() {

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -100,7 +100,7 @@ final class MainPageViewController: BaseViewController {
     $0.delegate = self
   }
   
-  init(plubbingID: Int, recommendedText: String) {
+  init(plubbingID: Int, recommendedText: String, meetingTitle: String) {
     self.plubbingID = plubbingID
     self.recommendedText = recommendedText
     super.init(nibName: nil, bundle: nil)

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -100,7 +100,7 @@ final class MainPageViewController: BaseViewController {
     $0.delegate = self
   }
   
-  init(plubbingID: Int, recommendedText: String, meetingTitle: String) {
+  init(plubbingID: Int, recommendedText: String) {
     self.plubbingID = plubbingID
     self.recommendedText = recommendedText
     super.init(nibName: nil, bundle: nil)
@@ -127,9 +127,8 @@ final class MainPageViewController: BaseViewController {
   
   override func setupStyles() {
     super.setupStyles()
-    
-    self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: mainpageNavigationView)
-    title = "요란한 밧줄"
+    navigationItem.title = title
+    navigationItem.rightBarButtonItem = UIBarButtonItem(customView: mainpageNavigationView)
     
     let scrollView = pageViewController.view.subviews
       .compactMap { $0 as? UIScrollView }
@@ -185,13 +184,13 @@ final class MainPageViewController: BaseViewController {
         if owner.currentPage == 0 {
           let vc = CreateBoardViewController(plubbingID: owner.plubbingID)
           vc.navigationItem.largeTitleDisplayMode = .never
-          vc.title = "요란한 밧줄"
+          vc.title = owner.title
           owner.navigationController?.pushViewController(vc, animated: true)
         }
         else {
           let vc = AddTodoListViewController(plubbingID: owner.plubbingID)
           vc.navigationItem.largeTitleDisplayMode = .never
-          vc.title = "요란한 밧줄"
+          vc.title = owner.title
           owner.navigationController?.pushViewController(vc, animated: true)
         }
       }
@@ -234,6 +233,7 @@ extension MainPageViewController: UIScrollViewDelegate {
 extension MainPageViewController: BoardViewControllerDelegate {
   func didTappedBoardClipboardHeaderView() {
     let vc = ClipboardViewController(viewModel: ClipboardViewModel(plubbingID: plubbingID))
+    vc.title = title
     vc.navigationItem.largeTitleDisplayMode = .never
     self.navigationController?.pushViewController(vc, animated: true)
   }
@@ -242,6 +242,7 @@ extension MainPageViewController: BoardViewControllerDelegate {
     let vc = BoardDetailViewController(
       viewModel: BoardDetailViewModelWithFeedsFactory.make(plubbingID: plubbingID, feedID: content.feedID)
     )
+    vc.title = title
     vc.navigationItem.largeTitleDisplayMode = .never
     navigationController?.pushViewController(vc, animated: true)
   }

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -29,7 +29,7 @@ enum MainPageFilterType: CaseIterable {
     case .board:
       return "+ 새 글 작성"
     case .todoList:
-      return "TO-DO 추가"
+      return "+ TO-DO 플래너"
     }
   }
 }
@@ -165,7 +165,7 @@ final class MainPageViewController: BaseViewController {
     writeButton.snp.makeConstraints {
       $0.bottom.equalToSuperview().inset(24)
       $0.centerX.equalToSuperview()
-      $0.width.equalTo(110)
+      $0.width.greaterThanOrEqualTo(110)
       $0.height.equalTo(32)
     }
   }

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -268,6 +268,13 @@ extension MainPageViewController: MainPageHeaderViewDelegate {
   func didTappedMainPageBackButton() {
     self.navigationController?.popViewController(animated: true)
   }
+  
+  func didTappedNoticeButton() {
+    let vc = NotificationViewController(viewModel: NotificationViewModel())
+    vc.title = title
+    vc.navigationItem.largeTitleDisplayMode = .never
+    navigationController?.pushViewController(vc, animated: true)
+  }
 }
 
 extension MainPageViewController: MainPageNavigationViewDelegate {
@@ -279,7 +286,7 @@ extension MainPageViewController: MainPageNavigationViewDelegate {
         deleteArchiveUseCase: DefaultDeleteArchiveUseCase(plubbingID: plubbingID)
       )
     )
-    vc.title = "" // 추후에 메인페이지헤더뷰에 대한 데이터를 올바르게 받아올 경우 코드 추가
+    vc.title = title
     vc.navigationItem.largeTitleDisplayMode = .never
     navigationController?.pushViewController(vc, animated: true)
   }

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -188,7 +188,7 @@ final class MainPageViewController: BaseViewController {
           owner.navigationController?.pushViewController(vc, animated: true)
         }
         else {
-          let vc = AddTodoListViewController(plubbingID: owner.plubbingID)
+          let vc = TodoPlannerViewController(plubbingID: owner.plubbingID)
           vc.navigationItem.largeTitleDisplayMode = .never
           vc.title = owner.title
           owner.navigationController?.pushViewController(vc, animated: true)

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -180,7 +180,7 @@ extension TodoPlannerViewController: FSCalendarDelegate, FSCalendarDataSource, F
 
 extension TodoPlannerViewController: AddTodoViewDelegate {
   func tappedMoreButton(todoID: Int, isChecked: Bool) {
-    let bottomSheet = AddTodolistBottomSheetViewController(type: isChecked ? .complete : .noComplete, todoID: todoID)
+    let bottomSheet = TodoPlannerBottomSheetViewController(type: isChecked ? .complete : .noComplete, todoID: todoID)
     bottomSheet.delegate = self
     present(bottomSheet, animated: true)
   }
@@ -195,7 +195,7 @@ extension TodoPlannerViewController: AddTodoViewDelegate {
   }
 }
 
-extension TodoPlannerViewController: AddTodolistBottomSheetDelegate {
+extension TodoPlannerViewController: TodoPlannerBottomSheetDelegate {
   func proofImage(todoID: Int) {
     
   }

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -121,14 +121,14 @@ final class TodoPlannerViewController: BaseViewController {
 
 extension TodoPlannerViewController: FSCalendarDelegate, FSCalendarDataSource, FSCalendarDelegateAppearance {
   func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, fillSelectionColorFor date: Date) -> UIColor? {
-      return .main
+    return .main
   }
   
   func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, fillDefaultColorFor date: Date) -> UIColor? {
     if Calendar.current.isDateInToday(date) {
       return .white
     }
-      return nil
+    return nil
   }
   
   func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
@@ -197,14 +197,14 @@ extension TodoPlannerViewController: AddTodoViewDelegate {
 
 extension TodoPlannerViewController: TodoPlannerBottomSheetDelegate {
   func proofImage(todoID: Int) {
-    
+    Log.debug("투두인증 \(todoID)")
   }
   
   func editTodo(todoID: Int) {
-    
+    Log.debug("투두작성 \(todoID)")
   }
   
   func deleteTodo(todoID: Int) {
-    
+    Log.debug("투두삭제 \(todoID)")
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -11,7 +11,7 @@ import FSCalendar
 import SnapKit
 import Then
 
-final class AddTodoListViewController: BaseViewController {
+final class TodoPlannerViewController: BaseViewController {
   
   private let viewModel: AddTodoListViewModelType
   
@@ -119,7 +119,7 @@ final class AddTodoListViewController: BaseViewController {
   }
 }
 
-extension AddTodoListViewController: FSCalendarDelegate, FSCalendarDataSource, FSCalendarDelegateAppearance {
+extension TodoPlannerViewController: FSCalendarDelegate, FSCalendarDataSource, FSCalendarDelegateAppearance {
   func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, fillSelectionColorFor date: Date) -> UIColor? {
       return .main
   }
@@ -178,7 +178,7 @@ extension AddTodoListViewController: FSCalendarDelegate, FSCalendarDataSource, F
   }
 }
 
-extension AddTodoListViewController: AddTodoViewDelegate {
+extension TodoPlannerViewController: AddTodoViewDelegate {
   func tappedMoreButton(todoID: Int, isChecked: Bool) {
     let bottomSheet = AddTodolistBottomSheetViewController(type: isChecked ? .complete : .noComplete, todoID: todoID)
     bottomSheet.delegate = self
@@ -195,7 +195,7 @@ extension AddTodoListViewController: AddTodoViewDelegate {
   }
 }
 
-extension AddTodoListViewController: AddTodolistBottomSheetDelegate {
+extension TodoPlannerViewController: AddTodolistBottomSheetDelegate {
   func proofImage(todoID: Int) {
     
   }

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -13,7 +13,7 @@ import Then
 
 final class TodoPlannerViewController: BaseViewController {
   
-  private let viewModel: AddTodoListViewModelType
+  private let viewModel: TodoPlannerViewModelType
   
   private let plubbingID: Int
   
@@ -60,7 +60,7 @@ final class TodoPlannerViewController: BaseViewController {
     $0.delegate = self
   }
   
-  init(viewModel: AddTodoListViewModelType = AddTodoListViewModel(), plubbingID: Int) {
+  init(viewModel: TodoPlannerViewModelType = TodoPlannerViewModel(), plubbingID: Int) {
     self.plubbingID = plubbingID
     self.viewModel = viewModel
     super.init(nibName: nil, bundle: nil)

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/TodoPlannerViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/TodoPlannerViewModel.swift
@@ -11,7 +11,7 @@ import RxSwift
 import RxCocoa
 import RxRelay
 
-protocol AddTodoListViewModelType {
+protocol TodoPlannerViewModelType {
   var whichCreateTodoRequest: AnyObserver<CreateTodoRequest> { get }
   var whichInquireDate: AnyObserver<Date> { get }
   var selectPlubbingID: AnyObserver<Int> { get }
@@ -20,7 +20,7 @@ protocol AddTodoListViewModelType {
   var todolistModelByDate: Driver<AddTodoViewModel> { get }
 }
 
-final class AddTodoListViewModel: AddTodoListViewModelType {
+final class TodoPlannerViewModel: TodoPlannerViewModelType {
   
   private let disposeBag = DisposeBag()
   
@@ -51,7 +51,7 @@ final class AddTodoListViewModel: AddTodoListViewModelType {
     requestCompleteOrCancelTodo
       .withLatestFrom(todolistModelByCurrentDate) { ($0, $1) }
       .do(onNext: { Log.debug("투두완성 혹은 취소 성공 \($0.1)") })
-      .subscribe(with: self) { (owner: AddTodoListViewModel, result: (CompleteProofTodolistResponse, AddTodoViewModel)) in
+      .subscribe(with: self) { (owner: TodoPlannerViewModel, result: (CompleteProofTodolistResponse, AddTodoViewModel)) in
         let (response, model) = result
         let todoViewModel = TodoViewModel(response: response)
         owner.addTodoViewModel(what: todoViewModel, where: model)
@@ -71,7 +71,7 @@ final class AddTodoListViewModel: AddTodoListViewModelType {
     
     requestCreateTodo
       .withLatestFrom(todolistModelByCurrentDate) { ($0, $1) }
-      .subscribe(with: self) { (owner: AddTodoListViewModel, result: (CreateTodoResponse, AddTodoViewModel)) in
+      .subscribe(with: self) { (owner: TodoPlannerViewModel, result: (CreateTodoResponse, AddTodoViewModel)) in
         let (response, model) = result
         let todoViewModel = TodoViewModel(response: response)
         owner.addTodoViewModel(what: todoViewModel, where: model)
@@ -129,7 +129,7 @@ final class AddTodoListViewModel: AddTodoListViewModelType {
   }
 }
 
-extension AddTodoListViewModel {
+extension TodoPlannerViewModel {
   
   var selectPlubbingID: AnyObserver<Int> {
     whichPlubbingID.asObserver()

--- a/PLUB/Sources/Views/Meeting/MeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewController.swift
@@ -178,7 +178,7 @@ extension MeetingViewController: UICollectionViewDelegate, UICollectionViewDataS
     if indexPath.row < meetingList.count - 1 {
       guard let plubbing = meetingList[indexPath.row].plubbing else { return }
       // 플러빙 메인
-      let vc = MainPageViewController(plubbingID: plubbing.plubbingID, recommendedText: plubbing.goal)
+      let vc = MainPageViewController(plubbingID: plubbing.plubbingID, recommendedText: plubbing.goal, meetingTitle: plubbing.name)
       vc.navigationItem.largeTitleDisplayMode = .never
       vc.hidesBottomBarWhenPushed = true
       self.navigationController?.pushViewController(vc, animated: true)

--- a/PLUB/Sources/Views/Meeting/MeetingViewController.swift
+++ b/PLUB/Sources/Views/Meeting/MeetingViewController.swift
@@ -178,7 +178,8 @@ extension MeetingViewController: UICollectionViewDelegate, UICollectionViewDataS
     if indexPath.row < meetingList.count - 1 {
       guard let plubbing = meetingList[indexPath.row].plubbing else { return }
       // 플러빙 메인
-      let vc = MainPageViewController(plubbingID: plubbing.plubbingID, recommendedText: plubbing.goal, meetingTitle: plubbing.name)
+      let vc = MainPageViewController(plubbingID: plubbing.plubbingID, recommendedText: plubbing.goal)
+      vc.title = plubbing.name
       vc.navigationItem.largeTitleDisplayMode = .never
       vc.hidesBottomBarWhenPushed = true
       self.navigationController?.pushViewController(vc, animated: true)


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 메인페이지, 투두플래너, 게시글생성 화면에 대한 모임타이틀 전달
- 메인페이지 플로팅버튼 피그마디자인에 따른 코드 수정
- 투두플래너에 대한 이름 수정

## 📮 관련 이슈
- Resolved: #375 

