### PR TITLE
[FEAT] 메인페이지 바텀시트 기능 구현

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		705F821229B2FCEC00830C4F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 705F821129B2FCEC00830C4F /* GoogleService-Info.plist */; };
 		705FD2742A0E895800F353FE /* TodoPlannerBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD2732A0E895800F353FE /* TodoPlannerBottomSheetViewController.swift */; };
 		705FD29D2A14E06900F353FE /* ProofTodoAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD29C2A14E06900F353FE /* ProofTodoAlertViewController.swift */; };
+		705FD2B52A1734CE00F353FE /* EditTodolistRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD2B42A1734CE00F353FE /* EditTodolistRequest.swift */; };
 		706315962A0BA93400DD8EFE /* TodoPlannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315952A0BA93400DD8EFE /* TodoPlannerViewModel.swift */; };
 		706315982A0BAA6000DD8EFE /* CreateTodoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */; };
 		7063159A2A0BAAE200DD8EFE /* CreateTodoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */; };
@@ -477,6 +478,7 @@
 		705F821129B2FCEC00830C4F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		705FD2732A0E895800F353FE /* TodoPlannerBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPlannerBottomSheetViewController.swift; sourceTree = "<group>"; };
 		705FD29C2A14E06900F353FE /* ProofTodoAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProofTodoAlertViewController.swift; sourceTree = "<group>"; };
+		705FD2B42A1734CE00F353FE /* EditTodolistRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTodolistRequest.swift; sourceTree = "<group>"; };
 		706315952A0BA93400DD8EFE /* TodoPlannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPlannerViewModel.swift; sourceTree = "<group>"; };
 		706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoRequest.swift; sourceTree = "<group>"; };
 		706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoResponse.swift; sourceTree = "<group>"; };
@@ -1199,6 +1201,7 @@
 			children = (
 				70C9CCA32A03FFC000BEB5F2 /* ProofTodolistRequest.swift */,
 				706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */,
+				705FD2B42A1734CE00F353FE /* EditTodolistRequest.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -2633,6 +2636,7 @@
 				70CF333929992FA60077FF47 /* RecruitmentFilterSlider.swift in Sources */,
 				BA42D1F328EDE10F00C20061 /* LoginViewController.swift in Sources */,
 				C3FF87AC2A06572000DA6017 /* MyFeedResponse.swift in Sources */,
+				705FD2B52A1734CE00F353FE /* EditTodolistRequest.swift in Sources */,
 				C3413E122995450B004B8DBD /* UnderlineSegmentedControl.swift in Sources */,
 				BAE5D3372975B20000268D44 /* TokenResponse.swift in Sources */,
 				C38A5B9F297B022A00485355 /* SearchView.swift in Sources */,

--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		705FD2742A0E895800F353FE /* TodoPlannerBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD2732A0E895800F353FE /* TodoPlannerBottomSheetViewController.swift */; };
 		705FD29D2A14E06900F353FE /* ProofTodoAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD29C2A14E06900F353FE /* ProofTodoAlertViewController.swift */; };
 		705FD2B52A1734CE00F353FE /* EditTodolistRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD2B42A1734CE00F353FE /* EditTodolistRequest.swift */; };
+		705FD2B72A17CA4700F353FE /* DeleteTodolistResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD2B62A17CA4700F353FE /* DeleteTodolistResponse.swift */; };
 		706315962A0BA93400DD8EFE /* TodoPlannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315952A0BA93400DD8EFE /* TodoPlannerViewModel.swift */; };
 		706315982A0BAA6000DD8EFE /* CreateTodoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */; };
 		7063159A2A0BAAE200DD8EFE /* CreateTodoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */; };
@@ -479,6 +480,7 @@
 		705FD2732A0E895800F353FE /* TodoPlannerBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPlannerBottomSheetViewController.swift; sourceTree = "<group>"; };
 		705FD29C2A14E06900F353FE /* ProofTodoAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProofTodoAlertViewController.swift; sourceTree = "<group>"; };
 		705FD2B42A1734CE00F353FE /* EditTodolistRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTodolistRequest.swift; sourceTree = "<group>"; };
+		705FD2B62A17CA4700F353FE /* DeleteTodolistResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteTodolistResponse.swift; sourceTree = "<group>"; };
 		706315952A0BA93400DD8EFE /* TodoPlannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPlannerViewModel.swift; sourceTree = "<group>"; };
 		706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoRequest.swift; sourceTree = "<group>"; };
 		706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoResponse.swift; sourceTree = "<group>"; };
@@ -1128,6 +1130,7 @@
 				70C9CCA52A05044400BEB5F2 /* LikeTodolistResponse.swift */,
 				706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */,
 				7063159D2A0BBF6B00DD8EFE /* InquireTodolistByDateResponse.swift */,
+				705FD2B62A17CA4700F353FE /* DeleteTodolistResponse.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -2661,6 +2664,7 @@
 				BA46CC9F28EC9B05004953B1 /* Ex+UIColor.swift in Sources */,
 				BA2173BD29F61A36000D72B1 /* EditArchiveUseCase.swift in Sources */,
 				BAB2E56C29E30A13006B7BDC /* PostCommentUseCase.swift in Sources */,
+				705FD2B72A17CA4700F353FE /* DeleteTodolistResponse.swift in Sources */,
 				C39E09B629C604DE00ECAD11 /* RecruitingFooterView.swift in Sources */,
 				706315962A0BA93400DD8EFE /* TodoPlannerViewModel.swift in Sources */,
 				BA340E1629782207002BAF2C /* IntroduceTagCollectionViewCell.swift in Sources */,

--- a/PLUB/Sources/Models/Todolist/Request/EditTodolistRequest.swift
+++ b/PLUB/Sources/Models/Todolist/Request/EditTodolistRequest.swift
@@ -1,0 +1,13 @@
+//
+//  EditTodolistRequest.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/05/19.
+//
+
+import Foundation
+
+struct EditTodolistRequest: Codable {
+  let content: String
+  let date: String
+}

