### PR TITLE
[FEAT] 메인페이지 페이징작업

### DIFF
--- a/PLUB.xcodeproj/project.pbxproj
+++ b/PLUB.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		705FD29D2A14E06900F353FE /* ProofTodoAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD29C2A14E06900F353FE /* ProofTodoAlertViewController.swift */; };
 		705FD2B52A1734CE00F353FE /* EditTodolistRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD2B42A1734CE00F353FE /* EditTodolistRequest.swift */; };
 		705FD2B72A17CA4700F353FE /* DeleteTodolistResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD2B62A17CA4700F353FE /* DeleteTodolistResponse.swift */; };
+		705FD2C12A1E51E800F353FE /* TodoGoalHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705FD2C02A1E51E800F353FE /* TodoGoalHeaderView.swift */; };
 		706315962A0BA93400DD8EFE /* TodoPlannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315952A0BA93400DD8EFE /* TodoPlannerViewModel.swift */; };
 		706315982A0BAA6000DD8EFE /* CreateTodoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */; };
 		7063159A2A0BAAE200DD8EFE /* CreateTodoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */; };
@@ -483,6 +484,7 @@
 		705FD29C2A14E06900F353FE /* ProofTodoAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProofTodoAlertViewController.swift; sourceTree = "<group>"; };
 		705FD2B42A1734CE00F353FE /* EditTodolistRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTodolistRequest.swift; sourceTree = "<group>"; };
 		705FD2B62A17CA4700F353FE /* DeleteTodolistResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteTodolistResponse.swift; sourceTree = "<group>"; };
+		705FD2C02A1E51E800F353FE /* TodoGoalHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoGoalHeaderView.swift; sourceTree = "<group>"; };
 		706315952A0BA93400DD8EFE /* TodoPlannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPlannerViewModel.swift; sourceTree = "<group>"; };
 		706315972A0BAA6000DD8EFE /* CreateTodoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoRequest.swift; sourceTree = "<group>"; };
 		706315992A0BAAE200DD8EFE /* CreateTodoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTodoResponse.swift; sourceTree = "<group>"; };
@@ -1085,6 +1087,7 @@
 				70727A1E29BF7FC6003DE956 /* BoardSystemCollectionViewCell.swift */,
 				70727A3229D2C635003DE956 /* TodoCollectionViewCell.swift */,
 				70C9CC922A01CE8B00BEB5F2 /* TodoCollectionHeaderView.swift */,
+				705FD2C02A1E51E800F353FE /* TodoGoalHeaderView.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -2627,6 +2630,7 @@
 				C3B3435D29BE4A3000935B73 /* MyPlubbingParameter.swift in Sources */,
 				C374E79729FC2F4D004738C2 /* MyTodoResponse.swift in Sources */,
 				BA72BCF029BB03FF007165E5 /* BaseNavigationController.swift in Sources */,
+				705FD2C12A1E51E800F353FE /* TodoGoalHeaderView.swift in Sources */,
 				70197B722953698F000503F6 /* SelectedCategoryViewController.swift in Sources */,
 				70727A2529C4C21A003DE956 /* CreateBoardViewModel.swift in Sources */,
 				BA5EC6CD29F167D7000A68B7 /* BoardDetailViewModelFactory.swift in Sources */,

