### PR TITLE
[CHORE] 투두플래너 타입에 따른 서로 다른 UI 구성

### DIFF
--- a/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Cell/TodoCollectionViewCell.swift
@@ -13,7 +13,7 @@ import SnapKit
 import Then
 
 protocol TodoCollectionViewCellDelegate: AnyObject {
-  func didTappedMoreButton(isAuthor: Bool)
+  func didTappedMoreButton(isAuthor: Bool, date: String)
   func didTappedLikeButton(timelineID: Int)
   func didTappedTodo(todoID: Int, isCompleted: Bool, model: TodoAlertModel)
 }
@@ -141,8 +141,10 @@ final class TodoCollectionViewCell: UICollectionViewCell {
   private func bind() {
     moreButton.rx.tap
       .subscribe(with: self) { owner, _ in
-        guard let isAuthor = owner.model?.isAuthor else { return }
-        owner.delegate?.didTappedMoreButton(isAuthor: isAuthor)
+        guard let model = owner.model else {
+          return
+        }
+        owner.delegate?.didTappedMoreButton(isAuthor: model.isAuthor, date: model.date)
       }
       .disposed(by: disposeBag)
     

--- a/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/AddTodoView.swift
@@ -81,6 +81,8 @@ final class AddTodoView: UIView {
       let isToday = Calendar.current.isDateInToday(date)
       self?.dateLabel.text = isToday ? "\(dateString) (오늘)" : dateString
       self?.dateLabel.textColor = isToday ? .main : .black
+      self?.layer.borderColor = isToday ? UIColor.main.cgColor : UIColor.lightGray.cgColor
+      self?.backgroundColor = isToday ? .subMain : .white
     }
   }
   
@@ -99,8 +101,7 @@ final class AddTodoView: UIView {
     todoContainerView.addArrangedSubview(dateLabel)
     todoContainerView.addArrangedSubview(inputTodoView)
     
-    let today = DateFormatterFactory.todolistDate.string(from: Date())
-    dateLabel.text = "\(today) (오늘)"
+
   }
   
   func configureUI(with model: AddTodoViewModel) {

--- a/PLUB/Sources/Views/Home/MainPage/Component/TodolistBottomSheetViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/Component/TodolistBottomSheetViewController.swift
@@ -11,7 +11,7 @@ import SnapKit
 import Then
 
 enum TodolistBottomSheetType {
-  case todoPlanner // 투두리스트 작성자일때
+  case todoPlanner(Date) // 투두리스트 작성자일때
   case report // 투두리스트 작성자아닐때
   
   var text: String {
@@ -34,7 +34,7 @@ enum TodolistBottomSheetType {
 }
 
 protocol TodolistBottomSheetDelegate: AnyObject {
-  func didTappedTodoPlanner()
+  func didTappedTodoPlanner(date: Date)
   func didTappedReport()
 }
 
@@ -61,8 +61,8 @@ final class TodolistBottomSheetViewController: BottomSheetViewController {
     bottomSheetView.button.rx.tap
       .subscribe(with: self) { owner, _ in
         switch owner.type {
-        case .todoPlanner:
-          owner.delegate?.didTappedTodoPlanner()
+        case .todoPlanner(let date):
+          owner.delegate?.didTappedTodoPlanner(date: date)
         case .report:
           owner.delegate?.didTappedReport()
         }

--- a/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/MainPageViewController.swift
@@ -249,8 +249,8 @@ extension MainPageViewController: MainPageNavigationViewDelegate {
 }
 
 extension MainPageViewController: TodolistDelegate {
-  func didTappedTodoPlanner() {
-    let vc = TodoPlannerViewController(plubbingID: plubbingID, type: .manageMyPlanner)
+  func didTappedTodoPlanner(date: Date) {
+    let vc = TodoPlannerViewController(plubbingID: plubbingID, type: .manageMyPlanner(date))
     vc.navigationItem.largeTitleDisplayMode = .never
     vc.title = title
     self.navigationController?.pushViewController(vc, animated: true)

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -119,16 +119,18 @@ final class TodoPlannerViewController: BaseViewController {
   
   override func setupStyles() {
     super.setupStyles()
+    let date: Date
+    
     switch type {
     case .addNewTodo:
-      viewModel.whichInquireDate.onNext(Date())
-      calendarView.select(Date())
-      addTodoView.completionHandler?(Date())
-    case .manageMyPlanner(let date):
-      viewModel.whichInquireDate.onNext(date)
-      calendarView.select(date)
-      addTodoView.completionHandler?(date)
+      date = Date()
+    case .manageMyPlanner(let selectedDate):
+      date = selectedDate
     }
+    
+    viewModel.whichInquireDate.onNext(date)
+    calendarView.select(date)
+    addTodoView.completionHandler?(date)
     navigationItem.title = title
     view.addGestureRecognizer(tapGesture)
   }

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -13,7 +13,7 @@ import Then
 
 enum TodoPlannerType {
   case addNewTodo
-  case manageMyPlanner
+  case manageMyPlanner(Date)
   
   var title: String {
     switch self {
@@ -64,7 +64,6 @@ final class TodoPlannerViewController: BaseViewController {
     $0.appearance.todayColor = .white
     $0.appearance.weekdayTextColor = .gray
     $0.appearance.titleWeekendColor = .red
-    $0.select(Date())
   }
   
   private lazy var addTodoView = AddTodoView().then {
@@ -172,13 +171,6 @@ extension TodoPlannerViewController: FSCalendarDelegate, FSCalendarDataSource, F
   func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
     addTodoView.completionHandler?(date)
     viewModel.whichInquireDate.onNext(date)
-    if Calendar.current.isDateInToday(date) {
-      addTodoView.layer.borderColor = UIColor.main.cgColor
-      addTodoView.backgroundColor = .subMain
-    } else {
-      addTodoView.layer.borderColor = UIColor.lightGray.cgColor
-      addTodoView.backgroundColor = .white
-    }
   }
   func calendar(_ calendar: FSCalendar, subtitleFor date: Date) -> String? {
     if Calendar.current.isDateInToday(date) {

--- a/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodoPlannerViewController.swift
@@ -119,7 +119,16 @@ final class TodoPlannerViewController: BaseViewController {
   
   override func setupStyles() {
     super.setupStyles()
-    viewModel.whichInquireDate.onNext(Date())
+    switch type {
+    case .addNewTodo:
+      viewModel.whichInquireDate.onNext(Date())
+      calendarView.select(Date())
+      addTodoView.completionHandler?(Date())
+    case .manageMyPlanner(let date):
+      viewModel.whichInquireDate.onNext(date)
+      calendarView.select(date)
+      addTodoView.completionHandler?(date)
+    }
     navigationItem.title = title
     view.addGestureRecognizer(tapGesture)
   }

--- a/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
+++ b/PLUB/Sources/Views/Home/MainPage/TodolistViewController.swift
@@ -17,7 +17,7 @@ struct TodolistModel {
 }
 
 protocol TodolistDelegate: AnyObject {
-  func didTappedTodoPlanner()
+  func didTappedTodoPlanner(date: Date)
 }
 
 final class TodolistViewController: BaseViewController {
@@ -197,9 +197,12 @@ extension TodolistViewController: TodoCollectionViewCellDelegate {
     viewModel.selectLikeButton.onNext(timelineID)
   }
   
-  func didTappedMoreButton(isAuthor: Bool) { /// 투두리스트 작성자에 따른 type 지정해줘야함
-    ///
-    let bottomSheet = isAuthor ? TodolistBottomSheetViewController(type: .todoPlanner) : TodolistBottomSheetViewController(type: .report)
+  func didTappedMoreButton(isAuthor: Bool, date: String) { /// 투두리스트 작성자에 따른 type 지정해줘야함
+    guard let date = DateFormatterFactory.dateWithHypen.date(from: date) else {
+      return
+    }
+    
+    let bottomSheet = isAuthor ? TodolistBottomSheetViewController(type: .todoPlanner(date)) : TodolistBottomSheetViewController(type: .report)
     bottomSheet.delegate = self
     present(bottomSheet, animated: true)
   }
@@ -212,8 +215,8 @@ extension TodolistViewController: TodoAlertDelegate {
 }
 
 extension TodolistViewController: TodolistBottomSheetDelegate {
-  func didTappedTodoPlanner() {
-    delegate?.didTappedTodoPlanner()
+  func didTappedTodoPlanner(date: Date) {
+    delegate?.didTappedTodoPlanner(date: date)
   }
   
   func didTappedReport() {


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 투두추가하기, 내 플래너보기에 따른 서로 다른 기능 추가

🌱 PR 포인트
- 투두추가하기버튼에 따른 TodoPlannerViewController에선 문제가 없는데 내 플래너보기 이후 pop되는 과정에서 TodolistViewController에서 viewWillAppear함수가 호출이 안되어 데이터최신화가 이뤄지지않고 있습니다, 혹시 이 부분 해결하는 방법아시면 말씀해주세요 !!

## 📸 스크린샷
|투두추가하기|
|:--:|
|<img width="357" alt="스크린샷 2023-05-28 오후 3 40 27" src="https://github.com/PLUB2022/PLUB-iOS/assets/39263235/b977854a-abe6-4191-8c8e-5922ef337d8d">|
|내 플래너관리하기|
|<img width="373" alt="스크린샷 2023-05-28 오후 3 40 50" src="https://github.com/PLUB2022/PLUB-iOS/assets/39263235/f628f871-cd94-455b-adff-6a7a784c4750">|

|파일첨부바람|

## 📮 관련 이슈
- Resolved: #395 