--- a/PLUB/Sources/Models/Todolist/Response/DeleteTodolistResponse.swift
+++ b/PLUB/Sources/Models/Todolist/Response/DeleteTodolistResponse.swift
@@ -1,0 +1,12 @@
+//
+//  DeleteTodolistResponse.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/05/20.
+//
+
+import Foundation
+
+struct DeleteTodolistResponse: Codable {
+  let result: String
+}

--- a/PLUB/Sources/Network/Routers/TodolistRouter.swift
+++ b/PLUB/Sources/Network/Routers/TodolistRouter.swift
@@ -17,6 +17,7 @@ enum TodolistRouter {
   case createTodo(Int, CreateTodoRequest)
   case inquireTodolistByDate(Int, String)
   case editTodolist(Int, Int, EditTodolistRequest)
+  case deleteTodolist(Int, Int)
 }
 
 extension TodolistRouter: Router {
@@ -28,6 +29,8 @@ extension TodolistRouter: Router {
       return .put
     case .proofTodolist, .createTodo:
       return .post
+    case .deleteTodolist:
+      return .delete
     }
   }
   
@@ -51,6 +54,8 @@ extension TodolistRouter: Router {
       return "/plubbings/\(plubbingID)/timeline/\(todoDate)"
     case .editTodolist(let plubbingID, let todoID, _):
       return "/plubbings/\(plubbingID)/todolist/\(todoID)"
+    case .deleteTodolist(let plubbingID, let todoID):
+      return "/plubbings/\(plubbingID)/todolist/\(todoID)"
     }
   }
   