--- a/PLUB/Sources/Models/Auth/Request/SignUpRequest.swift
+++ b/PLUB/Sources/Models/Auth/Request/SignUpRequest.swift
@@ -52,7 +52,7 @@ struct SignUpRequest: Codable {
   var marketing: Bool
 
   init() {
-    fcmToken = UserManager.shared.fcmToken!
+    fcmToken = UserManager.shared.fcmToken ?? ""
     signToken = UserManager.shared.signToken!
     categoryList = []
     birthday = ""

--- a/PLUB/Sources/Views/Home/Clipboard/Cell/BoardCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/Clipboard/Cell/BoardCollectionViewCell.swift
@@ -114,6 +114,17 @@ final class BoardCollectionViewCell: UICollectionViewCell {
     fatalError("init(coder:) has not been implemented")
   }
   
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    profileImageView.image = nil
+    authorLabel.text = nil
+    dateLabel.text = nil
+    heartCountLabel.text = nil
+    commentCountLabel.text = nil
+    titleLabel.text = nil
+    contentLabel.text = nil
+  }
+  
   // MARK: - Configuration
   
   private func setupLayouts() {

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -85,7 +85,6 @@ final class BoardViewController: BaseViewController {
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     viewModel.clearStatus()
-    viewModel.selectPlubbingID.onNext(plubbingID)
   }
   
   override func setupStyles() {

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -84,6 +84,7 @@ final class BoardViewController: BaseViewController {
   
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
+    viewModel.clearStatus()
     viewModel.selectPlubbingID.onNext(plubbingID)
   }
   

--- a/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/BoardViewController.swift
@@ -134,6 +134,17 @@ final class BoardViewController: BaseViewController {
         Log.debug("해당 게시글 삭제 성공")
       })
       .disposed(by: disposeBag)
+    
+    collectionView.rx.didScroll
+      .subscribe(with: self, onNext: { owner, _ in
+        let offSetY = owner.collectionView.contentOffset.y
+        let contentHeight = owner.collectionView.contentSize.height
+        
+        if offSetY > (contentHeight - owner.collectionView.frame.size.height) {
+          owner.viewModel.fetchMoreDatas.onNext(())
+        }
+      })
+      .disposed(by: disposeBag)
   }
   
   @objc func handleLongPress(gestureRecognizer: UILongPressGestureRecognizer) {
@@ -154,12 +165,6 @@ final class BoardViewController: BaseViewController {
     }
   }
   
-}
-
-extension BoardViewController: UIScrollViewDelegate {
-  func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    
-  }
 }
 
 extension BoardViewController: UICollectionViewDelegate, UICollectionViewDataSource {

--- a/PLUB/Sources/Views/Home/MainPage/Cell/TodoGoalHeaderView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/TodoGoalHeaderView.swift
@@ -1,0 +1,55 @@
+//
+//  TodoGoalHeaderView.swift
+//  PLUB
+//
+//  Created by 이건준 on 2023/05/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class TodoGoalHeaderView: UICollectionReusableView {
+  
+  static let identifier = "TodoGoalHeaderView"
+  
+  private let titleLabel = UILabel().then {
+    $0.font = .appFont(family: .nanum, size: 32)
+    $0.textAlignment = .center
+    $0.numberOfLines = 0
+  }
+  
+  private let goalBackgroundView = UIView().then {
+    $0.backgroundColor = .subMain
+  }
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    configureUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func configureUI() {
+    [goalBackgroundView, titleLabel].forEach { addSubview($0) }
+    
+    goalBackgroundView.snp.makeConstraints {
+      $0.top.equalToSuperview().inset(40)
+      $0.centerX.equalToSuperview()
+      $0.width.equalTo(187)
+      $0.height.equalTo(19)
+    }
+    
+    titleLabel.snp.makeConstraints {
+      $0.top.equalToSuperview().inset(24)
+      $0.directionalHorizontalEdges.equalToSuperview()
+    }
+  }
+  
+  func configureUI(with model: String) {
+    titleLabel.text = model
+  }
+}

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -70,12 +70,11 @@ final class TodolistViewController: BaseViewController {
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     viewModel.clearStatus()
-    viewModel.selectPlubbingID.onNext(plubbingID)
   }
   
   override func setupLayouts() {
     super.setupLayouts()
-    [todoCollectionView].forEach { view.addSubview($0) }
+    view.addSubview(todoCollectionView)
   }
   
   override func setupConstraints() {

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -26,6 +26,7 @@ final class TodolistViewController: BaseViewController {
   weak var delegate: TodolistDelegate?
   
   private let plubbingID: Int
+  private let goal: String
   
   private var model: [TodolistModel] = [] {
     didSet {
@@ -39,38 +40,17 @@ final class TodolistViewController: BaseViewController {
     }
   }
   
-  private let scrollView = UIScrollView().then {
-    $0.showsVerticalScrollIndicator = true
-    $0.showsHorizontalScrollIndicator = false
-    $0.isScrollEnabled = true
-    $0.alwaysBounceVertical = true
-  }
-  
-  private let scrollContainerView = UIView().then {
-    $0.backgroundColor = .clear
-  }
-  
-  private let titleLabel = UILabel().then {
-    $0.font = .appFont(family: .nanum, size: 32)
-    $0.textAlignment = .center
-    $0.numberOfLines = 0
-    $0.sizeToFit()
-  }
-  
-  private let goalBackgroundView = UIView().then {
-    $0.backgroundColor = .subMain
-  }
-  
   private lazy var todoCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout().then {
     $0.minimumLineSpacing = 8
+    $0.scrollDirection = .vertical
   }).then {
     $0.backgroundColor = .background
     $0.register(TodoCollectionViewCell.self, forCellWithReuseIdentifier: TodoCollectionViewCell.identifier)
     $0.register(TodoCollectionHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: TodoCollectionHeaderView.identifier)
+    $0.register(TodoGoalHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: TodoGoalHeaderView.identifier)
     $0.delegate = self
     $0.dataSource = self
     $0.contentInset = UIEdgeInsets(top: .zero, left: 16, bottom: .zero, right: 16)
-    $0.isScrollEnabled = false
     $0.showsVerticalScrollIndicator = false
     $0.showsHorizontalScrollIndicator = false
   }
@@ -78,7 +58,7 @@ final class TodolistViewController: BaseViewController {
   init(plubbingID: Int, goal: String, viewModel: TodolistViewModelType = TodolistViewModel()) {
     self.viewModel = viewModel
     self.plubbingID = plubbingID
-    titleLabel.text = goal
+    self.goal = goal
     super.init(nibName: nil, bundle: nil)
     bind(plubbingID: plubbingID)
   }
@@ -95,38 +75,14 @@ final class TodolistViewController: BaseViewController {
   
   override func setupLayouts() {
     super.setupLayouts()
-    view.addSubview(scrollView)
-    scrollView.addSubview(scrollContainerView)
-    [goalBackgroundView, titleLabel, todoCollectionView].forEach { scrollContainerView.addSubview($0) }
+    [todoCollectionView].forEach { view.addSubview($0) }
   }
   
   override func setupConstraints() {
     super.setupConstraints()
     
-    scrollView.snp.makeConstraints {
-      $0.directionalEdges.equalToSuperview()
-    }
-    
-    scrollContainerView.snp.makeConstraints {
-      $0.directionalEdges.width.equalToSuperview()
-    }
-    
-    goalBackgroundView.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(40)
-      $0.centerX.equalToSuperview()
-      $0.width.equalTo(187)
-      $0.height.equalTo(19)
-    }
-    
-    titleLabel.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(24)
-      $0.directionalHorizontalEdges.equalToSuperview()
-    }
-    
     todoCollectionView.snp.makeConstraints {
-      $0.top.equalTo(goalBackgroundView.snp.bottom).offset(26)
-      $0.directionalHorizontalEdges.bottom.equalToSuperview()
-      $0.height.equalTo(UIScreen.main.bounds.height - Device.navigationBarHeight - 32 - 24 - 21 - 40)
+      $0.directionalEdges.equalToSuperview()
     }
   }
   
@@ -168,27 +124,41 @@ final class TodolistViewController: BaseViewController {
 
 extension TodolistViewController: UICollectionViewDelegate, UICollectionViewDataSource {
   func numberOfSections(in collectionView: UICollectionView) -> Int {
-    return model.count
+    return model.count + 1
   }
   
   func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    if section == 0 {
+      return 0
+    }
     return 1
   }
   
   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    if indexPath.section == 0 {
+      return UICollectionViewCell()
+    }
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TodoCollectionViewCell.identifier, for: indexPath) as? TodoCollectionViewCell ?? TodoCollectionViewCell()
-    cell.configureUI(with: model[indexPath.section].cellModel)
+    cell.configureUI(with: model[indexPath.section - 1].cellModel)
     cell.delegate = self
     return cell
   }
   
   func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+    if indexPath.section == 0 {
+      let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: TodoGoalHeaderView.identifier, for: indexPath) as? TodoGoalHeaderView ?? TodoGoalHeaderView()
+      header.configureUI(with: goal)
+      return header
+    }
     let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: TodoCollectionHeaderView.identifier, for: indexPath) as? TodoCollectionHeaderView ?? TodoCollectionHeaderView()
-    header.configureUI(with: model[indexPath.section].headerModel)
+    header.configureUI(with: model[indexPath.section - 1].headerModel)
     return header
   }
   
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+    if section == 0 {
+      return CGSize(width: collectionView.frame.width, height: 85)
+    }
     let width: CGFloat = collectionView.frame.width
     let height: CGFloat = 8 + 21 + 8
     return CGSize(width: width, height: height)
@@ -197,12 +167,15 @@ extension TodolistViewController: UICollectionViewDelegate, UICollectionViewData
 
 extension TodolistViewController: UICollectionViewDelegateFlowLayout {
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    if indexPath.section == 0 {
+      return .zero
+    }
     return TodoCollectionViewCell.estimatedCommentCellSize(
       CGSize(
         width: view.bounds.width - 32,
         height: UIView.layoutFittingCompressedSize.height
       ),
-      model: model[indexPath.section].cellModel
+      model: model[indexPath.section - 1].cellModel
     )
   }
 }

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -39,6 +39,17 @@ final class TodolistViewController: BaseViewController {
     }
   }
   
+  private let scrollView = UIScrollView().then {
+    $0.showsVerticalScrollIndicator = true
+    $0.showsHorizontalScrollIndicator = false
+    $0.isScrollEnabled = true
+    $0.alwaysBounceVertical = true
+  }
+  
+  private let scrollContainerView = UIView().then {
+    $0.backgroundColor = .clear
+  }
+  
   private let titleLabel = UILabel().then {
     $0.font = .appFont(family: .nanum, size: 32)
     $0.textAlignment = .center
@@ -59,6 +70,9 @@ final class TodolistViewController: BaseViewController {
     $0.delegate = self
     $0.dataSource = self
     $0.contentInset = UIEdgeInsets(top: .zero, left: 16, bottom: .zero, right: 16)
+    $0.isScrollEnabled = false
+    $0.showsVerticalScrollIndicator = false
+    $0.showsHorizontalScrollIndicator = false
   }
   
   init(plubbingID: Int, goal: String, viewModel: TodolistViewModelType = TodolistViewModel()) {
@@ -81,27 +95,38 @@ final class TodolistViewController: BaseViewController {
   
   override func setupLayouts() {
     super.setupLayouts()
-    [goalBackgroundView, titleLabel, todoCollectionView].forEach { view.addSubview($0) }
+    view.addSubview(scrollView)
+    scrollView.addSubview(scrollContainerView)
+    [goalBackgroundView, titleLabel, todoCollectionView].forEach { scrollContainerView.addSubview($0) }
   }
   
   override func setupConstraints() {
     super.setupConstraints()
     
+    scrollView.snp.makeConstraints {
+      $0.directionalEdges.equalToSuperview()
+    }
+    
+    scrollContainerView.snp.makeConstraints {
+      $0.directionalEdges.width.equalToSuperview()
+    }
+    
     goalBackgroundView.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(32)
+      $0.top.equalToSuperview().inset(40)
       $0.centerX.equalToSuperview()
       $0.width.equalTo(187)
       $0.height.equalTo(19)
     }
     
     titleLabel.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(16)
+      $0.top.equalToSuperview().inset(24)
       $0.directionalHorizontalEdges.equalToSuperview()
     }
     
     todoCollectionView.snp.makeConstraints {
-      $0.top.equalTo(titleLabel.snp.bottom)
+      $0.top.equalTo(goalBackgroundView.snp.bottom).offset(26)
       $0.directionalHorizontalEdges.bottom.equalToSuperview()
+      $0.height.equalTo(UIScreen.main.bounds.height - Device.navigationBarHeight - 32 - 24 - 21 - 40)
     }
   }
   

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -75,6 +75,7 @@ final class TodolistViewController: BaseViewController {
   
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
+    viewModel.clearStatus()
     viewModel.selectPlubbingID.onNext(plubbingID)
   }
   

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import RxSwift
 import SnapKit
 import Then
 
@@ -122,6 +123,17 @@ final class TodolistViewController: BaseViewController {
         let alert = ProofTodoAlertViewController()
         alert.modalPresentationStyle = .overFullScreen
         owner.present(alert, animated: false)
+      }
+      .disposed(by: disposeBag)
+    
+    todoCollectionView.rx.didScroll
+      .subscribe(with: self) { owner, _ in
+        let offSetY = owner.todoCollectionView.contentOffset.y
+        let contentHeight = owner.todoCollectionView.contentSize.height
+        
+        if offSetY > (contentHeight - owner.todoCollectionView.frame.size.height) {
+          owner.viewModel.fetchMoreDatas.onNext(())
+        }
       }
       .disposed(by: disposeBag)
   

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
@@ -149,10 +149,3 @@ final class BoardViewModel: BoardViewModelType {
   }
   
 }