@@ -58,7 +63,7 @@ extension TodolistRouter: Router {
     switch self {
     case .inquireAllTodoTimeline(_, let cursorID):
       return .query(["cursorId": cursorID])
-    case .inquireTodolist, .completeTodolist, .cancelCompleteTodolist, .likeTodolist, .inquireTodolistByDate:
+    case .inquireTodolist, .completeTodolist, .cancelCompleteTodolist, .likeTodolist, .inquireTodolistByDate, .deleteTodolist:
       return .plain
     case .proofTodolist(_, _, let request):
       return .body(request)

--- a/PLUB/Sources/Network/Routers/TodolistRouter.swift
+++ b/PLUB/Sources/Network/Routers/TodolistRouter.swift
@@ -16,6 +16,7 @@ enum TodolistRouter {
   case likeTodolist(Int, Int)
   case createTodo(Int, CreateTodoRequest)
   case inquireTodolistByDate(Int, String)
+  case editTodolist(Int, Int, EditTodolistRequest)
 }
 
 extension TodolistRouter: Router {
@@ -23,7 +24,7 @@ extension TodolistRouter: Router {
     switch self {
     case .inquireAllTodoTimeline, .inquireTodolist, .inquireTodolistByDate:
       return .get
-    case .completeTodolist, .cancelCompleteTodolist, .likeTodolist:
+    case .completeTodolist, .cancelCompleteTodolist, .likeTodolist, .editTodolist:
       return .put
     case .proofTodolist, .createTodo:
       return .post
@@ -48,6 +49,8 @@ extension TodolistRouter: Router {
       return "/plubbings/\(plubbingID)/todolist"
     case .inquireTodolistByDate(let plubbingID, let todoDate):
       return "/plubbings/\(plubbingID)/timeline/\(todoDate)"
+    case .editTodolist(let plubbingID, let todoID, _):
+      return "/plubbings/\(plubbingID)/todolist/\(todoID)"
     }
   }
   
@@ -60,6 +63,8 @@ extension TodolistRouter: Router {
     case .proofTodolist(_, _, let request):
       return .body(request)
     case .createTodo(_, let request):
+      return .body(request)
+    case .editTodolist(_, _, let request):
       return .body(request)
     }
   }

--- a/PLUB/Sources/Network/Services/TodolistService.swift
+++ b/PLUB/Sources/Network/Services/TodolistService.swift
@@ -74,4 +74,8 @@ extension TodolistService {
   func inquireTodolistByDate(plubbingID: Int, todoDate: String) -> Observable<InquireTodolistByDateResponse> {
     sendObservableRequest(TodolistRouter.inquireTodolistByDate(plubbingID, todoDate))
   }
+  
+  func editTodolist(plubbingID: Int, todoID: Int, request: EditTodolistRequest) -> Observable<CompleteProofTodolistResponse> {
+    sendObservableRequest(TodolistRouter.editTodolist(plubbingID, todoID, request))
+  }
 }

--- a/PLUB/Sources/Network/Services/TodolistService.swift
+++ b/PLUB/Sources/Network/Services/TodolistService.swift
@@ -78,4 +78,8 @@ extension TodolistService {
   func editTodolist(plubbingID: Int, todoID: Int, request: EditTodolistRequest) -> Observable<CompleteProofTodolistResponse> {
     sendObservableRequest(TodolistRouter.editTodolist(plubbingID, todoID, request))
   }
+  
+  func deleteTodolist(plubbingID: Int, todoID: Int) -> Observable<DeleteTodolistResponse> {
+    sendObservableRequest(TodolistRouter.deleteTodolist(plubbingID, todoID))
+  }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
@@ -51,7 +51,7 @@ enum AddTodoType {
 final class AddTodoView: UIView {
   
   weak var delegate: AddTodoViewDelegate?
-  private var type: AddTodoType = .create
+  private var type: AddTodoType = .create 
   private var date: Date?
   private(set) var completionHandler: ((Date) -> Void)?
   private(set) var todoHandler: ((AddTodoType, String?) -> Void)?
@@ -108,8 +108,6 @@ final class AddTodoView: UIView {
       .arrangedSubviews[2...]
       .forEach { $0.removeFromSuperview() }
     
-    inputTodoView.clearTextField()
-    
     todoHandler = { [weak self] type, content in
       guard let self = self else { return }
       self.type = type
@@ -134,6 +132,12 @@ final class AddTodoView: UIView {
 }
 
 extension AddTodoView: TodoViewDelegate {
+  func inputTextIsEmpty(isEmpty: Bool) {
+    if type == .edit && isEmpty {
+      type = .create
+    }
+  }
+  
   func tappedMoreButton(todoID: Int, isChecked: Bool, isProof: Bool, content: String) {
     delegate?.tappedMoreButton(todoID: todoID, isChecked: isChecked, isProof: isProof, content: content)
   }
@@ -146,5 +150,6 @@ extension AddTodoView: TodoViewDelegate {
     guard let date = self.date else { return }
     let dateString = DateFormatterFactory.dateWithHypen.string(from: date)
     delegate?.whichCreateTodoRequest(request: .init(content: content, date: dateString), type: type)
+    inputTodoView.clearTextField()
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
@@ -25,7 +25,9 @@ struct AddTodoViewModel {
         todoID: $0.todoID,
         date: $0.date,
         isChecked: $0.isChecked,
-        content: $0.content
+        content: $0.content,
+        isAuthor: $0.isAuthor,
+        isProof: $0.isProof
       )
     }
   }
@@ -121,7 +123,9 @@ final class AddTodoView: UIView {
         todoID: model.todoID,
         date: model.date,
         isChecked: model.isChecked,
-        content: model.content)
+        content: model.content,
+        isAuthor: model.isAuthor,
+        isProof: model.isProof)
       )
       todoContainerView.addArrangedSubview(todoView)
     }

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
@@ -46,6 +46,7 @@ final class AddTodoView: UIView {
   weak var delegate: AddTodoViewDelegate?
   private var date: Date?
   private(set) var completionHandler: ((Date) -> Void)?
+  private(set) var todoHandler: (() -> Void)?
   
   private let todoContainerView = UIStackView().then {
     $0.axis = .vertical
@@ -100,6 +101,9 @@ final class AddTodoView: UIView {
     let inputTodoView = TodoView(type: .input)
     inputTodoView.delegate = self
     todoContainerView.addArrangedSubview(inputTodoView)
+    todoHandler = { _ in
+      inputTodoView.becomeResponder()
+    }
     
     model.todoViewModel.forEach { model in
       let todoView = TodoView(type: .todo)

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
@@ -40,7 +40,7 @@ struct AddTodoViewModel {
 protocol AddTodoViewDelegate: AnyObject {
   func whichCreateTodoRequest(request: CreateTodoRequest, type: AddTodoType)
   func whichTodoChecked(isChecked: Bool, todoID: Int)
-  func tappedMoreButton(todoID: Int, isChecked: Bool, isProof: Bool)
+  func tappedMoreButton(todoID: Int, isChecked: Bool, isProof: Bool, content: String)
 }
 
 enum AddTodoType {
@@ -54,7 +54,7 @@ final class AddTodoView: UIView {
   private var type: AddTodoType = .create
   private var date: Date?
   private(set) var completionHandler: ((Date) -> Void)?
-  private(set) var todoHandler: ((AddTodoType) -> Void)?
+  private(set) var todoHandler: ((AddTodoType, String?) -> Void)?
   
   private let todoContainerView = UIStackView().then {
     $0.axis = .vertical
@@ -110,9 +110,10 @@ final class AddTodoView: UIView {
     
     inputTodoView.clearTextField()
     
-    todoHandler = { [weak self] type in
+    todoHandler = { [weak self] type, content in
       guard let self = self else { return }
       self.type = type
+      self.inputTodoView.changedTextForEdit(content: content)
       self.inputTodoView.becomeResponder()
     }
     
@@ -133,8 +134,8 @@ final class AddTodoView: UIView {
 }
 
 extension AddTodoView: TodoViewDelegate {
-  func tappedMoreButton(todoID: Int, isChecked: Bool, isProof: Bool) {
-    delegate?.tappedMoreButton(todoID: todoID, isChecked: isChecked, isProof: isProof)
+  func tappedMoreButton(todoID: Int, isChecked: Bool, isProof: Bool, content: String) {
+    delegate?.tappedMoreButton(todoID: todoID, isChecked: isChecked, isProof: isProof, content: content)
   }
   
   func whichTodoChecked(isChecked: Bool, todoID: Int) {

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
@@ -147,8 +147,7 @@ extension AddTodoView: TodoViewDelegate {
   }
   
   func whichTodoContent(content: String) {
-    guard let date = self.date else { return }
-    let dateString = DateFormatterFactory.dateWithHypen.string(from: date)
+    let dateString = DateFormatterFactory.dateWithHypen.string(from: date ?? Date())
     delegate?.whichCreateTodoRequest(request: .init(content: content, date: dateString), type: type)
     inputTodoView.clearTextField()
   }

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
@@ -40,7 +40,7 @@ struct AddTodoViewModel {
 protocol AddTodoViewDelegate: AnyObject {
   func whichCreateTodoRequest(request: CreateTodoRequest, type: AddTodoType)
   func whichTodoChecked(isChecked: Bool, todoID: Int)
-  func tappedMoreButton(todoID: Int, isChecked: Bool)
+  func tappedMoreButton(todoID: Int, isChecked: Bool, isProof: Bool)
 }
 
 enum AddTodoType {
@@ -133,8 +133,8 @@ final class AddTodoView: UIView {
 }
 
 extension AddTodoView: TodoViewDelegate {
-  func tappedMoreButton(todoID: Int, isChecked: Bool) {
-    delegate?.tappedMoreButton(todoID: todoID, isChecked: isChecked)
+  func tappedMoreButton(todoID: Int, isChecked: Bool, isProof: Bool) {
+    delegate?.tappedMoreButton(todoID: todoID, isChecked: isChecked, isProof: isProof)
   }
   
   func whichTodoChecked(isChecked: Bool, todoID: Int) {

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoPlannerBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoPlannerBottomSheetViewController.swift
@@ -14,6 +14,7 @@ import Then
 enum TodoPlannerBottomSheetType {
   case complete
   case noComplete
+  case proof
 }
 
 protocol TodoPlannerBottomSheetDelegate: AnyObject {
@@ -82,6 +83,8 @@ final class TodoPlannerBottomSheetViewController: BottomSheetViewController {
       [proofImageListView, editTodoListView, deleteTodoListView].forEach { stackView.addArrangedSubview($0) }
     case .noComplete:
       [editTodoListView, deleteTodoListView].forEach { stackView.addArrangedSubview($0) }
+    case .proof:
+      stackView.addArrangedSubview(deleteTodoListView)
     }
   }
   
@@ -106,6 +109,10 @@ final class TodoPlannerBottomSheetViewController: BottomSheetViewController {
         $0.snp.makeConstraints {
           $0.height.equalTo(Metrics.Size.listHeight)
         }
+      }
+    case .proof:
+      deleteTodoListView.snp.makeConstraints {
+        $0.height.equalTo(Metrics.Size.listHeight)
       }
     }
   }

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoPlannerBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoPlannerBottomSheetViewController.swift
@@ -83,7 +83,7 @@ final class TodoPlannerBottomSheetViewController: BottomSheetViewController {
     
     switch type {
     case .complete:
-      [proofImageListView, editTodoListView, deleteTodoListView].forEach { stackView.addArrangedSubview($0) }
+      [proofImageListView, deleteTodoListView].forEach { stackView.addArrangedSubview($0) }
     case .noComplete:
       [editTodoListView, deleteTodoListView].forEach { stackView.addArrangedSubview($0) }
     case .proof:

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoPlannerBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoPlannerBottomSheetViewController.swift
@@ -19,7 +19,7 @@ enum TodoPlannerBottomSheetType {
 
 protocol TodoPlannerBottomSheetDelegate: AnyObject {
   func proofImage(todoID: Int)
-  func editTodo(todoID: Int)
+  func editTodo(todoID: Int, content: String)
   func deleteTodo(todoID: Int)
 }
 
@@ -29,6 +29,7 @@ final class TodoPlannerBottomSheetViewController: BottomSheetViewController {
   
   private let type: TodoPlannerBottomSheetType
   private let todoID: Int
+  private let content: String?
   
   private let stackView = UIStackView().then {
     $0.axis = .vertical
@@ -39,9 +40,10 @@ final class TodoPlannerBottomSheetViewController: BottomSheetViewController {
   private let editTodoListView = BottomSheetListView(text: "TO-DO 수정", image: "editBlack")
   private let deleteTodoListView = BottomSheetListView(text: "TO-DO 삭제", image: "trashRed", textColor: .error)
   
-  init(type: TodoPlannerBottomSheetType, todoID: Int) {
+  init(type: TodoPlannerBottomSheetType, todoID: Int, content: String?) {
     self.type = type
     self.todoID = todoID
+    self.content = content
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -61,7 +63,8 @@ final class TodoPlannerBottomSheetViewController: BottomSheetViewController {
     
     editTodoListView.button.rx.tap
       .subscribe(with: self) { owner, _ in
-        owner.delegate?.editTodo(todoID: owner.todoID)
+        guard let content = owner.content else { return }
+        owner.delegate?.editTodo(todoID: owner.todoID, content: content)
         owner.dismiss(animated: true)
       }
       .disposed(by: disposeBag)

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoPlannerBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoPlannerBottomSheetViewController.swift
@@ -54,18 +54,21 @@ final class TodoPlannerBottomSheetViewController: BottomSheetViewController {
     proofImageListView.button.rx.tap
       .subscribe(with: self) { owner, _ in
         owner.delegate?.proofImage(todoID: owner.todoID)
+        owner.dismiss(animated: true)
       }
       .disposed(by: disposeBag)
     
     editTodoListView.button.rx.tap
       .subscribe(with: self) { owner, _ in
         owner.delegate?.editTodo(todoID: owner.todoID)
+        owner.dismiss(animated: true)
       }
       .disposed(by: disposeBag)
     
     deleteTodoListView.button.rx.tap
       .subscribe(with: self) { owner, _ in
         owner.delegate?.deleteTodo(todoID: owner.todoID)
+        owner.dismiss(animated: true)
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
@@ -68,9 +68,9 @@ final class TodoView: UIView {
   
   private lazy var todoTextField = UITextField().then {
     $0.placeholder = "새로운 TO-DO 추가하기"
-    $0.layer.shouldRasterize = true
     $0.delegate = self
     $0.returnKeyType = .done
+    $0.isUserInteractionEnabled = true
   }
   
   private lazy var moreButton = UIButton().then {
@@ -138,6 +138,10 @@ final class TodoView: UIView {
         $0.centerY.trailing.equalToSuperview()
       }
     }
+  }
+  
+  func becomeResponder() {
+    todoTextField.becomeFirstResponder()
   }
   
   func configureUI(with model: TodoViewModel) {

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
@@ -14,7 +14,7 @@ import Then
 protocol TodoViewDelegate: AnyObject {
   func whichTodoContent(content: String)
   func whichTodoChecked(isChecked: Bool, todoID: Int)
-  func tappedMoreButton(todoID: Int, isChecked: Bool)
+  func tappedMoreButton(todoID: Int, isChecked: Bool, isProof: Bool)
 }
 
 struct TodoViewModel {
@@ -58,7 +58,7 @@ final class TodoView: UIView {
   weak var delegate: TodoViewDelegate?
   private let disposeBag = DisposeBag()
   private let type: TodoViewType
-  private var todoID: Int?
+  private var model: TodoViewModel?
   
   private lazy var emptyCheckView = UIView().then {
     $0.layer.borderWidth = 1
@@ -157,7 +157,7 @@ final class TodoView: UIView {
   }
   
   func configureUI(with model: TodoViewModel) {
-    todoID = model.todoID
+    self.model = model
     contentLabel.text = model.content
     checkBoxButton.isChecked = model.isChecked || model.isProof
     contentLabel.attributedText = model.isChecked ? contentLabel.text?.strikeThrough() : NSAttributedString(string: contentLabel.text ?? "")
@@ -169,7 +169,7 @@ final class TodoView: UIView {
   private func bind() {
     checkBoxButton.rx.isChecked
       .subscribe(with: self) { owner, isChecked in
-        guard let todoID = owner.todoID else { return }
+        guard let todoID = owner.model?.todoID else { return }
         owner.contentLabel.attributedText = isChecked ? owner.contentLabel.text?.strikeThrough() : NSAttributedString(string: owner.contentLabel.text ?? "")
         
         owner.delegate?.whichTodoChecked(isChecked: isChecked, todoID: todoID)
@@ -178,8 +178,8 @@ final class TodoView: UIView {
     
     moreButton.rx.tap
       .subscribe(with: self) { owner, _ in
-        guard let todoID = owner.todoID else { return }
-        owner.delegate?.tappedMoreButton(todoID: todoID, isChecked: owner.checkBoxButton.isChecked)
+        guard let model = owner.model else { return }
+        owner.delegate?.tappedMoreButton(todoID: model.todoID, isChecked: owner.checkBoxButton.isChecked, isProof: model.isProof)
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
@@ -14,7 +14,7 @@ import Then
 protocol TodoViewDelegate: AnyObject {
   func whichTodoContent(content: String)
   func whichTodoChecked(isChecked: Bool, todoID: Int)
-  func tappedMoreButton(todoID: Int, isChecked: Bool, isProof: Bool)
+  func tappedMoreButton(todoID: Int, isChecked: Bool, isProof: Bool, content: String)
 }
 
 struct TodoViewModel {
@@ -148,6 +148,11 @@ final class TodoView: UIView {
     }
   }
   
+  func changedTextForEdit(content: String?) {
+    guard let content = content else { return }
+    todoTextField.text = content
+  }
+  
   func clearTextField() {
     todoTextField.text = nil
   }
@@ -179,7 +184,7 @@ final class TodoView: UIView {
     moreButton.rx.tap
       .subscribe(with: self) { owner, _ in
         guard let model = owner.model else { return }
-        owner.delegate?.tappedMoreButton(todoID: model.todoID, isChecked: owner.checkBoxButton.isChecked, isProof: model.isProof)
+        owner.delegate?.tappedMoreButton(todoID: model.todoID, isChecked: owner.checkBoxButton.isChecked, isProof: model.isProof, content: model.content)
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
@@ -22,12 +22,16 @@ struct TodoViewModel {
   let date: String
   let isChecked: Bool
   let content: String
+  let isAuthor: Bool
+  let isProof: Bool
   
-  init(todoID: Int, date: String, isChecked: Bool, content: String) {
+  init(todoID: Int, date: String, isChecked: Bool, content: String, isAuthor: Bool, isProof: Bool) {
     self.todoID = todoID
     self.date = date
     self.isChecked = isChecked
     self.content = content
+    self.isAuthor = isAuthor
+    self.isProof = isProof
   }
   
   init(response: CreateTodoResponse) {
@@ -35,6 +39,8 @@ struct TodoViewModel {
     date = response.date
     isChecked = response.isChecked
     content = response.content
+    isAuthor = response.isAuthor
+    isProof = response.isProof
   }
   
   init(response: CompleteProofTodolistResponse) {
@@ -42,6 +48,8 @@ struct TodoViewModel {
     date = response.date
     isChecked = response.isChecked
     content = response.content
+    isAuthor = response.isAuthor
+    isProof = response.isProof
   }
 }
 
@@ -151,8 +159,11 @@ final class TodoView: UIView {
   func configureUI(with model: TodoViewModel) {
     todoID = model.todoID
     contentLabel.text = model.content
-    checkBoxButton.isChecked = model.isChecked
+    checkBoxButton.isChecked = model.isChecked || model.isProof
     contentLabel.attributedText = model.isChecked ? contentLabel.text?.strikeThrough() : NSAttributedString(string: contentLabel.text ?? "")
+    
+    // 해당 투두가 인증되었거나 작성자가 아니라면 -> 체크버튼 비활성화
+    checkBoxButton.isEnabled = model.isProof || !model.isAuthor ? false : true
   }
   
   private func bind() {

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
@@ -140,6 +140,10 @@ final class TodoView: UIView {
     }
   }
   
+  func clearTextField() {
+    todoTextField.text = nil
+  }
+  
   func becomeResponder() {
     todoTextField.becomeFirstResponder()
   }

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodoView.swift
@@ -12,6 +12,7 @@ import SnapKit
 import Then
 
 protocol TodoViewDelegate: AnyObject {
+  func inputTextIsEmpty(isEmpty: Bool)
   func whichTodoContent(content: String)
   func whichTodoChecked(isChecked: Bool, todoID: Int)
   func tappedMoreButton(todoID: Int, isChecked: Bool, isProof: Bool, content: String)
@@ -185,6 +186,15 @@ final class TodoView: UIView {
       .subscribe(with: self) { owner, _ in
         guard let model = owner.model else { return }
         owner.delegate?.tappedMoreButton(todoID: model.todoID, isChecked: owner.checkBoxButton.isChecked, isProof: model.isProof, content: model.content)
+      }
+      .disposed(by: disposeBag)
+    
+    todoTextField.rx.text
+      .orEmpty
+      .map { $0.isEmpty }
+      .distinctUntilChanged()
+      .subscribe(with: self) { owner, isEmpty in
+        owner.delegate?.inputTextIsEmpty(isEmpty: isEmpty)
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodolistBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodolistBottomSheetViewController.swift
@@ -33,9 +33,15 @@ enum TodolistBottomSheetType {
   }
 }
 
+protocol TodolistBottomSheetDelegate: AnyObject {
+  func didTappedTodoPlanner()
+  func didTappedReport()
+}
+
 final class TodolistBottomSheetViewController: BottomSheetViewController {
   
   private let type: TodolistBottomSheetType
+  weak var delegate: TodolistBottomSheetDelegate?
   
   private lazy var bottomSheetView = BottomSheetListView(
     text: type.text,
@@ -49,6 +55,20 @@ final class TodolistBottomSheetViewController: BottomSheetViewController {
   
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func bind() {
+    bottomSheetView.button.rx.tap
+      .subscribe(with: self) { owner, _ in
+        switch owner.type {
+        case .todoPlanner:
+          owner.delegate?.didTappedTodoPlanner()
+        case .report:
+          owner.delegate?.didTappedReport()
+        }
+        owner.dismiss(animated: true)
+      }
+      .disposed(by: disposeBag)
   }
   
   override func setupLayouts() {

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -80,7 +80,9 @@ final class MainPageViewController: BaseViewController {
     $0.delegate = self
   }
   
-  private lazy var todolistViewController = TodolistViewController(plubbingID: plubbingID, goal: goal)
+  private lazy var todolistViewController = TodolistViewController(plubbingID: plubbingID, goal: goal).then {
+    $0.delegate = self
+  }
   
   private var viewControllers: [UIViewController] {
     [
@@ -289,5 +291,14 @@ extension MainPageViewController: MainPageNavigationViewDelegate {
     vc.title = title
     vc.navigationItem.largeTitleDisplayMode = .never
     navigationController?.pushViewController(vc, animated: true)
+  }
+}
+
+extension MainPageViewController: TodolistDelegate {
+  func didTappedTodoPlanner() {
+    let vc = TodoPlannerViewController(plubbingID: plubbingID, type: .manageMyPlanner)
+    vc.navigationItem.largeTitleDisplayMode = .never
+    vc.title = title
+    self.navigationController?.pushViewController(vc, animated: true)
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -202,10 +202,17 @@ extension TodoPlannerViewController: FSCalendarDelegate, FSCalendarDataSource, F
 }
 
 extension TodoPlannerViewController: AddTodoViewDelegate {
-  func tappedMoreButton(todoID: Int, isChecked: Bool) {
-    let bottomSheet = TodoPlannerBottomSheetViewController(type: isChecked ? .complete : .noComplete, todoID: todoID)
-    bottomSheet.delegate = self
-    present(bottomSheet, animated: true)
+  func tappedMoreButton(todoID: Int, isChecked: Bool, isProof: Bool) {
+    
+    if isProof {
+      let bottomSheet = TodoPlannerBottomSheetViewController(type: .proof, todoID: todoID)
+      bottomSheet.delegate = self
+      present(bottomSheet, animated: true)
+    } else {
+      let bottomSheet = TodoPlannerBottomSheetViewController(type: isChecked ? .complete : .noComplete, todoID: todoID)
+      bottomSheet.delegate = self
+      present(bottomSheet, animated: true)
+    }
   }
   
   func whichTodoChecked(isChecked: Bool, todoID: Int) {

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -100,7 +100,6 @@ final class TodoPlannerViewController: BaseViewController {
     viewModel.selectPlubbingID.onNext(plubbingID)
     
     viewModel.todolistModelByDate
-      .do(onNext: { _ in print("데이터나오는중") })
       .drive(rx.todolistModel)
       .disposed(by: disposeBag)
     
@@ -171,7 +170,6 @@ extension TodoPlannerViewController: FSCalendarDelegate, FSCalendarDataSource, F
   }
   
   func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
-    print("데이트 \(date)")
     addTodoView.completionHandler?(date)
     viewModel.whichInquireDate.onNext(date)
     if Calendar.current.isDateInToday(date) {

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -243,7 +243,6 @@ extension TodoPlannerViewController: AddTodoViewDelegate {
       viewModel.whichCreateTodoRequest.onNext(request)
     case .edit:
       viewModel.whichEditRequest.onNext(EditTodolistRequest(content: request.content, date: request.date))
-      addTodoView.todoHandler?(.create, nil)
     }
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -64,6 +64,7 @@ final class TodoPlannerViewController: BaseViewController {
     $0.appearance.todayColor = .white
     $0.appearance.weekdayTextColor = .gray
     $0.appearance.titleWeekendColor = .red
+    $0.select(Date())
   }
   
   private lazy var addTodoView = AddTodoView().then {

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -124,7 +124,6 @@ final class TodoPlannerViewController: BaseViewController {
     viewModel.whichInquireDate.onNext(Date())
     navigationItem.title = title
     view.addGestureRecognizer(tapGesture)
-    view.isUserInteractionEnabled = true
   }
   
   override func setupLayouts() {
@@ -172,6 +171,7 @@ extension TodoPlannerViewController: FSCalendarDelegate, FSCalendarDataSource, F
   }
   
   func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
+    print("데이트 \(date)")
     addTodoView.completionHandler?(date)
     viewModel.whichInquireDate.onNext(date)
     if Calendar.current.isDateInToday(date) {
@@ -237,7 +237,7 @@ extension TodoPlannerViewController: AddTodoViewDelegate {
   }
   
   func whichCreateTodoRequest(request: CreateTodoRequest, type: AddTodoType) {
-    Log.debug("투두생성리퀘스트 \(type)")
+    Log.debug("투두생성리퀘스트 \(type)\n 투두생성요청 \(request)")
     switch type {
     case .create:
       viewModel.whichCreateTodoRequest.onNext(request)

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -202,14 +202,14 @@ extension TodoPlannerViewController: FSCalendarDelegate, FSCalendarDataSource, F
 }
 
 extension TodoPlannerViewController: AddTodoViewDelegate {
-  func tappedMoreButton(todoID: Int, isChecked: Bool, isProof: Bool) {
+  func tappedMoreButton(todoID: Int, isChecked: Bool, isProof: Bool, content: String) {
     
     if isProof {
-      let bottomSheet = TodoPlannerBottomSheetViewController(type: .proof, todoID: todoID)
+      let bottomSheet = TodoPlannerBottomSheetViewController(type: .proof, todoID: todoID, content: nil)
       bottomSheet.delegate = self
       present(bottomSheet, animated: true)
     } else {
-      let bottomSheet = TodoPlannerBottomSheetViewController(type: isChecked ? .complete : .noComplete, todoID: todoID)
+      let bottomSheet = TodoPlannerBottomSheetViewController(type: isChecked ? .complete : .noComplete, todoID: todoID, content: content)
       bottomSheet.delegate = self
       present(bottomSheet, animated: true)
     }
@@ -226,7 +226,7 @@ extension TodoPlannerViewController: AddTodoViewDelegate {
       viewModel.whichCreateTodoRequest.onNext(request)
     case .edit:
       viewModel.whichEditRequest.onNext(EditTodolistRequest(content: request.content, date: request.date))
-      addTodoView.todoHandler?(.create)
+      addTodoView.todoHandler?(.create, nil)
     }
   }
 }
@@ -236,9 +236,9 @@ extension TodoPlannerViewController: TodoPlannerBottomSheetDelegate {
     Log.debug("투두인증 \(todoID)")
   }
   
-  func editTodo(todoID: Int) {
+  func editTodo(todoID: Int, content: String) {
     Log.debug("투두작성 \(todoID)")
-    addTodoView.todoHandler?(.edit)
+    addTodoView.todoHandler?(.edit, content)
     viewModel.whichTodoID.onNext(todoID)
   }
   

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -95,6 +95,13 @@ final class TodoPlannerViewController: BaseViewController {
     viewModel.todolistModelByDate
       .drive(rx.todolistModel)
       .disposed(by: disposeBag)
+    
+    viewModel.successDeleteTodo
+      .emit(with: self) { owner, success in
+        Log.debug(success)
+        owner.viewModel.selectPlubbingID.onNext(owner.plubbingID)
+      }
+      .disposed(by: disposeBag)
   }
   
   override func setupStyles() {

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -205,9 +205,15 @@ extension TodoPlannerViewController: AddTodoViewDelegate {
     viewModel.whichTodoChecked.onNext((isChecked, todoID))
   }
   
-  func whichCreateTodoRequest(request: CreateTodoRequest) {
-    Log.debug("투두생성리퀘스트 \(request)")
-    viewModel.whichCreateTodoRequest.onNext(request)
+  func whichCreateTodoRequest(request: CreateTodoRequest, type: AddTodoType) {
+    Log.debug("투두생성리퀘스트 \(type)")
+    switch type {
+    case .create:
+      viewModel.whichCreateTodoRequest.onNext(request)
+    case .edit:
+      viewModel.whichEditRequest.onNext(EditTodolistRequest(content: request.content, date: request.date))
+      addTodoView.todoHandler?(.create)
+    }
   }
 }
 
@@ -218,8 +224,8 @@ extension TodoPlannerViewController: TodoPlannerBottomSheetDelegate {
   
   func editTodo(todoID: Int) {
     Log.debug("투두작성 \(todoID)")
-    addTodoView.todoHandler?(())
-//    viewModel.whichEditTodolist.onNext((todoID, ))
+    addTodoView.todoHandler?(.edit)
+    viewModel.whichTodoID.onNext(todoID)
   }
   
   func deleteTodo(todoID: Int) {

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -11,9 +11,24 @@ import FSCalendar
 import SnapKit
 import Then
 
+enum TodoPlannerType {
+  case addNewTodo
+  case manageMyPlanner
+  
+  var title: String {
+    switch self {
+    case .addNewTodo:
+      return "새 To-Do 추가하기"
+    case .manageMyPlanner:
+      return "내 Planner 관리하기"
+    }
+  }
+}
+
 final class TodoPlannerViewController: BaseViewController {
   
   private let viewModel: TodoPlannerViewModelType
+  private let type: TodoPlannerType
   
   private let plubbingID: Int
   
@@ -33,8 +48,8 @@ final class TodoPlannerViewController: BaseViewController {
     $0.layoutMargins = .init(top: .zero, left: 16, bottom: .zero, right: 16)
   }
   
-  private let textLabel = UILabel().then {
-    $0.text = "새 To-Do 추가하기"
+  private lazy var textLabel = UILabel().then {
+    $0.text = type.title
     $0.font = .h3
     $0.textColor = .black
   }
@@ -60,9 +75,10 @@ final class TodoPlannerViewController: BaseViewController {
     $0.delegate = self
   }
   
-  init(viewModel: TodoPlannerViewModelType = TodoPlannerViewModel(), plubbingID: Int) {
+  init(viewModel: TodoPlannerViewModelType = TodoPlannerViewModel(), plubbingID: Int, type: TodoPlannerType = .addNewTodo) {
     self.plubbingID = plubbingID
     self.viewModel = viewModel
+    self.type = type
     super.init(nibName: nil, bundle: nil)
     bind(plubbingID: plubbingID)
   }

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -234,6 +234,12 @@ extension TodoPlannerViewController: AddTodoViewDelegate {
 extension TodoPlannerViewController: TodoPlannerBottomSheetDelegate {
   func proofImage(todoID: Int) {
     Log.debug("투두인증 \(todoID)")
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+      guard let self = self else { return }
+      let alert = TodoAlertController()
+      alert.modalPresentationStyle = .overFullScreen
+      self.present(alert, animated: true)
+    }
   }
   
   func editTodo(todoID: Int, content: String) {

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -218,6 +218,8 @@ extension TodoPlannerViewController: TodoPlannerBottomSheetDelegate {
   
   func editTodo(todoID: Int) {
     Log.debug("투두작성 \(todoID)")
+    addTodoView.todoHandler?(())
+//    viewModel.whichEditTodolist.onNext((todoID, ))
   }
   
   func deleteTodo(todoID: Int) {

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -230,5 +230,6 @@ extension TodoPlannerViewController: TodoPlannerBottomSheetDelegate {
   
   func deleteTodo(todoID: Int) {
     Log.debug("투두삭제 \(todoID)")
+    viewModel.whichDeleteTodo.onNext(todoID)
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -76,6 +76,12 @@ final class TodoPlannerViewController: BaseViewController {
     $0.delegate = self
   }
   
+  private let tapGesture = UITapGestureRecognizer(target: TodoPlannerViewController.self, action: nil).then {
+    $0.numberOfTapsRequired = 1
+    $0.cancelsTouchesInView = false
+    $0.isEnabled = true
+  }
+  
   init(viewModel: TodoPlannerViewModelType = TodoPlannerViewModel(), plubbingID: Int, type: TodoPlannerType = .addNewTodo) {
     self.plubbingID = plubbingID
     self.viewModel = viewModel
@@ -94,6 +100,7 @@ final class TodoPlannerViewController: BaseViewController {
     viewModel.selectPlubbingID.onNext(plubbingID)
     
     viewModel.todolistModelByDate
+      .do(onNext: { _ in print("데이터나오는중") })
       .drive(rx.todolistModel)
       .disposed(by: disposeBag)
     
@@ -103,12 +110,21 @@ final class TodoPlannerViewController: BaseViewController {
         owner.viewModel.selectPlubbingID.onNext(owner.plubbingID)
       }
       .disposed(by: disposeBag)
+    
+    tapGesture.rx.event
+      .asDriver()
+      .drive(with: self) { owner, _ in
+        owner.view.endEditing(true)
+      }
+      .disposed(by: disposeBag)
   }
   
   override func setupStyles() {
     super.setupStyles()
     viewModel.whichInquireDate.onNext(Date())
     navigationItem.title = title
+    view.addGestureRecognizer(tapGesture)
+    view.isUserInteractionEnabled = true
   }
   
   override func setupLayouts() {

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -15,9 +15,14 @@ struct TodolistModel {
   var cellModel: TodoCollectionViewCellModel
 }
 
+protocol TodolistDelegate: AnyObject {
+  func didTappedTodoPlanner()
+}
+
 final class TodolistViewController: BaseViewController {
   
   private let viewModel: TodolistViewModelType
+  weak var delegate: TodolistDelegate?
   
   private let plubbingID: Int
   
@@ -186,6 +191,7 @@ extension TodolistViewController: TodoCollectionViewCellDelegate {
   func didTappedMoreButton(isAuthor: Bool) { /// 투두리스트 작성자에 따른 type 지정해줘야함
     ///
     let bottomSheet = isAuthor ? TodolistBottomSheetViewController(type: .todoPlanner) : TodolistBottomSheetViewController(type: .report)
+    bottomSheet.delegate = self
     present(bottomSheet, animated: true)
   }
 }
@@ -193,5 +199,15 @@ extension TodolistViewController: TodoCollectionViewCellDelegate {
 extension TodolistViewController: TodoAlertDelegate {
   func whichProofImage(image: UIImage) {
     viewModel.whichProofImage.onNext(image)
+  }
+}
+
+extension TodolistViewController: TodolistBottomSheetDelegate {
+  func didTappedTodoPlanner() {
+    delegate?.didTappedTodoPlanner()
+  }
+  
+  func didTappedReport() {
+    Log.debug("투두리스트 바텀시트 신고 클릭")
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/TodoPlannerViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/TodoPlannerViewModel.swift
@@ -62,13 +62,15 @@ final class TodoPlannerViewModel: TodoPlannerViewModelType {
   }
   
   private func tryEditTodolist() {
-    let editTodolist = Observable.combineLatest(
-      whichPlubbingID,
-      selectTodoID,
-      editRequest
-    ) { ($0, $1, $2) }
-      .flatMapLatest { result in
-        let (plubbingID, todoID, request) = result
+    let editTodolist = editRequest
+      .withLatestFrom(
+        Observable.combineLatest(
+          whichPlubbingID,
+          selectTodoID
+        ) { ($0, $1) }
+      ) { ($0, $1) }
+      .flatMapLatest { (request: EditTodolistRequest, result: (Int, Int)) in
+        let (plubbingID, todoID) = result
         return TodolistService.shared.editTodolist(
           plubbingID: plubbingID,
           todoID: todoID,


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 메인페이지 투두리스트 TO-DO 플래너 선택에 따라 투두플래너이동 
- 메인페이지 투두플래너 인증여부에 따라 UI Interaction 가능 여부 구현
- 메인페이지 투두플래너 인증여부에 따라 다른 바텀시트 구현
- 메인페이지 투두플래너 완료여부에 따라 다른 바텀시트 구현
- 메인페이지 투두플래너 바텀시트 투두 수정 기능 구현 
- 메인페이지 투두플래너 바텀시트 투두 수정 선택 시 input텍스트필드에 기존 content 넣어주기
- 메인페이지 투두플래너 바텀시트 투두 삭제 시 기능 구현 및 데이터 최신화 구현
- 메인페이지 투두플래너 바텀시트 투두 인증 시 모달창 띄어주기
- 메인페이지 투두플래너 기본 선택값 추가

🌱 PR 포인트
- 메인페이지 투두리스트 신고기능 미구현
- 메인페이지 투두플래너 투두인증에 따른 모달창 UI 데이터 전달 및 기능 미구현
- 동작영상 2번째에서 더 많은 투두를 생성하려할 경우 오류뜨는 것에 대한 부분은 아직 디자인상 없는거같아서 넣지않았는데 알게되면 수정하도록 할게요 !!

## 📸 동작영상
https://github.com/PLUB2022/PLUB-iOS/assets/39263235/2871d1ef-c774-4606-a076-1a944e16c032
https://github.com/PLUB2022/PLUB-iOS/assets/39263235/5afc6826-9f30-4c55-bded-dcb2ca38c410


## 📮 관련 이슈
- Resolved: #383 