-
-struct MockModel {
-  let type: PostType
-  let viewType: ViewType
-  let content: String
-  let feedImageURL: String?
-}

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
@@ -78,15 +78,14 @@ final class BoardViewModel {
     
     fetchingBoards
       .subscribe(with: self) { owner, boards in
-        owner.isLastPage.onNext(boards.isLast)
-        guard !boards.isLast,
-              let feedID = boards.content.last?.feedID else { return }
+        guard let feedID = boards.content.last?.feedID else { return }
         var entireModel = owner.fetchingBoardModel.value
         let boardModels = boards.content.map { $0.toBoardModel }
         entireModel.append(contentsOf: boardModels)
         owner.fetchingBoardModel.accept(entireModel)
         owner.isLoading.onNext(false)
         owner.lastID.onNext(feedID)
+        owner.isLastPage.onNext(boards.isLast)
       }
       .disposed(by: disposeBag)
   }

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
@@ -66,9 +66,9 @@ final class BoardViewModel {
     ) { ($0, $1) }
       .withUnretained(self)
       .filter { owner, _ in try !owner.isLastPage.value() && !owner.isLoading.value() }
-      .do(onNext: { owner, _ in owner.isLoading.onNext(true) })
       .flatMapLatest { owner, result in
         let (plubbingID, cursorID) = result
+        owner.isLoading.onNext(true)
         return FeedsService.shared.fetchBoards(
           plubbingID: plubbingID,
           nextCursorID: cursorID
@@ -76,7 +76,6 @@ final class BoardViewModel {
       }
     
     fetchingBoards.subscribe(with: self) { owner, boards in
-      print("게시판 \(boards)")
       let boardModels = boards.content.map { $0.toBoardModel }
       owner.fetchingBoardModel.accept(boardModels)
       owner.isLoading.onNext(false)
@@ -107,7 +106,7 @@ final class BoardViewModel {
   private func tryFetchingMoreDatas() {
     fetchingMoreDatas.withLatestFrom(currentCursorID)
       .withUnretained(self)
-      .filter({ owner, page in
+      .filter({ owner, _ in
         try owner.isLastPage.value() || owner.isLoading.value() ? false : true
       })
       .map { $1 + 1 }

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/BoardViewModel.swift
@@ -26,75 +26,72 @@ protocol BoardViewModelType {
   var isPinnedFeed: Driver<Int> { get }
   var successDeleteFeed: Driver<Void> { get }
   
+  func clearStatus()
+  
 }
 
-final class BoardViewModel: BoardViewModelType {
+final class BoardViewModel {
   
   private let disposeBag = DisposeBag()
   
-  // Input
-  let selectPlubbingID: AnyObserver<Int>
-  let selectFeedID: AnyObserver<Int>
-  let selectFix: AnyObserver<Void>
-  //  let selectModify: AnyObserver<Void>
-  //  let selectReport: AnyObserver<Void>
-  let selectDelete: AnyObserver<Void>
-  let fetchMoreDatas: AnyObserver<Void>
+  private let selectingPlubbingID = PublishSubject<Int>()
+  private let selectingFeedID = PublishSubject<Int>()
+  private let selectingFix = PublishSubject<Void>()
+  private let selectingDelete = PublishSubject<Void>()
+  private let fetchingMainpageClipboardViewModel = BehaviorRelay<[MainPageClipboardViewModel]>(value: [])
+  private let fetchingBoardModel = BehaviorRelay<[BoardModel]>(value: [])
+  private let fetchingMoreDatas = PublishSubject<Void>()
+  private let currentCursorID = BehaviorRelay<Int>(value: 0)
+  private let isLastPage = BehaviorSubject<Bool>(value: false)
+  private let isLoading = BehaviorSubject<Bool>(value: false)
   
-  // Output
-  let fetchedMainpageClipboardViewModel: Driver<[MainPageClipboardViewModel]>
-  let fetchedBoardModel: Driver<[BoardModel]>
-  let clipboardListIsEmpty: Driver<Bool>
-  let isPinnedFeed: Driver<Int>
-  let successDeleteFeed: Driver<Void>
   
   init() {
-    let selectingPlubbingID = PublishSubject<Int>()
-    let selectingFeedID = PublishSubject<Int>()
-    let selectingFix = PublishSubject<Void>()
-    let selectingDelete = PublishSubject<Void>()
-    let fetchingMainpageClipboardViewModel = BehaviorRelay<[MainPageClipboardViewModel]>(value: [])
-    let fetchingBoardModel = BehaviorRelay<[BoardModel]>(value: [])
-    let fetchingMoreDatas = PublishSubject<Void>()
-    let currentCursorID = BehaviorRelay<Int>(value: 0)
-    let isLastPage = BehaviorSubject<Bool>(value: false)
-    let isLoading = BehaviorSubject<Bool>(value: false)
-    
-    self.selectFeedID = selectingFeedID.asObserver()
-    self.selectPlubbingID = selectingPlubbingID.asObserver()
-    self.selectFix = selectingFix.asObserver()
-    self.selectDelete = selectingDelete.asObserver()
-    self.fetchMoreDatas = fetchingMoreDatas.asObserver()
-    
-    // Input
+    tryFetchingBoards()
+    tryFetchingClipboards()
+    tryFetchingMoreDatas()
+  }
+  
+  func clearStatus() {
+    isLastPage.onNext(false)
+    isLoading.onNext(false)
+    currentCursorID.accept(0)
+  }
+  
+  private func tryFetchingBoards() {
     let fetchingBoards =
     Observable.combineLatest(
       selectingPlubbingID,
       currentCursorID
-    )
-    .filter { _ in try !isLastPage.value() && !isLoading.value() }
-    .flatMapLatest { plubbingID, cursorID in
-        isLoading.onNext(true)
+    ) { ($0, $1) }
+      .withUnretained(self)
+      .filter { owner, _ in try !owner.isLastPage.value() && !owner.isLoading.value() }
+      .do(onNext: { owner, _ in owner.isLoading.onNext(true) })
+      .flatMapLatest { owner, result in
+        let (plubbingID, cursorID) = result
         return FeedsService.shared.fetchBoards(
           plubbingID: plubbingID,
           nextCursorID: cursorID
         )
-    }
+      }
     
-    fetchingBoards.subscribe(onNext: { boards in
+    fetchingBoards.subscribe(with: self) { owner, boards in
+      print("게시판 \(boards)")
       let boardModels = boards.content.map { $0.toBoardModel }
-      fetchingBoardModel.accept(boardModels)
-      isLoading.onNext(false)
-      isLastPage.onNext(boards.isLast)
-    })
+      owner.fetchingBoardModel.accept(boardModels)
+      owner.isLoading.onNext(false)
+      owner.isLastPage.onNext(boards.isLast)
+    }
     .disposed(by: disposeBag)
-    
+  }
+  
+  private func tryFetchingClipboards() {
     let fetchingClipboards = selectingPlubbingID
       .flatMapLatest { plubbingID in
         return FeedsService.shared.fetchClipboards(plubbingID: plubbingID)
       }
     
-    fetchingClipboards.subscribe(onNext: { contents in
+    fetchingClipboards.subscribe(with: self) { owner, contents in
       let mainPageClipboardViewModel = contents.pinnedFeedList.map {
         return MainPageClipboardViewModel(
           type: $0.type,
@@ -102,50 +99,85 @@ final class BoardViewModel: BoardViewModelType {
           contentText: $0.content
         )
       }
-      fetchingMainpageClipboardViewModel.accept(mainPageClipboardViewModel)
-    })
+      owner.fetchingMainpageClipboardViewModel.accept(mainPageClipboardViewModel)
+    }
     .disposed(by: disposeBag)
-    
-    let requestPinFeed = selectingFix.withLatestFrom(
-      Observable.zip(
-        selectingPlubbingID,
-        selectingFeedID
-      )
-    )
-      .flatMapLatest(FeedsService.shared.pinFeed)
-    
-    let requestDeleteFeed = selectingDelete.withLatestFrom(
-      Observable.zip(
-        selectingPlubbingID,
-        selectingFeedID
-      )
-    )
-      .flatMapLatest(FeedsService.shared.deleteFeed)
-      .map { _ in Void() }
-    
-    fetchingMoreDatas.withLatestFrom(currentCursorID)
-      .filter({ page in
-        try isLastPage.value() || isLoading.value() ? false : true
-      })
-      .map { $0 + 1 }
-      .bind(to: currentCursorID)
-      .disposed(by: disposeBag)
-    
-    // Output
-    fetchedMainpageClipboardViewModel = fetchingMainpageClipboardViewModel.asDriver(onErrorDriveWith: .empty())
-    
-    clipboardListIsEmpty = fetchingMainpageClipboardViewModel
-      .map { $0.isEmpty }
-      .asDriver(onErrorDriveWith: .empty())
-    
-    fetchedBoardModel = fetchingBoardModel
-      .asDriver(onErrorDriveWith: .empty())
-    
-    isPinnedFeed = requestPinFeed
-      .map { $0.feedID }
-      .asDriver(onErrorDriveWith: .empty())
-    
-    successDeleteFeed = requestDeleteFeed.asDriver(onErrorDriveWith: .empty())
   }
   
+  private func tryFetchingMoreDatas() {
+    fetchingMoreDatas.withLatestFrom(currentCursorID)
+      .withUnretained(self)
+      .filter({ owner, page in
+        try owner.isLastPage.value() || owner.isLoading.value() ? false : true
+      })
+      .map { $1 + 1 }
+      .bind(to: currentCursorID)
+      .disposed(by: disposeBag)
+  }
+}
+
+extension BoardViewModel: BoardViewModelType {
+  
+  // Input
+  var selectPlubbingID: AnyObserver<Int> {
+    selectingPlubbingID.asObserver()
+  }
+  
+  var selectFeedID: AnyObserver<Int> {
+    selectingFeedID.asObserver()
+  }
+  
+  var selectFix: AnyObserver<Void> {
+    selectingFix.asObserver()
+  }
+  
+  //  let selectModify: AnyObserver<Void>
+  //  let selectReport: AnyObserver<Void>
+  var selectDelete: AnyObserver<Void> {
+    selectingDelete.asObserver()
+  }
+  
+  var fetchMoreDatas: AnyObserver<Void> {
+    fetchingMoreDatas.asObserver()
+  }
+  
+  // Output
+  var fetchedMainpageClipboardViewModel: Driver<[MainPageClipboardViewModel]> {
+    fetchingMainpageClipboardViewModel.asDriver(onErrorDriveWith: .empty())
+  }
+  
+  var fetchedBoardModel: Driver<[BoardModel]> {
+    fetchingBoardModel
+      .asDriver(onErrorDriveWith: .empty())
+  }
+  
+  var clipboardListIsEmpty: Driver<Bool> {
+    fetchingMainpageClipboardViewModel
+      .map { $0.isEmpty }
+      .asDriver(onErrorDriveWith: .empty())
+  }
+  
+  var isPinnedFeed: Driver<Int> {
+    selectingFix.withLatestFrom(
+      Observable.zip(
+        selectingPlubbingID,
+        selectingFeedID
+      )
+    )
+    .flatMapLatest(FeedsService.shared.pinFeed)
+    .map { $0.feedID }
+    .asDriver(onErrorDriveWith: .empty())
+  }
+  
+  var successDeleteFeed: Driver<Void> {
+    selectingDelete.withLatestFrom(
+      Observable.zip(
+        selectingPlubbingID,
+        selectingFeedID
+      )
+    )
+    .flatMapLatest(FeedsService.shared.deleteFeed)
+    .map { _ in Void() }
+    .asDriver(onErrorDriveWith: .empty())
+  }
 }

--- a/PLUB/Sources/Views/Home/MainPage/ViewModel/TodolistViewModel.swift
+++ b/PLUB/Sources/Views/Home/MainPage/ViewModel/TodolistViewModel.swift
@@ -61,9 +61,9 @@ final class TodolistViewModel {
   
   private func tryFetchMoreDatas() {
     fetchingMoreDatas
-      .withLatestFrom(currentCursorID) { $1 }
+      .withLatestFrom(currentCursorID)
       .withUnretained(self)
-      .filter({ owner, cursorID in
+      .filter({ owner, _ in
         try owner.isLastPage.value() || owner.isLoading.value() ? false : true
       })
       .map { $1 + 1 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 메인페이지 게시글 및 투두리스트 커서페이징 작업
- 게시글 및 투두리스트 생성에 따른 데이터 최신화

🌱 PR 포인트
- 기존에 커서페이징에 대해 잘못 알게된 개념이 있어서 홈, 검색 등등 커서페이징이 적용되는 모든 부분을 다시 전면 수정하여 올릴 예정입니다.
- 게시글의 갯수가 많아짐에 따라서 셀의 재사용 문제로 승현님께서 만든 BoardCollectionViewCell에 prepareForReuse함수를 구현하였는데 혹여 기존 동작에 문제가 생기면 말씀해주세요
- @WhiteHyun  그리고 profileImage가 nil로 내려올때 게시글의 프로필이미지 디폴트이미지로 변경시키는 코드도 추가시켜줘야할꺼같아요

## 📸 동작영상
https://github.com/PLUB2022/PLUB-iOS/assets/39263235/5250682a-fd1c-4538-895c-6442500035d1

## 📮 관련 이슈
- Res#341 d: #341 

